### PR TITLE
Feat/vm detail api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 thiserror = "2.0.18"
 uuid = { version = "1.19.0", features = ["serde"] }
+
+# unoptimized sha2 is ~50-100x slower, turning multi-GB template hashing
+# (startup verification + per-request re-verification) into a multi-second stall.
+[profile.dev.package.sha2]
+opt-level = 3

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,17 @@ curl http://localhost:3000/api/vms
 
 VM이 없으면 `[]` 반환.
 
+### 3) MicroVM 상세 조회 — GET /api/vms/{id}
+
+```sh
+curl http://localhost:3000/api/vms/<uuid>
+```
+
+응답 (200 OK): 생성 응답과 동일한 형식
+
+- 없는 UUID: `404 not_found`
+- UUID 형식이 아닌 id: `400 validation_failed` (`fields.id`)
+
 ## 템플릿 레지스트리
 
 VM 생성 시 `template` alias는 `TemplateRegistry`(`firecrab-api/src/templates.rs`)를 통해 불변 버전으로 해석된다.

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap};
 
 use axum::Json;
-use axum::extract::{Extension, State};
+use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use firecrab_api_types::VmResponse;
 use uuid::Uuid;
@@ -19,6 +19,26 @@ pub async fn list_vms(State(state): State<AppState>) -> Json<Vec<VmResponse>> {
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     Json(sorted_responses(&vms))
+}
+
+pub async fn get_vm(
+    State(state): State<AppState>,
+    Extension(request_id): Extension<RequestId>,
+    Path(id): Path<String>,
+) -> Result<Json<VmResponse>, AppError> {
+    let id = Uuid::parse_str(&id).map_err(|_| {
+        let mut fields = BTreeMap::new();
+        fields.insert("id".to_owned(), "must be a UUID".to_owned());
+        AppError::validation(fields, request_id.0)
+    })?;
+    let vms = state
+        .vms
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    vms.get(&id)
+        .map(vm_response)
+        .map(Json)
+        .ok_or_else(|| AppError::not_found(request_id.0))
 }
 
 pub async fn create_vm(
@@ -136,6 +156,7 @@ mod tests {
     use std::fs;
     use std::path::{Path, PathBuf};
 
+    use axum::response::IntoResponse;
     use tempfile::tempdir;
 
     use super::*;
@@ -225,6 +246,57 @@ mod tests {
 
         assert_eq!(body.len(), 1);
         assert_eq!(body[0].id, vm.id);
+    }
+
+    #[tokio::test]
+    async fn get_vm_returns_a_known_vm() {
+        let directory = tempdir().unwrap();
+        let state = test_state(directory.path()).await;
+        let vm = record("test-vm", Uuid::new_v4());
+        state.vms.lock().unwrap().insert(vm.id, vm.clone());
+
+        let Json(body) = get_vm(
+            State(state),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(body.id, vm.id);
+        assert_eq!(body.name, "test-vm");
+    }
+
+    #[tokio::test]
+    async fn get_vm_unknown_id_returns_not_found() {
+        let directory = tempdir().unwrap();
+        let state = test_state(directory.path()).await;
+
+        let error = get_vm(
+            State(state),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(Uuid::new_v4().to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.into_response().status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_vm_rejects_a_malformed_uuid() {
+        let directory = tempdir().unwrap();
+        let state = test_state(directory.path()).await;
+
+        let error = get_vm(
+            State(state),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path("not-a-uuid".to_owned()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.into_response().status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -54,14 +54,15 @@ pub async fn create_vm(
         .templates
         .resolve_alias(&req.template)
         .ok_or_else(|| AppError::internal(request_id.0))?;
-    state
-        .templates
-        .open_verified(&template.kernel)
-        .map_err(|_| AppError::internal(request_id.0))?;
-    state
-        .templates
-        .open_verified(&template.rootfs)
-        .map_err(|_| AppError::internal(request_id.0))?;
+    let verify_templates = state.templates.clone();
+    let verify_template = template.clone();
+    tokio::task::spawn_blocking(move || {
+        verify_templates.open_verified(&verify_template.kernel)?;
+        verify_templates.open_verified(&verify_template.rootfs)
+    })
+    .await
+    .map_err(|_| AppError::internal(request_id.0))?
+    .map_err(|_| AppError::internal(request_id.0))?;
     let vm = VmRecord {
         id: Uuid::new_v4(),
         name: req.name,

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -134,6 +134,7 @@ pub fn build_router(state: AppState, config: &HttpConfig) -> Router {
             "/api/vms",
             get(handlers::vms::list_vms).post(handlers::vms::create_vm),
         )
+        .route("/api/vms/{id}", get(handlers::vms::get_vm))
         .fallback(not_found)
         .with_state(state)
         .layer(cors)

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -87,22 +87,13 @@ impl TemplateRegistry {
 
         Self::from_specs(
             &image_root,
-            [
-                TemplateSpec {
-                    alias: "ubuntu-rootfs-26.04".to_owned(),
-                    version: "ubuntu-26.04-v1".to_owned(),
-                    kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
-                    rootfs: PathBuf::from("rootfs/ubuntu-rootfs-26.04-amd64.ext4"),
-                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
-                },
-                TemplateSpec {
-                    alias: "ubuntu-26.04".to_owned(),
-                    version: "ubuntu-26.04-v1".to_owned(),
-                    kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
-                    rootfs: PathBuf::from("rootfs/ubuntu-rootfs-26.04-amd64.ext4"),
-                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
-                },
-            ],
+            [TemplateSpec {
+                alias: "ubuntu-26.04".to_owned(),
+                version: "ubuntu-26.04-v1".to_owned(),
+                kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
+                rootfs: PathBuf::from("rootfs/ubuntu-rootfs-26.04-amd64.ext4"),
+                boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
+            }],
         )
     }
 

--- a/firecrab-frontend/index.html
+++ b/firecrab-frontend/index.html
@@ -317,6 +317,57 @@
       color: var(--shell);
     }
 
+    .vm-table tbody tr.is-clickable {
+      cursor: pointer;
+    }
+
+    .vm-table tbody tr.is-clickable:hover td,
+    .vm-table tbody tr.is-clickable:focus-visible td {
+      background: rgba(196, 62, 18, 0.06);
+    }
+
+    .detail-grid {
+      margin: 0;
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+    }
+
+    .detail-row {
+      display: grid;
+      grid-template-columns: 10rem 1fr;
+      gap: 1rem;
+      padding: 0.55rem 0.1rem;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .detail-row:last-child {
+      border-bottom: 0;
+    }
+
+    .detail-grid dt {
+      align-self: center;
+      color: var(--shell);
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .detail-grid dd {
+      margin: 0;
+      white-space: normal;
+      word-break: break-all;
+    }
+
+    .detail-grid .detail-message {
+      color: var(--shell);
+    }
+
+    .detail-grid .detail-message.is-error {
+      color: var(--error);
+      font-weight: 600;
+    }
+
     .table-message.is-error {
       color: var(--error);
       font-weight: 600;
@@ -527,7 +578,7 @@
             <div>
               <label class="field-label" for="vm-template">template</label>
               <select id="vm-template" name="template" class="field-control">
-                <option value="ubuntu-rootfs-26.04">ubuntu-rootfs (26.04)</option>
+                <option value="ubuntu-26.04">ubuntu (26.04)</option>
               </select>
             </div>
 
@@ -599,6 +650,24 @@
         </div>
       </section>
 
+      <section class="panel detail" id="detail-panel" aria-label="VM 상세">
+        <button type="button" class="panel-toggle" id="detail-toggle" aria-expanded="false" aria-controls="detail-body">
+          <h2 class="panel-title">describe-vm</h2>
+          <span class="panel-status" id="detail-status">idle</span>
+          <span class="chevron" aria-hidden="true">&#9656;</span>
+        </button>
+        <div class="panel-body" id="detail-body">
+          <div class="panel-body-inner">
+            <dl class="detail-grid" id="detail-grid">
+              <div class="detail-row">
+                <dt>hint</dt>
+                <dd class="detail-message">select a vm from the list</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </section>
+
       <section class="panel console" id="console-panel" aria-label="부팅 콘솔">
         <button type="button" class="panel-toggle" id="console-toggle" aria-expanded="false" aria-controls="console-body">
           <h2 class="panel-title">console</h2>
@@ -666,8 +735,14 @@
       });
     }
 
+    const detailPanel = document.getElementById("detail-panel");
+    const detailToggle = document.getElementById("detail-toggle");
+    const detailStatus = document.getElementById("detail-status");
+    const detailGrid = document.getElementById("detail-grid");
+
     bindToggle(consolePanel, consoleToggle);
     bindToggle(jsonPanel, jsonToggle);
+    bindToggle(detailPanel, detailToggle);
 
     function resetLog() {
       logEl.textContent = "";
@@ -746,6 +821,19 @@
           row.appendChild(cell);
         });
 
+        if (vm.id) {
+          row.className = "is-clickable";
+          row.tabIndex = 0;
+          row.setAttribute("aria-label", `${vm.name || vm.id} 상세 보기`);
+          row.addEventListener("click", () => loadVmDetail(vm.id));
+          row.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              loadVmDetail(vm.id);
+            }
+          });
+        }
+
         vmListBody.appendChild(row);
       }
     }
@@ -768,6 +856,70 @@
         setListStatus("error", "is-error");
       } finally {
         vmListRefresh.disabled = false;
+      }
+    }
+
+    function setDetailMessage(message, cls) {
+      detailGrid.replaceChildren();
+      const row = document.createElement("div");
+      row.className = "detail-row";
+      const dt = document.createElement("dt");
+      dt.textContent = cls ? "error" : "hint";
+      const dd = document.createElement("dd");
+      dd.className = cls ? `detail-message ${cls}` : "detail-message";
+      dd.textContent = message;
+      row.append(dt, dd);
+      detailGrid.appendChild(row);
+    }
+
+    function renderVmDetail(vm) {
+      const fields = [
+        ["name", vm.name],
+        ["state", vm.state],
+        ["template", vm.template],
+        ["template version", vm.templateVersion],
+        ["vcpu", vm.cpu],
+        ["memory", vm.ram != null ? `${vm.ram} MiB` : null],
+        ["id", vm.id],
+      ];
+
+      detailGrid.replaceChildren();
+      for (const [label, value] of fields) {
+        const row = document.createElement("div");
+        row.className = "detail-row";
+        const dt = document.createElement("dt");
+        dt.textContent = label;
+        const dd = document.createElement("dd");
+        dd.textContent = value ?? "—";
+        if (label === "state" && value) {
+          const pill = document.createElement("span");
+          pill.className = "state-pill";
+          pill.textContent = value;
+          dd.replaceChildren(pill);
+        }
+        row.append(dt, dd);
+        detailGrid.appendChild(row);
+      }
+    }
+
+    async function loadVmDetail(id) {
+      openPanel(detailPanel, detailToggle);
+      setPanelStatus(detailPanel, detailStatus, "is-running", "loading");
+
+      try {
+        const res = await fetch(`${API_BASE}/api/vms/${encodeURIComponent(id)}`);
+        const data = await res.json().catch(() => null);
+
+        if (!res.ok) {
+          const code = data && data.error && data.error.code;
+          throw new Error(code || `http ${res.status}`);
+        }
+
+        renderVmDetail(data);
+        setPanelStatus(detailPanel, detailStatus, "is-ready", shortId(data.id));
+      } catch (err) {
+        setDetailMessage(`describe failed: ${err.message}`, "is-error");
+        setPanelStatus(detailPanel, detailStatus, "is-error", "error");
       }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added VM detail retrieval through `GET /api/vms/{id}`.
  * VM list entries are now clickable and keyboard-accessible, opening a detail panel with status and VM information.
  * Added loading and error feedback for VM detail requests.
* **Bug Fixes**
  * Invalid VM IDs now return clear validation errors; unknown IDs return not-found responses.
* **Documentation**
  * Documented VM detail response formats and error behavior.
* **Updates**
  * Set `ubuntu-26.04` as the default template and removed the duplicate rootfs alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->