### PR TITLE
Feat/list vms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Rust
 target/
 
+# Go
+firecrab-api-go/firecrab-api-go
+
 # Data files
 firecrab-api/data/
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,25 @@ curl -X POST http://localhost:3000/api/vms \
 {"id":"<uuid>","name":"test-vm","state":"Created","template":"ubuntu-rootfs-26.04","cpu":0.5,"ram":512}
 ```
 
+### MicroVM 목록 조회 — GET /api/vms
+
+목록 조회는 Go 서버 `firecrab-api-go`가 제공한다. `firecrab-api`와 같은 `data/vms.json`을 읽으며 `0.0.0.0:3001`에서 대기한다.
+
+```sh
+cd firecrab-api-go
+go run .
+```
+
+```sh
+curl http://localhost:3001/api/vms
+```
+
+응답 (200 OK, `name` 기준 정렬):
+
+```json
+[{"id":"<uuid>","name":"test-vm","state":"Created","template":"ubuntu-rootfs-26.04","cpu":0.5,"ram":512}]
+```
+
 ## 데이터 저장
 
 VM 레코드는 생성/변경 시마다 `firecrab-api/data/vms.json`에 저장되며, 서버 재시작 시 이 파일에서 복원된다.

--- a/firecrab-api-go/go.mod
+++ b/firecrab-api-go/go.mod
@@ -1,0 +1,3 @@
+module firecrab-api-go
+
+go 1.26.4

--- a/firecrab-api-go/handlers.go
+++ b/firecrab-api-go/handlers.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"cmp"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+func listVMs(w http.ResponseWriter, r *http.Request) {
+	vms := loadVMs()
+
+	list := make([]VMRecord, 0, len(vms))
+	for _, vm := range vms {
+		list = append(list, vm)
+	}
+	slices.SortFunc(list, func(a, b VMRecord) int {
+		return cmp.Or(strings.Compare(a.Name, b.Name), strings.Compare(a.ID, b.ID))
+	})
+
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(list)
+}

--- a/firecrab-api-go/main.go
+++ b/firecrab-api-go/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/vms", listVMs)
+
+	addr := "0.0.0.0:3001"
+	log.Printf("[INFO] Listening on http://%s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/firecrab-api-go/model.go
+++ b/firecrab-api-go/model.go
@@ -1,0 +1,10 @@
+package main
+
+type VMRecord struct {
+	ID       string  `json:"id"`
+	Name     string  `json:"name"`
+	State    string  `json:"state"`
+	Template string  `json:"template"`
+	CPU      float64 `json:"cpu"`
+	RAM      uint32  `json:"ram"`
+}

--- a/firecrab-api-go/store.go
+++ b/firecrab-api-go/store.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// firecrab-api(Rust)가 쓰는 데이터 파일을 공유한다. firecrab-api-go/에서 실행해야 한다.
+const dataFile = "../firecrab-api/data/vms.json"
+
+func loadVMs() map[string]VMRecord {
+	content, err := os.ReadFile(dataFile)
+	if err != nil {
+		return map[string]VMRecord{}
+	}
+	var vms map[string]VMRecord
+	if err := json.Unmarshal(content, &vms); err != nil {
+		return map[string]VMRecord{}
+	}
+	return vms
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Go-based API service that serves the VM list at `/api/vms`.
  * Responses are returned as JSON and sorted consistently by name.

* **Documentation**
  * Expanded API docs with setup, run, and test examples for the VM list endpoint.

* **Chores**
  * Updated ignore rules to exclude the new Go project directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->