### PR TITLE
docs: document the workspace to clear the 75% rustdoc coverage floor

### DIFF
--- a/docs/week3-tasks.md
+++ b/docs/week3-tasks.md
@@ -1,0 +1,78 @@
+# 3주차 권장 Tasks - Network, SSH, and UI
+
+- Week 2의 VM별 rootfs, 리소스, process lifecycle과 상태 복구가 완료된 뒤 진행함
+- API와 host network helper는 Rust로 구현함
+- 권한이 필요한 host 작업은 unprivileged HTTP API와 분리함
+- Week 2의 공통 operation과 오류 계약을 그대로 사용함
+- 코드 조각은 설계 골격이며 workspace 고정 crate version으로 compile/test해 적용함
+- 2026-07-19 우선순위 재조정: 네트워크(TAP 이하)보다 MicroVM 부팅 + Terminal UI를 선행. serial console은 네트워크와 무관해 데모 가능한 최소 경로. 남은 network v2(TAP~접속 API)는 후순위로 유지
+- 2026-07-20 재조정: VM 관련 작업(시작 단계별 진행 상황 표시)을 다음 순위로 먼저 하고, 그다음 네트워크는
+  TAP 자동화 + Guest 네트워크 설정(DHCP/eth0)까지만 진행한다 — 이미 구현된 NAT/VPC CIDR(bridge
+  subnet)/VM IP 할당(IPAM)이 실제 VM에 연결되어 동작하게 만드는 최소 구성. Guest agent/vsock, SSH
+  identity, 접속 정보 API는 계속 후순위로 유지
+- 2026-07-21: VM 시작 단계별 진행 상황 표시 완료(생성 즉시화 + 상세 모달로 재구현, `docs/tests/vm-detail-modal.md`).
+  같은 날 VM 디스크 용량 설정 추가(`task-vm-disk-capacity.md`, 별도 브랜치 `feat/vm-disk-capacity`).
+- 2026-07-21(계속): 구축된 VM의 cpu/ram/disk 수정 기능 추가(`task-vm-resource-update.md`, 별도
+  브랜치 `feat/vm-resource-update`)
+- 2026-07-21(계속): `feat/microvm-terminal`을 `feat/vm-resource-update`에 병합 — `terminal` 버튼
+  연결 끊김 버그 수정. 아래 표·각주 갱신
+- 2026-07-21(계속): 이미지 템플릿 Alpine Linux 추가를 다음 순위로 등록(`task-alpine-linux-template.md`)
+- 2026-07-21(계속) 네트워크 범위 최소화: 대회 일정상 남은 네트워크 작업을 "VM이 실제 IP로 외부와
+  통신 가능"까지로 좁힌다 — TAP 자동화 + Guest DHCP 적용 2개만 다음 순위로 유지. Guest agent/vsock,
+  SSH identity, 접속 정보 조회 API, 통합 테스트는 **이번 대회 범위 밖으로 보류**(브라우저 터미널로
+  이미 guest 접속이 가능해 데모에 필수는 아님) — 재개할 경우를 대비해 표는 남겨두되 상태만 구분
+- 2026-07-22: 이미지 템플릿 Alpine Linux 추가 완료. Alpine minirootfs(v3.24.1)를 Docker의
+  `apk --root`로 구성해 ext4 이미지로 패키징(host root/sudo 불필요 — `scripts/firecracker-menual/install-alpine-rootfs.sh`),
+  기존 Ubuntu 템플릿과 커널을 공유. `templates.rs`에 `alpine-3.24` alias 등록, `CreateVm.tsx`
+  드롭다운에 추가. 실제 API+프론트 엔드투엔드(생성→start→console.log)로 Alpine 부팅과 Ubuntu
+  무회귀를 모두 확인(`docs/tests/alpine-linux-template.md`). `cargo test --workspace` 83/9/9/31 green
+- 2026-07-22(계속): CI(GitHub Actions) 구현. `rust`(fmt/clippy/`cargo-llvm-cov`+Codecov 업로드),
+  `docs`(`RUSTDOCFLAGS=-D warnings cargo doc`), `frontend`(oxlint/tsc/vite build) 3개 job.
+  `rust-toolchain.toml`에 `llvm-tools` 컴포넌트 추가, 기존 미포맷 코드 `cargo fmt --all`로 정리.
+  `CODECOV_TOKEN` 시크릿 등록은 GitHub 저장소 설정에서 별도 필요(`task-cicd-github-actions.md`)
+- 2026-07-22(계속): rustdoc 문서화율을 75% 목표까지 끌어올림(별도 브랜치 `feat/rustdoc-coverage`,
+  main에서 분기). `firecrab-api-types`/`firecrab-helper-protocol` 100%, `firecrab-net-helper`
+  97.2%, `firecrab-api` 76.2% — 워크스페이스 전체 84.1%(503/598 아이템). `cargo fmt --all` +
+  `cargo clippy --workspace --all-targets` + `cargo test --workspace`(83/9/9/31) +
+  `RUSTDOCFLAGS=-D warnings cargo doc` 전부 green 확인
+
+| 상태 | 제목 | 작업 | 완료 기준 | 산출물 |
+|---|---|---|---|---|
+| ✅ | [호스트 네트워크 권한 및 자원 소유권 구현](task-host-network-privileges.md) | API 전체를 root로 실행하지 않고 bridge, TAP, firewall 작업만 제한된 helper에서 수행한다. | 검증된 UUID 기반 자원만 조작하고 Firecrab 소유가 아닌 interface와 firewall rule은 변경하거나 삭제하지 않는다. | `firecrab-api/src/network.rs`, `firecrab-net-helper/src/main.rs`, `docs/net-helper.md` |
+| ✅ | [공용 bridge 및 네트워크 기반 구현](task-shared-bridge-network.md) | Firecrab 전용 bridge, subnet(VPC CIDR), gateway와 host forwarding 구조를 idempotent하게 준비한다. | 반복 실행과 host 재부팅 후에도 동일한 bridge 구성이 복구되며 여러 VM이 공용 gateway를 사용한다. | `firecrab-net-helper/src/bridge.rs` |
+| ✅ | [VM IP 및 MAC 할당 관리 구현](task-vm-ip-mac-allocation.md) | SQLite에서 VM별 IP와 MAC을 원자적으로 할당하고 중복과 pool 고갈을 처리한다. | 동시에 여러 VM을 생성해도 IP와 MAC이 중복되지 않는다. 할당값은 stop 동안 유지되고 delete 성공 후 반환된다. | `firecrab-api/src/ipam.rs`, `firecrab-api/src/model.rs`, `firecrab-api/src/persistence.rs` |
+| ✅ | [외부 통신 NAT 및 firewall 자동화 구현](task-nat-firewall-automation.md) | subnet 단위 NAT와 forwarding rule을 전용 nftables table로 관리한다. | 여러 VM이 동시에 외부 통신하고 한 VM의 stop/delete가 다른 VM의 연결을 끊지 않는다. 기존 host firewall rule은 보존된다. | `firecrab-net-helper/src/firewall.rs` |
+| ✅ | [VM network 격리 및 anti-spoofing 구현](task-vm-network-isolation.md) | VM 간 통신과 host·reserved subnet 접근을 기본 거부하고 lease 기반 source 검증을 적용한다. | 허용 정책 없는 east-west·spoofed traffic이 차단되고 DNS, gateway, 명시적 SSH와 외부 응답 traffic만 통과한다. | `firecrab-api/src/network_policy.rs`, `firecrab-net-helper/src/firewall.rs` |
+| ✅ | [MicroVM 부팅 + 대시보드 Terminal UI 구현](task-microvm-terminal.md) | net-helper 없이 VM을 부팅하고, 대시보드에서 serial console(ttyS0)에 실시간 접속한다. | `terminal` 버튼으로 실제 부팅 로그·셸이 브라우저에 보이고 타이핑이 guest에 도달하며, WS는 REST 타임아웃과 무관하게 유지된다. | `firecrab-api/src/console.rs`, `firecrab-api/src/handlers/console.rs`, `firecrab-frontend/src/components/Console.tsx` |
+| ✅ | [프론트엔드 VM 대시보드 구현](task-vm-dashboard.md) | 목록, 생성, 시작, 중지, 삭제와 상태 polling을 제공한다(React/TypeScript로 재구현, 원래 Wasm 계획에서 전환). | 상태별 action만 활성화되고 중복 클릭, 전이 상태, `409`와 비동기 실패가 사용자에게 표시된다. | `firecrab-frontend/src/App.tsx`, `firecrab-frontend/src/components/`, `docs/browser-test.md` |
+| ✅ | [VM 시작 단계별 진행 상황 표시 구현](task-vm-startup-progress.md) | `starting` 상태를 rootfs 준비·Firecracker 기동·부팅 확인 등 이름 붙은 단계로 나눠 로그·UI에 노출한다. | 단계 전환이 순서대로 로그에 남고, 대시보드에서도 폴링 주기 내에 단계별로 반영된다. | `firecrab-api-types/src/lib.rs`, `firecrab-api/src/firecracker.rs`, `firecrab-api/src/rootfs.rs`, `firecrab-frontend/src/components/VmDetailModal.tsx` |
+| ✅ | [VM 디스크 용량 설정 구현](task-vm-disk-capacity.md) | VM 생성 시 디스크 용량(GiB)을 지정하고 rootfs 템플릿 복사 후 `e2fsck`+`resize2fs`로 실제 확장한다. | 지정한 용량으로 디스크가 만들어지고 guest가 그 크기를 실제로 인식하며, 템플릿 크기 미만은 검증 오류로 거부된다. | `firecrab-api-types/src/lib.rs`, `firecrab-api/src/rootfs.rs`, `firecrab-api/src/handlers/vms.rs`, `firecrab-frontend/src/components/CreateVm.tsx` |
+| ✅ | [구축된 VM CPU/MEM/DISK 수정 구현](task-vm-resource-update.md) | `PUT /api/vms/{id}`로 프로세스가 안 떠 있는 VM의 cpu/ram/disk를 다음 시작에 반영되게 수정한다. | `running`/`starting`/`stopping`은 거부되고, disk는 축소가 거부되며, 수정 후 시작하면 Firecracker config와 실제 디스크 크기에 반영된다. | `firecrab-api-types/src/lib.rs`, `firecrab-api/src/handlers/vms.rs`, `firecrab-api/src/rootfs.rs`, `firecrab-frontend/src/components/VmDetailModal.tsx` |
+| ✅ | [이미지 템플릿 Alpine Linux 추가](task-alpine-linux-template.md) | Alpine 커널·rootfs를 두 번째 템플릿으로 등록하고 생성 폼에서 고를 수 있게 한다. | Alpine 선택 시 실제로 Alpine 커널이 부팅되고, 기존 Ubuntu 템플릿 동작에 회귀가 없다. | `firecrab-api/src/templates.rs`, `firecrab-frontend/src/components/CreateVm.tsx`, `images/` |
+| ✅ | [CI 구현(GitHub Actions)](task-cicd-github-actions.md) | PR/push마다 fmt·clippy·test+coverage(Codecov)·rustdoc(Rust)와 lint·typecheck·build(frontend)를 자동 검증한다. | `rust`/`docs`/`frontend` 3개 job 모두 green(rustdoc 문서화율 게이트 75% 대비 `feat/rustdoc-coverage`에서 84.1% 달성). | `.github/workflows/ci.yml`, `codecov.yml`, `rust-toolchain.toml` |
+
+### 네트워크 — 최소 범위(VM이 실제 IP로 외부와 통신 가능한 상태까지)
+
+| 상태 | 제목 | 작업 | 완료 기준 | 산출물 |
+|---|---|---|---|---|
+| 미완료 (다음) | [VM별 TAP 디바이스 자동화 구현](task-vm-tap-automation.md) | VM start 시 고유 TAP을 생성해 bridge에 연결하고 stop, delete, 실패 시 정리한다. | 두 VM이 서로 다른 TAP을 사용하며 daemon 복구 후에도 고아 TAP이 남지 않는다. | `firecrab-api/src/network.rs`, `firecrab-net-helper/src/tap.rs` |
+| 미완료 (다음) | [Guest 네트워크 설정 적용 구현](task-guest-network-configuration.md) | DHCP와 MAC 예약으로 할당 IP를 Guest `eth0`에 적용한다. | DB IP, Firecracker MAC, Guest `eth0` 주소가 일치하고 gateway와 DNS 설정이 재부팅 후에도 유지된다. | `firecrab-api/src/dhcp.rs`, `firecrab-net-helper/src/dhcp.rs`, Guest template 설정 |
+
+### 네트워크 이후
+
+| 상태 | 제목 | 작업 | 완료 기준 | 산출물 |
+|---|---|---|---|---|
+| 미완료 (네트워크 이후) | [배포판 표준 커널 사용](task-distro-standard-kernels.md) | Ubuntu/Alpine 템플릿이 공유하는 자체 빌드 vanilla 커널 대신, 각 배포판이 실제 배포하는 공식 커널(`linux-image-generic`, `linux-virt`)을 추출해 쓴다. | 두 템플릿 모두 실제 배포판 공식 커널로 부팅되고 기존 동작에 회귀가 없다(Alpine은 virtio_blk/ext4가 모듈이라 initrd 필요). | `firecrab-api/src/templates.rs`, `firecrab-api/src/firecracker.rs`, `images/kernel/` |
+
+### 네트워크 — 범위 밖으로 보류 (재개 시 참고용, 이번 대회 일정에는 포함 안 함)
+
+| 상태 | 제목 | 보류 사유 |
+|---|---|---|
+| 범위 밖 | [Guest agent 및 vsock provisioning 구현](task-guest-agent-vsock-provisioning.md) | Guest agent 자체가 별도 crate(`firecrab-guest-protocol`/`firecrab-guest-agent`) 신규 개발이 필요한 큰 작업. 브라우저 터미널로 이미 guest 접속 가능해 데모엔 불필요 |
+| 범위 밖 | [VM별 SSH identity 및 접근 정책 구현](task-vm-ssh-identity.md) | 위 Guest agent가 선행돼야 키 배포 경로가 생김 |
+| 범위 밖 | [VM 접속 정보 조회 API 구현](task-vm-connection-api.md) | SSH 미지원 상태에서는 조회할 접속 정보 자체가 없음 |
+| 범위 밖 | [Network, SSH, UI 통합 테스트 구현](task-network-ssh-ui-tests.md) | 위 항목들이 모두 범위 밖이라 테스트 대상 자체가 없음 — TAP·Guest DHCP는 각 task 문서의 자체 완료 기준으로 검증 |
+
+`feat/microvm-terminal`은 `feat/vm-resource-update`에 병합 완료(충돌 1건, `server.rs`의 라우트
+목록 — 손으로 정리). `cargo test --workspace` 82/9/8/27 green, 실제 VM으로 터미널 연결·부팅 로그
+렌더링·키보드 입력 왕복까지 확인됨(자세한 내용은 [web.md](web.md) 참고).

--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -1,20 +1,32 @@
+//! Wire types shared between `firecrab-api` and `firecrab-frontend`'s
+//! generated bindings: request/response bodies and the VM lifecycle state
+//! machine.
+
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// A VM's lifecycle state, serialized lowercase over the API.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum VmState {
+    /// Record exists, no Firecracker process has ever run for it.
     Created,
+    /// `start_vm`'s pipeline is running (see [`StartupStep`]).
     Starting,
+    /// Firecracker process is up and the guest has booted.
     Running,
+    /// Shutdown requested, process not yet confirmed gone.
     Stopping,
+    /// Process exited cleanly.
     Stopped,
+    /// Process exited unexpectedly or a start attempt failed.
     Error,
 }
 
 impl VmState {
+    /// Whether the lifecycle table allows moving from `self` to `to`.
     pub fn can_transition(self, to: Self) -> bool {
         use VmState::{Created, Error, Running, Starting, Stopped, Stopping};
         matches!(
@@ -28,7 +40,8 @@ impl VmState {
         )
     }
 
-    // Deletion is record removal, not a state transition; only inactive VMs qualify.
+    /// Whether the VM record may be deleted — deletion is record removal,
+    /// not a state transition, so only inactive VMs qualify.
     pub fn can_delete(self) -> bool {
         matches!(self, Self::Created | Self::Stopped | Self::Error)
     }
@@ -40,13 +53,19 @@ impl VmState {
     }
 }
 
+/// Body for `POST /api/vms`.
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct CreateVmRequest {
+    /// 1–64 chars, alphanumeric plus `.`/`_`/`-`.
     pub name: String,
+    /// Template registry alias (e.g. `ubuntu-26.04`), not a specific version.
     pub template: String,
+    /// RAM in MiB; must be a power of two in the accepted range.
     pub ram: u32,
+    /// vCPU count.
     pub cpu: u8,
+    /// Disk capacity in GiB; rejected below the template rootfs's own size.
     pub disk_gb: u16,
 }
 
@@ -55,8 +74,11 @@ pub struct CreateVmRequest {
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct UpdateVmResourcesRequest {
+    /// New RAM in MiB.
     pub ram: u32,
+    /// New vCPU count.
     pub cpu: u8,
+    /// New disk capacity in GiB; must be >= the VM's current size.
     pub disk_gb: u16,
 }
 
@@ -66,21 +88,33 @@ pub struct UpdateVmResourcesRequest {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum StartupStep {
+    /// Copying/growing the template rootfs into the VM's own disk file.
     PreparingDisk,
+    /// Writing the Firecracker `firecracker-config.json`.
     GeneratingConfig,
+    /// Spawning the Firecracker process and waiting for it to come up.
     StartingProcess,
 }
 
+/// A VM record as returned by the list/detail/create/update endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VmResponse {
+    /// Stable identifier, also the `data/vms/<id>/` directory name.
     pub id: Uuid,
+    /// User-supplied name.
     pub name: String,
+    /// Current lifecycle state.
     pub state: VmState,
+    /// Template alias this VM was created from.
     pub template: String,
+    /// Pinned template version the alias resolved to at creation time.
     pub template_version: String,
+    /// vCPU count.
     pub cpu: u8,
+    /// RAM in MiB.
     pub ram: u32,
+    /// Disk capacity in GiB.
     pub disk_gb: u16,
     /// `Some` only while `state == Starting`.
     pub startup_step: Option<StartupStep>,
@@ -92,25 +126,34 @@ pub struct VmResponse {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct VmLogResponse {
+    /// Captured serial console output, capped in size.
     pub console_log: String,
     /// `true` if the on-disk log exceeds the cap and `console_log` is only
     /// the first portion of it.
     pub truncated: bool,
 }
 
+/// JSON error body wrapper: `{"error": {...}}`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorResponse {
+    /// The structured error payload.
     pub error: ApiError,
 }
 
+/// Structured API error: a machine-readable `code`, a human `message`, and
+/// optional per-field validation detail.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiError {
+    /// Machine-readable error code (e.g. `validation_error`).
     pub code: String,
+    /// Human-readable message.
     pub message: String,
+    /// Field name → error message, for request validation failures.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub fields: BTreeMap<String, String>,
+    /// Correlates this error with server-side logs.
     pub request_id: Uuid,
 }
 
@@ -184,7 +227,14 @@ mod tests {
     fn update_vm_resources_request_deserializes_camel_case_disk_gb() {
         let json = r#"{"ram":1024,"cpu":2,"diskGb":8}"#;
         let request: UpdateVmResourcesRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(request, UpdateVmResourcesRequest { ram: 1024, cpu: 2, disk_gb: 8 });
+        assert_eq!(
+            request,
+            UpdateVmResourcesRequest {
+                ram: 1024,
+                cpu: 2,
+                disk_gb: 8
+            }
+        );
     }
 
     #[test]
@@ -249,6 +299,9 @@ mod tests {
         let json = serde_json::to_string(&response).expect("serialize response");
         assert!(json.contains("\"consoleLog\":\"booting...\\n\""));
         assert!(json.contains("\"truncated\":true"));
-        assert_eq!(serde_json::from_str::<VmLogResponse>(&json).unwrap(), response);
+        assert_eq!(
+            serde_json::from_str::<VmLogResponse>(&json).unwrap(),
+            response
+        );
     }
 }

--- a/firecrab-api/src/console.rs
+++ b/firecrab-api/src/console.rs
@@ -93,11 +93,16 @@ impl ConsoleBroker {
     /// subscribe call can be missed or double-delivered.
     pub fn subscribe(&self) -> (Vec<u8>, broadcast::Receiver<Vec<u8>>) {
         let state = self.lock();
-        (state.backlog.iter().copied().collect(), state.output.subscribe())
+        (
+            state.backlog.iter().copied().collect(),
+            state.output.subscribe(),
+        )
     }
 
     fn lock(&self) -> std::sync::MutexGuard<'_, ConsoleState> {
-        self.state.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+        self.state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -189,7 +194,9 @@ mod tests {
 
         let mut buffer = [0_u8; 32];
         let read = tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            tokio::io::AsyncReadExt::read(&mut stdout, &mut buffer).await.unwrap()
+            tokio::io::AsyncReadExt::read(&mut stdout, &mut buffer)
+                .await
+                .unwrap()
         })
         .await
         .expect("cat echoed input back before the timeout");

--- a/firecrab-api/src/error.rs
+++ b/firecrab-api/src/error.rs
@@ -1,3 +1,7 @@
+//! Structured API error type: renders as the `ErrorResponse` JSON shape with
+//! a stable `code`, human `message`, and optional per-field validation
+//! detail, so `internal_error` never leaks details a client shouldn't see.
+
 use std::collections::BTreeMap;
 
 use axum::Json;
@@ -9,16 +13,23 @@ use uuid::Uuid;
 use crate::model::VmState;
 use crate::persistence::encode_state;
 
+/// A structured, HTTP-status-carrying API error.
 #[derive(Debug)]
 pub struct AppError {
+    /// HTTP status this error renders as.
     status: StatusCode,
+    /// Machine-readable error code.
     code: &'static str,
+    /// Human-readable message.
     message: &'static str,
+    /// Field name -> error message, for validation failures.
     fields: BTreeMap<String, String>,
+    /// Correlates this error with server-side logs.
     request_id: Uuid,
 }
 
 impl AppError {
+    /// Builds an error with no per-field validation detail.
     pub fn new(
         status: StatusCode,
         code: &'static str,
@@ -34,6 +45,7 @@ impl AppError {
         }
     }
 
+    /// `400` with per-field validation messages.
     pub fn validation(fields: BTreeMap<String, String>, request_id: Uuid) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,
@@ -44,6 +56,7 @@ impl AppError {
         }
     }
 
+    /// `400`: request body isn't valid JSON.
     pub fn invalid_json(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::BAD_REQUEST,
@@ -53,6 +66,7 @@ impl AppError {
         )
     }
 
+    /// `415`: `Content-Type` isn't `application/json`.
     pub fn unsupported_media_type(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::UNSUPPORTED_MEDIA_TYPE,
@@ -62,6 +76,7 @@ impl AppError {
         )
     }
 
+    /// `413`: request body exceeds the size limit.
     pub fn request_too_large(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::PAYLOAD_TOO_LARGE,
@@ -71,6 +86,7 @@ impl AppError {
         )
     }
 
+    /// `403`: request `Origin` isn't on the allowlist.
     pub fn forbidden_origin(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::FORBIDDEN,
@@ -80,6 +96,7 @@ impl AppError {
         )
     }
 
+    /// `429`: concurrency/rate limit exceeded.
     pub fn too_many_requests(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::TOO_MANY_REQUESTS,
@@ -89,6 +106,7 @@ impl AppError {
         )
     }
 
+    /// `504`: request processing exceeded its deadline.
     pub fn gateway_timeout(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::GATEWAY_TIMEOUT,
@@ -98,6 +116,7 @@ impl AppError {
         )
     }
 
+    /// `500` with no detail exposed to the client.
     pub fn internal(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -107,6 +126,7 @@ impl AppError {
         )
     }
 
+    /// `404`: the resource (e.g. VM) doesn't exist.
     pub fn not_found(request_id: Uuid) -> Self {
         Self::new(
             StatusCode::NOT_FOUND,
@@ -128,6 +148,7 @@ impl AppError {
         )
     }
 
+    /// `409`: the VM's current state doesn't allow the requested operation.
     pub fn invalid_state(current: VmState, request_id: Uuid) -> Self {
         let mut fields = BTreeMap::new();
         fields.insert("state".to_owned(), encode_state(current));
@@ -142,6 +163,7 @@ impl AppError {
 }
 
 impl IntoResponse for AppError {
+    /// Renders as the `ErrorResponse` JSON body at the error's status code.
     fn into_response(self) -> Response {
         let body = ErrorResponse {
             error: ApiError {

--- a/firecrab-api/src/firecracker.rs
+++ b/firecrab-api/src/firecracker.rs
@@ -1,3 +1,7 @@
+//! Renders and runs the Firecracker microVM process: `firecracker.json`
+//! generation, spawning + readiness polling of the child, and the exit
+//! monitor that records guest-initiated state transitions.
+
 use std::env;
 use std::fs::{self, File};
 use std::io;
@@ -23,51 +27,75 @@ use crate::state::AppState;
 /// disk and broadcast to viewers.
 const CONSOLE_READ_CHUNK: usize = 4096;
 
+/// File name of the rendered Firecracker JSON config, within a VM's directory.
 const CONFIG_FILE_NAME: &str = "firecracker.json";
+/// File name of the Firecracker API Unix socket, within a VM's directory.
 const API_SOCK_FILE_NAME: &str = "firecracker.sock";
+/// File name of the tee'd guest console log, within a VM's directory.
 const CONSOLE_LOG_FILE_NAME: &str = "console.log";
+/// Delay between readiness probe attempts while waiting for the API socket.
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
+/// Failure modes for rendering config, spawning, or stopping Firecracker.
 #[derive(Debug, Error)]
 pub enum FirecrackerError {
+    /// Couldn't create the VM's own directory.
     #[error("failed to create VM directory {path}: {source}")]
     CreateDirectory {
+        /// The directory that couldn't be created.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't serialize the config to JSON.
     #[error("failed to serialize Firecracker config for {path}: {source}")]
     Serialize {
+        /// The config file path this was destined for.
         path: PathBuf,
         #[source]
         source: serde_json::Error,
     },
+    /// Couldn't write the rendered config to disk.
     #[error("failed to write Firecracker config {path}: {source}")]
     Write {
+        /// The config file path that failed to write.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// A pre-existing API socket file couldn't be removed before binding.
     #[error("failed to remove stale API socket {path}: {source}")]
     StaleSocket {
+        /// The stale socket path.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't open the console log file for writing.
     #[error("failed to open console log {path}: {source}")]
     ConsoleLog {
+        /// The console log path that couldn't be opened.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't spawn the Firecracker binary.
     #[error("failed to spawn Firecracker binary {binary}: {source}")]
     Spawn {
+        /// The binary path that failed to spawn.
         binary: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// The API socket never answered within the readiness timeout.
     #[error("Firecracker API socket {path} did not become ready within {timeout:?}")]
-    NotReady { path: PathBuf, timeout: Duration },
+    NotReady {
+        /// The API socket path that never became ready.
+        path: PathBuf,
+        /// The timeout that was exceeded.
+        timeout: Duration,
+    },
+    /// Waiting for or killing the process failed.
     #[error("failed to terminate Firecracker process: {source}")]
     // Only the owned-handle stop path builds this; handlers stop via pid
     // signals because the exit monitor owns the child.
@@ -78,36 +106,52 @@ pub enum FirecrackerError {
     },
 }
 
+/// The JSON body Firecracker's `--config-file` expects.
 #[derive(Debug, Serialize)]
 pub struct FirecrackerConfig {
+    /// Kernel image path and boot args.
     #[serde(rename = "boot-source")]
     boot_source: BootSource,
+    /// Block devices, always exactly the one root drive today.
     drives: Vec<Drive>,
+    /// vCPU/memory sizing.
     #[serde(rename = "machine-config")]
     machine_config: MachineConfig,
 }
 
+/// `boot-source` section of [`FirecrackerConfig`].
 #[derive(Debug, Serialize)]
 struct BootSource {
+    /// Absolute path to the kernel image.
     kernel_image_path: PathBuf,
+    /// Kernel command line.
     boot_args: String,
 }
 
+/// One entry in [`FirecrackerConfig`]'s `drives` list.
 #[derive(Debug, Serialize)]
 struct Drive {
+    /// Firecracker-side drive identifier.
     drive_id: String,
+    /// Absolute host path to the backing file.
     path_on_host: PathBuf,
+    /// Whether this drive is mounted as the VM's root filesystem.
     is_root_device: bool,
+    /// Whether the drive is exposed read-only to the guest.
     is_read_only: bool,
 }
 
+/// `machine-config` section of [`FirecrackerConfig`].
 #[derive(Debug, Serialize)]
 struct MachineConfig {
+    /// vCPU count.
     vcpu_count: u8,
+    /// RAM in MiB.
     mem_size_mib: u32,
 }
 
 impl FirecrackerConfig {
+    /// Builds the config for `vm`'s single root drive at `rootfs_path`.
     pub fn for_vm(
         vm: &VmRecord,
         kernel_image_path: &Path,
@@ -167,28 +211,37 @@ pub fn write_config(
     Ok(path)
 }
 
+/// Resolves the Firecracker binary path: `FIRECRAB_FIRECRACKER_BIN` if set,
+/// otherwise `firecracker` looked up on `PATH`.
 pub fn default_firecracker_binary() -> PathBuf {
     env::var_os("FIRECRAB_FIRECRACKER_BIN")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("firecracker"))
 }
 
+/// Path to a VM's Firecracker API Unix socket.
 pub fn api_sock_path(vms_dir: &Path, id: Uuid) -> PathBuf {
     vms_dir.join(id.to_string()).join(API_SOCK_FILE_NAME)
 }
 
+/// Path to a VM's tee'd guest console log file.
 pub fn console_log_path(vms_dir: &Path, id: Uuid) -> PathBuf {
     vms_dir.join(id.to_string()).join(CONSOLE_LOG_FILE_NAME)
 }
 
+/// A live, owned Firecracker child process and its associated resources.
 #[derive(Debug)]
 pub struct FirecrackerProcess {
+    /// The spawned child process.
     child: Child,
+    /// Path to its API socket, removed on stop/exit.
     api_sock: PathBuf,
+    /// Broker fanning out this VM's serial console to attached viewers.
     console: Arc<ConsoleBroker>,
 }
 
 impl FirecrackerProcess {
+    /// The child's OS process id, if it hasn't already been reaped.
     pub fn pid(&self) -> Option<u32> {
         self.child.id()
     }
@@ -199,11 +252,15 @@ impl FirecrackerProcess {
 /// console broker for anyone attaching a terminal to this VM's ttyS0.
 #[derive(Debug, Clone)]
 pub struct VmProcess {
+    /// The Firecracker process's OS process id.
     pub pid: u32,
+    /// Resolves to `true` once the exit monitor has recorded the final state.
     pub exited: watch::Receiver<bool>,
+    /// Broker for anyone attaching a terminal to this VM's ttyS0.
     pub console: Arc<ConsoleBroker>,
 }
 
+/// Sends `SIGTERM` to `pid`, requesting graceful shutdown.
 pub fn sigterm(pid: u32) {
     // SAFETY: sending a signal is memory-safe; pid races only misdeliver signals.
     unsafe {
@@ -211,6 +268,7 @@ pub fn sigterm(pid: u32) {
     }
 }
 
+/// Sends `SIGKILL` to `pid`, forcing immediate termination.
 pub fn sigkill(pid: u32) {
     // SAFETY: as above.
     unsafe {
@@ -227,7 +285,11 @@ pub fn sigkill(pid: u32) {
 pub fn register_and_watch(state: &AppState, id: Uuid, process: FirecrackerProcess) {
     let (exited_tx, exited_rx) = watch::channel(false);
     let pid = process.pid().unwrap_or_default();
-    let FirecrackerProcess { mut child, api_sock, console } = process;
+    let FirecrackerProcess {
+        mut child,
+        api_sock,
+        console,
+    } = process;
     state
         .processes
         .lock()
@@ -378,7 +440,12 @@ pub async fn spawn_vm(
 /// `console.log` on disk and pushed to the broker for any attached viewers.
 /// Runs until the pipe closes (the Firecracker process exiting closes its
 /// stdout, which is this loop's only way to know to stop).
-fn spawn_console_reader(id: Uuid, mut stdout: tokio::process::ChildStdout, log_file: File, console: Arc<ConsoleBroker>) {
+fn spawn_console_reader(
+    id: Uuid,
+    mut stdout: tokio::process::ChildStdout,
+    log_file: File,
+    console: Arc<ConsoleBroker>,
+) {
     let mut log_file = tokio::fs::File::from_std(log_file);
     tokio::spawn(async move {
         let mut buffer = [0_u8; CONSOLE_READ_CHUNK];
@@ -400,6 +467,8 @@ fn spawn_console_reader(id: Uuid, mut stdout: tokio::process::ChildStdout, log_f
     });
 }
 
+/// Polls the API socket with a minimal HTTP request until it answers or
+/// `timeout` elapses.
 async fn wait_ready(api_sock: &Path, timeout: Duration) -> Result<(), FirecrackerError> {
     let probe = async {
         loop {
@@ -465,19 +534,22 @@ pub async fn stop_vm(
     Ok(())
 }
 
+/// Test-only helpers for standing in a fake Firecracker binary (a small
+/// Python script) so process-spawning tests don't need the real one.
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::fs;
     use std::path::{Path, PathBuf};
 
-    // Every fake writes "{api_sock}.pid" so tests can probe the process after
-    // the FirecrackerProcess handle is consumed.
+    /// Every fake writes "{api_sock}.pid" so tests can probe the process after
+    /// the FirecrackerProcess handle is consumed.
     pub const FAKE_PRELUDE: &str = r#"#!/usr/bin/env python3
 import os, signal, socket, sys, time
 sock_path = sys.argv[sys.argv.index("--api-sock") + 1]
 open(sock_path + ".pid", "w").write(str(os.getpid()))
 "#;
 
+    /// Answers the readiness probe forever, like a running guest.
     pub const SERVE_LOOP: &str = r#"
 print("booted", flush=True)
 srv = socket.socket(socket.AF_UNIX)
@@ -490,7 +562,7 @@ while True:
     conn.close()
 "#;
 
-    // Serves the readiness probe once, then exits like a guest poweroff.
+    /// Serves the readiness probe once, then exits like a guest poweroff.
     pub const SERVE_ONCE_THEN_EXIT: &str = r#"
 srv = socket.socket(socket.AF_UNIX)
 srv.bind(sock_path)
@@ -502,6 +574,8 @@ conn.close()
 sys.exit(0)
 "#;
 
+    /// Writes an executable fake Firecracker script combining the prelude
+    /// with `body`.
     pub fn fake_firecracker(directory: &Path, body: &str) -> PathBuf {
         use std::os::unix::fs::PermissionsExt;
 
@@ -511,12 +585,13 @@ sys.exit(0)
         path
     }
 
-    // Unix socket paths are capped near 108 bytes, so keep test dirs in /tmp
-    // instead of a deeply nested TMPDIR.
+    /// A tempdir under `/tmp`: Unix socket paths are capped near 108 bytes,
+    /// so this avoids a deeply nested `TMPDIR`.
     pub fn short_tempdir() -> tempfile::TempDir {
         tempfile::tempdir_in("/tmp").unwrap()
     }
 
+    /// Whether a process with `pid` still exists.
     pub fn process_alive(pid: i32) -> bool {
         // SAFETY: signal 0 only probes for existence.
         unsafe { libc::kill(pid, 0) == 0 }
@@ -554,12 +629,14 @@ mod tests {
         let vms_dir = directory.path().join("vms");
         let vm = record(3, 768);
 
-        let path = write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0")
-            .unwrap();
+        let path =
+            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
 
-        assert_eq!(path, vms_dir.join(vm.id.to_string()).join("firecracker.json"));
-        let config: serde_json::Value =
-            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            path,
+            vms_dir.join(vm.id.to_string()).join("firecracker.json")
+        );
+        let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(config["machine-config"]["vcpu_count"], 3);
         assert_eq!(config["machine-config"]["mem_size_mib"], 768);
     }
@@ -570,12 +647,14 @@ mod tests {
         let vms_dir = directory.path().join("vms");
         let vm = record(1, 512);
 
-        let path = write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0")
-            .unwrap();
+        let path =
+            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
 
-        let config: serde_json::Value =
-            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
-        assert_eq!(config["boot-source"]["kernel_image_path"], "/images/vmlinux");
+        let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(
+            config["boot-source"]["kernel_image_path"],
+            "/images/vmlinux"
+        );
         assert_eq!(config["boot-source"]["boot_args"], "console=ttyS0");
 
         let drive = &config["drives"][0];
@@ -597,20 +676,23 @@ mod tests {
         write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
         vm.cpu = 2;
         vm.ram = 1024;
-        let path = write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0")
-            .unwrap();
+        let path =
+            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
 
-        let config: serde_json::Value =
-            serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(config["machine-config"]["vcpu_count"], 2);
         assert_eq!(config["machine-config"]["mem_size_mib"], 1024);
     }
 
-    use super::test_support::{fake_firecracker, process_alive, short_tempdir, SERVE_LOOP};
+    use super::test_support::{SERVE_LOOP, fake_firecracker, process_alive, short_tempdir};
 
     fn fake_pid(vms_dir: &Path, id: Uuid) -> i32 {
         let pid_file = format!("{}.pid", api_sock_path(vms_dir, id).display());
-        fs::read_to_string(pid_file).unwrap().trim().parse().unwrap()
+        fs::read_to_string(pid_file)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -653,10 +735,7 @@ mod tests {
     async fn readiness_timeout_cleans_up_the_process() {
         let directory = short_tempdir();
         let vms_dir = directory.path().join("vms");
-        let binary = fake_firecracker(
-            directory.path(),
-            "while True:\n    time.sleep(60)\n",
-        );
+        let binary = fake_firecracker(directory.path(), "while True:\n    time.sleep(60)\n");
         let config = directory.path().join("firecracker.json");
         fs::write(&config, "{}").unwrap();
         let id = Uuid::new_v4();

--- a/firecrab-api/src/handlers/console.rs
+++ b/firecrab-api/src/handlers/console.rs
@@ -46,7 +46,11 @@ fn resolve_console_process(
 }
 
 async fn stream_console(socket: WebSocket, process: VmProcess) {
-    let VmProcess { mut exited, console, .. } = process;
+    let VmProcess {
+        mut exited,
+        console,
+        ..
+    } = process;
     let (mut sink, mut inbound) = socket.split();
     let (backlog, mut output) = console.subscribe();
 
@@ -119,8 +123,9 @@ mod tests {
     fn unknown_vm_id_is_reported_as_not_running() {
         let processes = Mutex::new(HashMap::new());
 
-        let error = resolve_console_process(&processes, &Uuid::new_v4().to_string(), Uuid::new_v4())
-            .unwrap_err();
+        let error =
+            resolve_console_process(&processes, &Uuid::new_v4().to_string(), Uuid::new_v4())
+                .unwrap_err();
         assert_eq!(error.into_response().status(), StatusCode::CONFLICT);
     }
 

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -216,7 +216,10 @@ fn restore_resources(state: &AppState, id: Uuid, previous: PreviousResources) {
     }
 }
 
-fn validate_update(req: &UpdateVmResourcesRequest, current_disk_gb: u16) -> BTreeMap<String, String> {
+fn validate_update(
+    req: &UpdateVmResourcesRequest,
+    current_disk_gb: u16,
+) -> BTreeMap<String, String> {
     let mut fields = BTreeMap::new();
     if !(1..=32).contains(&req.cpu) {
         fields.insert("cpu".to_owned(), "must be between 1 and 32".to_owned());
@@ -338,7 +341,10 @@ pub async fn stop_vm(
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .get(&id)
         .cloned();
-    if let Some(VmProcess { pid, mut exited, .. }) = entry {
+    if let Some(VmProcess {
+        pid, mut exited, ..
+    }) = entry
+    {
         firecracker::sigterm(pid);
         if tokio::time::timeout(state.runtime.stop_grace, exited.changed())
             .await
@@ -537,7 +543,11 @@ async fn run_start(state: &AppState, vm: &VmRecord) -> Result<FirecrackerProcess
         rootfs::prepare_rootfs(&runtime.vms_dir, record.id, &mut source, target_bytes)
             .map_err(|error| format!("rootfs preparation failed: {error}"))?;
 
-        set_startup_step(&state_for_blocking, record.id, StartupStep::GeneratingConfig);
+        set_startup_step(
+            &state_for_blocking,
+            record.id,
+            StartupStep::GeneratingConfig,
+        );
         let kernel = templates.artifact_path(&template.kernel);
         firecracker::write_config(&runtime.vms_dir, &record, &kernel, &template.boot_args)
             .map_err(|error| format!("config generation failed: {error}"))
@@ -1323,7 +1333,10 @@ mod tests {
         assert_eq!(db_state(&reopened, vm.id), Some(VmState::Created));
         let persisted = reopened.store.load_all().unwrap();
         let persisted = persisted.get(&vm.id).unwrap();
-        assert_eq!((persisted.cpu, persisted.ram, persisted.disk_gb), (4, 1024, 3));
+        assert_eq!(
+            (persisted.cpu, persisted.ram, persisted.disk_gb),
+            (4, 1024, 3)
+        );
     }
 
     #[tokio::test]
@@ -1346,7 +1359,10 @@ mod tests {
         assert_eq!(error.into_response().status(), StatusCode::CONFLICT);
         let vms = state.vms.lock().unwrap();
         let unchanged = vms.get(&vm.id).unwrap();
-        assert_eq!((unchanged.cpu, unchanged.ram, unchanged.disk_gb), (1, 128, 0));
+        assert_eq!(
+            (unchanged.cpu, unchanged.ram, unchanged.disk_gb),
+            (1, 128, 0)
+        );
     }
 
     #[tokio::test]

--- a/firecrab-api/src/ipam.rs
+++ b/firecrab-api/src/ipam.rs
@@ -1,3 +1,7 @@
+//! IP address and MAC allocation management (IPAM): hands out unique
+//! IPv4/MAC leases from the fixed 172.30.0.0/24 subnet, backed by SQLite so
+//! allocation is atomic under concurrent VM creation.
+
 use std::collections::HashSet;
 use std::net::Ipv4Addr;
 
@@ -8,6 +12,7 @@ use uuid::Uuid;
 
 use crate::model::{Lease, MacAddr};
 
+/// Schema for the `network_leases` table.
 pub const CREATE_LEASES_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS network_leases (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     vm_id TEXT NOT NULL,
@@ -17,8 +22,8 @@ pub const CREATE_LEASES_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS network_le
     released_at TEXT
 ) STRICT";
 
-// Partial indexes: uniqueness only applies to still-active leases, so
-// released rows stay behind as history without blocking reuse.
+/// Partial indexes: uniqueness only applies to still-active leases, so
+/// released rows stay behind as history without blocking reuse.
 pub const CREATE_LEASES_INDEXES_SQL: [&str; 3] = [
     "CREATE UNIQUE INDEX IF NOT EXISTS network_leases_active_vm \
      ON network_leases(vm_id) WHERE released_at IS NULL",
@@ -28,24 +33,40 @@ pub const CREATE_LEASES_INDEXES_SQL: [&str; 3] = [
      ON network_leases(mac) WHERE released_at IS NULL",
 ];
 
-// Mirrors the fixed fcbr0 config in firecrab-net-helper/src/bridge.rs.
+/// Subnet network address; mirrors the fixed `fcbr0` config in
+/// `firecrab-net-helper/src/bridge.rs`.
 const NETWORK: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 0);
+/// Subnet gateway address, reserved from allocation.
 const GATEWAY: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 1);
+/// Subnet broadcast address, reserved from allocation.
 const BROADCAST: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 255);
+/// How many salted MAC candidates to try before giving up.
 const MAX_MAC_ATTEMPTS: u32 = 8;
 
+/// Failure modes for allocating or releasing a network lease.
 #[derive(Debug, Error)]
 pub enum IpamError {
+    /// A SQLite query/statement failed.
     #[error("network lease operation failed")]
     Database(#[from] rusqlite::Error),
+    /// Every host address in the subnet is already leased.
     #[error("no free IPv4 address left in 172.30.0.0/24")]
     PoolExhausted,
+    /// No unclaimed MAC was found within [`MAX_MAC_ATTEMPTS`] salted tries.
     #[error("could not find a free MAC address after {MAX_MAC_ATTEMPTS} attempts")]
     MacPoolExhausted,
+    /// The VM already holds an unreleased lease.
     #[error("vm {vm_id} already has an active network lease")]
-    AlreadyLeased { vm_id: Uuid },
+    AlreadyLeased {
+        /// The VM that already has an active lease.
+        vm_id: Uuid,
+    },
+    /// The VM has no active lease to release.
     #[error("vm {vm_id} has no active network lease to release")]
-    NotLeased { vm_id: Uuid },
+    NotLeased {
+        /// The VM with no active lease.
+        vm_id: Uuid,
+    },
 }
 
 /// Allocate an IPv4 + MAC for `vm_id`. Must run inside a `BEGIN IMMEDIATE`
@@ -93,6 +114,7 @@ pub fn release(tx: &Transaction<'_>, vm_id: Uuid) -> Result<(), IpamError> {
     Ok(())
 }
 
+/// Whether `vm_id` currently holds an unreleased lease.
 fn has_active_lease(tx: &Transaction<'_>, vm_id: Uuid) -> Result<bool, rusqlite::Error> {
     tx.query_row(
         "SELECT 1 FROM network_leases WHERE vm_id = ?1 AND released_at IS NULL",
@@ -103,6 +125,8 @@ fn has_active_lease(tx: &Transaction<'_>, vm_id: Uuid) -> Result<bool, rusqlite:
     .map(|row| row.is_some())
 }
 
+/// Every IPv4 address currently unavailable for allocation: reserved
+/// network/gateway/broadcast plus every still-leased address.
 fn active_ipv4s(tx: &Transaction<'_>) -> Result<HashSet<Ipv4Addr>, rusqlite::Error> {
     let mut statement = tx.prepare("SELECT ipv4 FROM network_leases WHERE released_at IS NULL")?;
     let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
@@ -115,6 +139,7 @@ fn active_ipv4s(tx: &Transaction<'_>) -> Result<HashSet<Ipv4Addr>, rusqlite::Err
     Ok(set)
 }
 
+/// Every MAC address currently claimed by a still-leased VM.
 fn active_macs(tx: &Transaction<'_>) -> Result<HashSet<MacAddr>, rusqlite::Error> {
     let mut statement = tx.prepare("SELECT mac FROM network_leases WHERE released_at IS NULL")?;
     let rows = statement.query_map([], |row| row.get::<_, String>(0))?;
@@ -127,6 +152,9 @@ fn active_macs(tx: &Transaction<'_>) -> Result<HashSet<MacAddr>, rusqlite::Error
     Ok(set)
 }
 
+/// Deterministically derives a candidate MAC from `vm_id` and `salt`, so
+/// retrying with an incremented salt tries a different address without
+/// needing to track previously-tried candidates.
 fn derive_mac(vm_id: Uuid, salt: u32) -> MacAddr {
     let mut hasher = Sha256::new();
     hasher.update(vm_id.as_bytes());
@@ -194,7 +222,10 @@ mod tests {
         }
 
         let tx = begin(&mut conn);
-        assert!(matches!(allocate(&tx, Uuid::new_v4()), Err(IpamError::PoolExhausted)));
+        assert!(matches!(
+            allocate(&tx, Uuid::new_v4()),
+            Err(IpamError::PoolExhausted)
+        ));
     }
 
     #[test]
@@ -312,6 +343,9 @@ mod tests {
                 |row| row.get(0),
             )
             .unwrap();
-        assert_eq!(leaked, 0, "failed allocation must not leave a lease row behind");
+        assert_eq!(
+            leaked, 0,
+            "failed allocation must not leave a lease row behind"
+        );
     }
 }

--- a/firecrab-api/src/model.rs
+++ b/firecrab-api/src/model.rs
@@ -1,3 +1,7 @@
+//! Internal VM/lease record types, re-exporting the wire types shared with
+//! `firecrab-frontend` from `firecrab-api-types` alongside server-only
+//! fields (e.g. template artifact hashes) that never cross the API boundary.
+
 use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
@@ -13,27 +17,44 @@ pub use firecrab_helper_protocol::network::MacAddr;
 /// subnet (see `firecrab-net-helper/src/bridge.rs`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Lease {
+    /// The VM this lease belongs to.
     pub vm_id: Uuid,
+    /// Allocated IPv4 address.
     pub ipv4: Ipv4Addr,
+    /// Allocated MAC address.
     pub mac: MacAddr,
 }
 
+/// The full server-side VM record, persisted in [`crate::persistence::Store`]
+/// — a superset of [`firecrab_api_types::VmResponse`] with fields (template
+/// artifact hashes) the API response never exposes.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct VmRecord {
+    /// Stable identifier, also the `data/vms/<id>/` directory name.
     pub id: Uuid,
+    /// User-supplied name.
     pub name: String,
+    /// Current lifecycle state.
     pub state: VmState,
+    /// Template alias this VM was created from.
     pub template: String,
+    /// Pinned template version the alias resolved to at creation time.
     #[serde(default)]
     pub template_version: String,
+    /// SHA256 of the template's kernel artifact at creation time.
     #[serde(default)]
     pub template_kernel_sha256: String,
+    /// SHA256 of the template's rootfs artifact at creation time.
     #[serde(default)]
     pub template_rootfs_sha256: String,
+    /// SHA256 of the template's boot args at creation time.
     #[serde(default)]
     pub template_boot_args_sha256: String,
+    /// vCPU count.
     pub cpu: u8,
+    /// RAM in MiB.
     pub ram: u32,
+    /// Disk capacity in GiB.
     #[serde(default = "default_disk_gb")]
     pub disk_gb: u16,
     /// Live progress while `state == Starting`; never persisted (a restart

--- a/firecrab-api/src/persistence.rs
+++ b/firecrab-api/src/persistence.rs
@@ -1,3 +1,6 @@
+//! SQLite-backed VM record storage: schema creation/migration, CRUD, IPAM
+//! lease delegation, and one-time import of the legacy `vms.json` format.
+
 use std::collections::HashMap;
 use std::fs;
 use std::io;
@@ -12,9 +15,12 @@ use uuid::Uuid;
 use crate::ipam::{self, IpamError};
 use crate::model::{Lease, VmRecord, VmState};
 
+/// Default SQLite database path, relative to the process's working directory.
 const DB_FILE: &str = "data/firecrab.db";
+/// File name of the legacy JSON store, imported once on first open.
 const LEGACY_FILE_NAME: &str = "vms.json";
 
+/// Schema for the `vms` table.
 const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS vms (
     id TEXT PRIMARY KEY,
     name TEXT NOT NULL,
@@ -29,19 +35,23 @@ const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS vms (
     disk_gb INTEGER NOT NULL DEFAULT 2
 ) STRICT";
 
+/// Selects every column [`Store::load_all`] needs.
 const SELECT_ALL_SQL: &str = "SELECT id, name, state, template, template_version, \
     template_kernel_sha256, template_rootfs_sha256, template_boot_args_sha256, cpu, ram, disk_gb \
     FROM vms";
 
+/// Inserts a new row; fails on a duplicate id.
 const INSERT_SQL: &str = "INSERT INTO vms (id, name, state, template, template_version, \
     template_kernel_sha256, template_rootfs_sha256, template_boot_args_sha256, cpu, ram, disk_gb) \
     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
 
+/// Upserts a row, used only by the one-time legacy `vms.json` import.
 const IMPORT_SQL: &str = "INSERT OR REPLACE INTO vms (id, name, state, template, \
     template_version, template_kernel_sha256, template_rootfs_sha256, \
     template_boot_args_sha256, cpu, ram, disk_gb) \
     VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)";
 
+/// Replaces an existing row's columns by id.
 const UPDATE_SQL: &str = "UPDATE vms SET name = ?2, state = ?3, template = ?4, \
     template_version = ?5, template_kernel_sha256 = ?6, template_rootfs_sha256 = ?7, \
     template_boot_args_sha256 = ?8, cpu = ?9, ram = ?10, disk_gb = ?11 \
@@ -56,63 +66,98 @@ fn migrate_disk_gb_column(conn: &Connection) -> Result<(), PersistenceError> {
         .prepare("SELECT 1 FROM pragma_table_info('vms') WHERE name = 'disk_gb'")?
         .exists([])?;
     if !has_column {
-        conn.execute("ALTER TABLE vms ADD COLUMN disk_gb INTEGER NOT NULL DEFAULT 2", [])?;
+        conn.execute(
+            "ALTER TABLE vms ADD COLUMN disk_gb INTEGER NOT NULL DEFAULT 2",
+            [],
+        )?;
     }
     Ok(())
 }
 
+/// Failure modes for opening or operating on the VM [`Store`].
 #[derive(Debug, Error)]
 pub enum PersistenceError {
+    /// Couldn't create the database's parent directory.
     #[error("failed to create VM data directory {path}: {source}")]
     CreateDirectory {
+        /// The directory that couldn't be created.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't open the SQLite database file.
     #[error("failed to open VM database {path}: {source}")]
     Open {
+        /// The database path that couldn't be opened.
         path: PathBuf,
         #[source]
         source: rusqlite::Error,
     },
+    /// A SQLite query/statement failed.
     #[error("VM database operation failed: {0}")]
     Database(#[from] rusqlite::Error),
+    /// A stored row's data doesn't match what the application expects.
     #[error("VM database record {id} is invalid: {reason}")]
-    CorruptRecord { id: String, reason: String },
+    CorruptRecord {
+        /// The invalid row's id (as stored, not necessarily a valid UUID).
+        id: String,
+        /// Human-readable reason the row is invalid.
+        reason: String,
+    },
+    /// An operation targeted a VM id with no matching row.
     #[error("VM {id} does not exist in the database")]
-    MissingVm { id: Uuid },
+    MissingVm {
+        /// The id that wasn't found.
+        id: Uuid,
+    },
+    /// Couldn't read the legacy `vms.json` file.
     #[error("failed to read legacy VM data from {path}: {source}")]
     LegacyRead {
+        /// The legacy file path that couldn't be read.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// The legacy `vms.json` file's content isn't valid for the expected shape.
     #[error("failed to deserialize legacy VM data from {path}: {source}")]
     LegacyDeserialize {
+        /// The legacy file path that failed to parse.
         path: PathBuf,
         #[source]
         source: serde_json::Error,
     },
+    /// Couldn't rename the legacy file after a successful import.
     #[error("failed to archive imported legacy VM data {path}: {source}")]
     LegacyArchive {
+        /// The legacy file path that couldn't be renamed.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
 }
 
+/// The default SQLite database path (`data/firecrab.db`).
 pub fn default_db_file() -> PathBuf {
     PathBuf::from(DB_FILE)
 }
 
+/// Handle to the VM records SQLite database. Cheaply `Clone`able; all
+/// clones share one connection behind a mutex.
 #[derive(Debug, Clone)]
 pub struct Store {
+    /// The shared, mutex-guarded SQLite connection.
     conn: Arc<Mutex<Connection>>,
 }
 
 impl Store {
+    /// Opens (creating if needed) the database at `path`: sets WAL mode,
+    /// creates/migrates the schema, and imports any legacy `vms.json` found
+    /// alongside it.
     pub fn open(path: &Path) -> Result<Self, PersistenceError> {
-        if let Some(directory) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        if let Some(directory) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
             fs::create_dir_all(directory).map_err(|source| PersistenceError::CreateDirectory {
                 path: directory.to_owned(),
                 source,
@@ -140,6 +185,7 @@ impl Store {
         Ok(store)
     }
 
+    /// Loads every VM record currently in the database.
     pub fn load_all(&self) -> Result<HashMap<Uuid, VmRecord>, PersistenceError> {
         let conn = self.lock();
         let mut statement = conn.prepare(SELECT_ALL_SQL)?;
@@ -147,11 +193,10 @@ impl Store {
         let mut vms = HashMap::new();
         while let Some(row) = rows.next()? {
             let id_text: String = row.get(0)?;
-            let id =
-                Uuid::parse_str(&id_text).map_err(|_| PersistenceError::CorruptRecord {
-                    id: id_text.clone(),
-                    reason: "id is not a UUID".to_owned(),
-                })?;
+            let id = Uuid::parse_str(&id_text).map_err(|_| PersistenceError::CorruptRecord {
+                id: id_text.clone(),
+                reason: "id is not a UUID".to_owned(),
+            })?;
             let state_text: String = row.get(2)?;
             vms.insert(
                 id,
@@ -174,11 +219,13 @@ impl Store {
         Ok(vms)
     }
 
+    /// Inserts a new VM record.
     pub fn insert(&self, vm: &VmRecord) -> Result<(), PersistenceError> {
         execute_record(&self.lock(), INSERT_SQL, vm)?;
         Ok(())
     }
 
+    /// Replaces an existing VM record's columns.
     pub fn update(&self, vm: &VmRecord) -> Result<(), PersistenceError> {
         if execute_record(&self.lock(), UPDATE_SQL, vm)? == 0 {
             return Err(PersistenceError::MissingVm { id: vm.id });
@@ -186,6 +233,7 @@ impl Store {
         Ok(())
     }
 
+    /// Deletes a VM record by id.
     pub fn delete(&self, id: Uuid) -> Result<(), PersistenceError> {
         let changed = self
             .lock()
@@ -231,6 +279,8 @@ impl Store {
         Ok(changed)
     }
 
+    /// Imports `legacy` (the old JSON store) if it exists, then renames it
+    /// with a `.imported` suffix so re-opening never imports it again.
     fn import_legacy(&self, legacy: &Path) -> Result<(), PersistenceError> {
         let content = match fs::read(legacy) {
             Ok(content) => content,
@@ -242,12 +292,13 @@ impl Store {
                 });
             }
         };
-        let records: HashMap<Uuid, VmRecord> = serde_json::from_slice(&content).map_err(
-            |source| PersistenceError::LegacyDeserialize {
-                path: legacy.to_owned(),
-                source,
-            },
-        )?;
+        let records: HashMap<Uuid, VmRecord> =
+            serde_json::from_slice(&content).map_err(|source| {
+                PersistenceError::LegacyDeserialize {
+                    path: legacy.to_owned(),
+                    source,
+                }
+            })?;
 
         {
             let mut conn = self.lock();
@@ -266,23 +317,23 @@ impl Store {
         })
     }
 
+    /// Locks the shared connection, recovering from a poisoned mutex.
     fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
+    /// Drops the `vms` table so tests can force subsequent queries to fail.
     #[cfg(test)]
     pub(crate) fn break_for_tests(&self) {
         self.lock().execute("DROP TABLE vms", []).unwrap();
     }
 }
 
-fn execute_record(
-    conn: &Connection,
-    sql: &str,
-    vm: &VmRecord,
-) -> Result<usize, rusqlite::Error> {
+/// Binds `vm`'s fields as parameters and executes `sql` (shared by insert,
+/// update, and legacy import, which differ only in which SQL they run).
+fn execute_record(conn: &Connection, sql: &str, vm: &VmRecord) -> Result<usize, rusqlite::Error> {
     conn.execute(
         sql,
         params![
@@ -301,7 +352,8 @@ fn execute_record(
     )
 }
 
-// Encode/decode through serde so the DB text stays in lockstep with the API wire format.
+/// Encodes through serde so the DB text stays in lockstep with the API wire
+/// format.
 pub(crate) fn encode_state(state: VmState) -> String {
     match serde_json::to_value(state) {
         Ok(serde_json::Value::String(name)) => name,
@@ -309,6 +361,7 @@ pub(crate) fn encode_state(state: VmState) -> String {
     }
 }
 
+/// Inverse of [`encode_state`]; fails on any string that isn't a known state.
 fn decode_state(id: &str, name: &str) -> Result<VmState, PersistenceError> {
     serde_json::from_value(serde_json::Value::String(name.to_owned())).map_err(|_| {
         PersistenceError::CorruptRecord {
@@ -479,7 +532,10 @@ mod tests {
                 std::thread::spawn(move || store.allocate_lease(Uuid::new_v4()).unwrap())
             })
             .collect();
-        let leases: Vec<Lease> = handles.into_iter().map(|handle| handle.join().unwrap()).collect();
+        let leases: Vec<Lease> = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect();
 
         let mut ips: Vec<_> = leases.iter().map(|lease| lease.ipv4).collect();
         let mut macs: Vec<_> = leases.iter().map(|lease| lease.mac).collect();
@@ -515,6 +571,9 @@ mod tests {
         store.release_lease(vm_id).unwrap();
         let other_vm = Uuid::new_v4();
         let reallocated = store.allocate_lease(other_vm).unwrap();
-        assert_eq!(reallocated.ipv4, lease.ipv4, "freed address should be reusable");
+        assert_eq!(
+            reallocated.ipv4, lease.ipv4,
+            "freed address should be reusable"
+        );
     }
 }

--- a/firecrab-api/src/rootfs.rs
+++ b/firecrab-api/src/rootfs.rs
@@ -1,3 +1,8 @@
+//! Per-VM writable disk management: copies a verified template rootfs into
+//! `data/vms/{id}/rootfs.ext4` on first start, and grows it (raw file +
+//! filesystem, via `e2fsck`/`resize2fs`) when the requested capacity exceeds
+//! its current size.
+
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -6,61 +11,84 @@ use std::process::Command;
 use thiserror::Error;
 use uuid::Uuid;
 
+/// Default root directory for per-VM state (disk, config, console log).
 const VMS_DIR: &str = "data/vms";
+/// File name of a VM's published writable disk.
 const ROOTFS_FILE_NAME: &str = "rootfs.ext4";
+/// File name of the in-progress copy before it's renamed into place.
 const ROOTFS_TMP_FILE_NAME: &str = "rootfs.ext4.tmp";
 
+/// Failure modes for preparing or growing a VM's rootfs disk.
 #[derive(Debug, Error)]
 pub enum RootfsError {
+    /// Couldn't create the VM's own directory.
     #[error("failed to create VM directory {path}: {source}")]
     CreateDirectory {
+        /// The directory that couldn't be created.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't stat the rootfs file.
     #[error("failed to inspect rootfs at {path}: {source}")]
     Inspect {
+        /// The rootfs path that couldn't be inspected.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't copy the template into the temporary file.
     #[error("failed to copy template rootfs into {path}: {source}")]
     Copy {
+        /// The temporary file path the copy was writing to.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't rename the temporary file into its final location.
     #[error("failed to publish rootfs at {path}: {source}")]
     Publish {
+        /// The final rootfs path that couldn't be published.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't `set_len` the rootfs file to the new target size.
     #[error("failed to extend rootfs file at {path}: {source}")]
     Extend {
+        /// The rootfs path that couldn't be extended.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't spawn `e2fsck`/`resize2fs`.
     #[error("failed to run '{tool}' on rootfs at {path}: {source}")]
     ResizeTool {
+        /// The rootfs path the tool was run against.
         path: PathBuf,
+        /// Which tool failed to spawn (`e2fsck` or `resize2fs`).
         tool: &'static str,
         #[source]
         source: io::Error,
     },
+    /// `e2fsck`/`resize2fs` ran but reported failure.
     #[error("'{tool}' reported a failure while resizing rootfs at {path}: {stderr}")]
     ResizeFailed {
+        /// The rootfs path the tool was run against.
         path: PathBuf,
+        /// Which tool failed (`e2fsck` or `resize2fs`).
         tool: &'static str,
+        /// The tool's stderr output.
         stderr: String,
     },
 }
 
+/// The default per-VM state root (`data/vms`).
 pub fn default_vms_dir() -> PathBuf {
     PathBuf::from(VMS_DIR)
 }
 
+/// Path to a VM's writable rootfs disk file.
 pub fn rootfs_path(vms_dir: &Path, id: Uuid) -> PathBuf {
     vms_dir.join(id.to_string()).join(ROOTFS_FILE_NAME)
 }
@@ -129,16 +157,18 @@ fn grow(rootfs: &Path, target_bytes: u64) -> Result<(), RootfsError> {
         return Ok(());
     }
 
-    let file = OpenOptions::new().write(true).open(rootfs).map_err(|source| {
-        RootfsError::Extend {
+    let file = OpenOptions::new()
+        .write(true)
+        .open(rootfs)
+        .map_err(|source| RootfsError::Extend {
             path: rootfs.to_owned(),
             source,
-        }
-    })?;
-    file.set_len(target_bytes).map_err(|source| RootfsError::Extend {
-        path: rootfs.to_owned(),
-        source,
-    })?;
+        })?;
+    file.set_len(target_bytes)
+        .map_err(|source| RootfsError::Extend {
+            path: rootfs.to_owned(),
+            source,
+        })?;
     drop(file);
 
     let resized = run_resize_tool(rootfs, "e2fsck", &["-f", "-y"], |status| {
@@ -159,6 +189,9 @@ fn grow(rootfs: &Path, target_bytes: u64) -> Result<(), RootfsError> {
     resized
 }
 
+/// Runs `tool` against `rootfs` and maps its exit status through `accept`
+/// (since a successful `e2fsck` run can still exit non-zero for "errors
+/// corrected").
 fn run_resize_tool(
     rootfs: &Path,
     tool: &'static str,
@@ -185,6 +218,7 @@ fn run_resize_tool(
     }
 }
 
+/// Copies `template` into `tmp` and atomically renames it to `rootfs`.
 fn publish(template: &mut File, tmp: &Path, rootfs: &Path) -> Result<(), RootfsError> {
     let copy_error = |source| RootfsError::Copy {
         path: tmp.to_owned(),
@@ -193,9 +227,7 @@ fn publish(template: &mut File, tmp: &Path, rootfs: &Path) -> Result<(), RootfsE
 
     // The registry's hash verification shares the descriptor offset, so the
     // template handle arrives at EOF.
-    template
-        .seek(SeekFrom::Start(0))
-        .map_err(copy_error)?;
+    template.seek(SeekFrom::Start(0)).map_err(copy_error)?;
     let mut out = File::create(tmp).map_err(copy_error)?;
     io::copy(template, &mut out).map_err(copy_error)?;
     out.sync_all().map_err(copy_error)?;
@@ -231,12 +263,17 @@ mod tests {
         let mut template = template_file(directory.path(), b"template-bytes");
         let id = Uuid::new_v4();
 
-        let rootfs = prepare_rootfs(&vms_dir, id, &mut template, "template-bytes".len() as u64)
-            .unwrap();
+        let rootfs =
+            prepare_rootfs(&vms_dir, id, &mut template, "template-bytes".len() as u64).unwrap();
 
         assert_eq!(rootfs, vms_dir.join(id.to_string()).join("rootfs.ext4"));
         assert_eq!(fs::read(&rootfs).unwrap(), b"template-bytes");
-        assert!(!vms_dir.join(id.to_string()).join("rootfs.ext4.tmp").exists());
+        assert!(
+            !vms_dir
+                .join(id.to_string())
+                .join("rootfs.ext4.tmp")
+                .exists()
+        );
     }
 
     #[test]
@@ -249,8 +286,8 @@ mod tests {
         fs::create_dir_all(&vm_dir).unwrap();
         fs::write(vm_dir.join("rootfs.ext4"), b"existing-disk").unwrap();
 
-        let rootfs = prepare_rootfs(&vms_dir, id, &mut template, "existing-disk".len() as u64)
-            .unwrap();
+        let rootfs =
+            prepare_rootfs(&vms_dir, id, &mut template, "existing-disk".len() as u64).unwrap();
 
         assert_eq!(fs::read(&rootfs).unwrap(), b"existing-disk");
     }

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -1,3 +1,6 @@
+//! Shared application state: the in-memory VM record cache, live process
+//! table, and runtime configuration every handler operates against.
+
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -11,15 +14,21 @@ use crate::persistence::{self, PersistenceError, Store};
 use crate::rootfs;
 use crate::templates::TemplateRegistry;
 
+/// Environment-derived settings for spawning/stopping Firecracker.
 #[derive(Debug, Clone)]
 pub struct RuntimeConfig {
+    /// Root directory for per-VM state (disk, config, console log).
     pub vms_dir: PathBuf,
+    /// Path to the Firecracker binary.
     pub firecracker_binary: PathBuf,
+    /// How long to wait for the API socket to become ready on start.
     pub ready_timeout: Duration,
+    /// Grace period before escalating SIGTERM to SIGKILL on stop.
     pub stop_grace: Duration,
 }
 
 impl RuntimeConfig {
+    /// Builds config from environment-derived defaults.
     fn from_defaults() -> Self {
         Self {
             vms_dir: rootfs::default_vms_dir(),
@@ -38,21 +47,33 @@ impl RuntimeConfig {
 /// (`docs/tests/vm-startup-progress.md`).
 const DISK_PREP_CONCURRENCY: usize = 2;
 
+/// Shared state handed to every handler: in-memory VM cache, live process
+/// table, template registry, and runtime config.
 #[derive(Debug, Clone)]
 pub struct AppState {
+    /// In-memory cache of every VM record, mirrored to [`AppState::store`].
     pub vms: Arc<Mutex<HashMap<Uuid, VmRecord>>>,
+    /// Verified boot template registry.
     pub templates: Arc<TemplateRegistry>,
+    /// SQLite-backed durable storage.
     pub(crate) store: Store,
+    /// Live VM id -> its running Firecracker process handle.
     pub(crate) processes: Arc<Mutex<HashMap<Uuid, VmProcess>>>,
+    /// Environment-derived runtime settings.
     pub(crate) runtime: Arc<RuntimeConfig>,
+    /// Bounds how many `start_vm` calls copy/grow a rootfs disk at once.
     pub(crate) disk_prep_permits: Arc<Semaphore>,
 }
 
 impl AppState {
+    /// Builds state backed by the default SQLite database path.
     pub async fn new(templates: TemplateRegistry) -> Result<Self, PersistenceError> {
         Self::with_db_file(templates, persistence::default_db_file()).await
     }
 
+    /// Builds state backed by an explicit database path, resetting any
+    /// leftover live states from a previous run to `Stopped` and loading
+    /// every record into the in-memory cache.
     pub(crate) async fn with_db_file(
         templates: TemplateRegistry,
         db_file: PathBuf,
@@ -78,6 +99,8 @@ impl AppState {
         })
     }
 
+    /// Overrides the runtime config, for tests that need a fake Firecracker
+    /// binary or a short timeout.
     #[cfg(test)]
     pub(crate) fn with_test_runtime(mut self, runtime: RuntimeConfig) -> Self {
         self.runtime = Arc::new(runtime);

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -1,3 +1,9 @@
+//! Immutable, integrity-verified VM boot template registry: resolves a
+//! stable alias (e.g. `ubuntu-26.04`) to a pinned kernel+rootfs version,
+//! re-verifying each artifact's identity (device/inode/length) and content
+//! hash on every open so a template swapped out from under a running
+//! registry is detected instead of silently served.
+
 use std::collections::HashMap;
 use std::env;
 use std::ffi::CString;
@@ -11,75 +17,118 @@ use std::sync::{Arc, Mutex};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+/// `openat2` `RESOLVE_*` flag: reject crossing a mount point.
 const RESOLVE_NO_XDEV: u64 = 0x01;
+/// `openat2` `RESOLVE_*` flag: reject magic-link procfs-style resolution.
 const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+/// `openat2` `RESOLVE_*` flag: reject any symlink in the path.
 const RESOLVE_NO_SYMLINKS: u64 = 0x04;
+/// `openat2` `RESOLVE_*` flag: keep resolution confined beneath the dirfd.
 const RESOLVE_BENEATH: u64 = 0x08;
 
+/// Failure modes for building or reading from a [`TemplateRegistry`].
 #[derive(Debug, Error)]
 pub enum TemplateError {
+    /// An artifact path was absolute, empty, or escaped the image root.
     #[error("template artifact path must be a non-empty relative path")]
     InvalidPath,
+    /// The resolved path exists but isn't a regular file.
     #[error("template artifact is not a regular file: {0}")]
     NotRegularFile(PathBuf),
+    /// An artifact's identity/content no longer matches what was verified
+    /// at registry construction time.
     #[error("template artifact changed after registry validation: {0}")]
     ArtifactChanged(PathBuf),
+    /// Two [`TemplateSpec`]s declared the same `(alias, version)` pair.
     #[error("template registry contains a duplicate version: {0}/{1}")]
     DuplicateVersion(String, String),
+    /// Two [`TemplateSpec`]s declared the same alias.
     #[error("template registry contains a duplicate alias: {0}")]
     DuplicateAlias(String),
+    /// A filesystem operation failed while building the registry.
     #[error("template registry I/O failed: {0}")]
     Io(#[from] io::Error),
 }
 
+/// One template to register: an alias, its pinned version tag, and the
+/// artifacts/boot args that version resolves to.
 #[derive(Debug, Clone)]
 pub struct TemplateSpec {
+    /// Stable, user-facing name (e.g. `ubuntu-26.04`); what the API accepts.
     pub alias: String,
+    /// Internal version tag this alias currently pins to.
     pub version: String,
+    /// Path to the kernel image, relative to the image root.
     pub kernel: PathBuf,
+    /// Path to the rootfs image, relative to the image root.
     pub rootfs: PathBuf,
+    /// Firecracker kernel command line for this template.
     pub boot_args: String,
 }
 
+/// An artifact whose identity and content have been hashed and pinned;
+/// [`TemplateRegistry::open_verified`] re-checks both before every read.
 #[derive(Debug, Clone)]
 pub struct VerifiedArtifact {
+    /// Path relative to the registry's image root.
     relative_path: PathBuf,
+    /// Device number at verification time.
     device: u64,
+    /// Inode number at verification time.
     inode: u64,
+    /// File length at verification time.
     length: u64,
+    /// Full-file SHA256 at verification time.
     sha256: String,
 }
 
 impl VerifiedArtifact {
+    /// The artifact's pinned SHA256 hex digest.
     pub fn sha256(&self) -> &str {
         &self.sha256
     }
 
+    /// The artifact's pinned length in bytes.
     pub fn length(&self) -> u64 {
         self.length
     }
 }
 
+/// One resolved, immutable version of a template: a name/version pair with
+/// its verified kernel and rootfs artifacts.
 #[derive(Debug, Clone)]
 pub struct TemplateVersion {
+    /// The alias this version was registered under.
     pub name: String,
+    /// This version's own tag (distinct from the alias it's reached through).
     pub version: String,
+    /// Verified kernel image.
     pub kernel: VerifiedArtifact,
+    /// Verified rootfs image.
     pub rootfs: VerifiedArtifact,
+    /// Firecracker kernel command line.
     pub boot_args: String,
 }
 
 impl TemplateVersion {
+    /// SHA256 of `boot_args`, so callers can detect a boot-args change
+    /// without re-hashing the (potentially multi-GB) rootfs.
     pub fn boot_args_sha256(&self) -> String {
         sha256_bytes(self.boot_args.as_bytes())
     }
 }
 
+/// Registry of verified template versions, resolved by alias or by exact
+/// `(name, version)`.
 #[derive(Debug, Clone)]
 pub struct TemplateRegistry {
+    /// Directory fd artifacts are opened beneath via `openat2`.
     image_root: Arc<File>,
+    /// Canonical path of the image root, for building absolute paths.
     image_root_path: PathBuf,
+    /// alias -> `(name, version)` it currently resolves to.
     aliases: HashMap<String, (String, String)>,
+    /// `(name, version)` -> the resolved, verified template.
     versions: HashMap<(String, String), Arc<TemplateVersion>>,
     /// Caches `open_verified`'s full-file hash by (device, inode), so many
     /// VMs starting at once against the same untouched multi-GB template
@@ -89,14 +138,20 @@ pub struct TemplateRegistry {
     verify_cache: Arc<Mutex<HashMap<(u64, u64), CachedHash>>>,
 }
 
+/// One entry in [`TemplateRegistry::verify_cache`].
 #[derive(Debug, Clone)]
 struct CachedHash {
+    /// File length when this hash was computed.
     length: u64,
+    /// `(mtime seconds, mtime nanoseconds)` when this hash was computed.
     mtime: (i64, i64),
+    /// The cached SHA256 hex digest.
     sha256: String,
 }
 
 impl TemplateRegistry {
+    /// Loads the registry's built-in template set (`ubuntu-26.04`,
+    /// `alpine-3.24`) from `images/` (or `FIRECRAB_IMAGE_ROOT` if set).
     pub fn load_default() -> Result<Self, TemplateError> {
         let default_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../images");
         let image_root = env::var_os("FIRECRAB_IMAGE_ROOT")
@@ -111,8 +166,7 @@ impl TemplateRegistry {
                     version: "ubuntu-26.04-v1".to_owned(),
                     kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
                     rootfs: PathBuf::from("rootfs/ubuntu-rootfs-26.04-amd64.ext4"),
-                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw"
-                        .to_owned(),
+                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
                 },
                 TemplateSpec {
                     alias: "alpine-3.24".to_owned(),
@@ -121,13 +175,15 @@ impl TemplateRegistry {
                     // (virtio/ext4/serial support, no guest-specific config).
                     kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
                     rootfs: PathBuf::from("rootfs/alpine-rootfs-3.24.1-x86_64.ext4"),
-                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw"
-                        .to_owned(),
+                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
                 },
             ],
         )
     }
 
+    /// Builds a registry from an explicit image root and template specs,
+    /// verifying every artifact's identity and hash up front and rejecting
+    /// duplicate aliases/versions.
     pub fn from_specs(
         image_root: &Path,
         specs: impl IntoIterator<Item = TemplateSpec>,
@@ -171,21 +227,29 @@ impl TemplateRegistry {
         })
     }
 
+    /// Absolute host path for a verified artifact (e.g. to hand to
+    /// Firecracker, which opens boot files by path, not fd).
     pub fn artifact_path(&self, artifact: &VerifiedArtifact) -> PathBuf {
         self.image_root_path.join(&artifact.relative_path)
     }
 
+    /// Resolves a user-facing alias (e.g. `ubuntu-26.04`) to its pinned
+    /// version.
     pub fn resolve_alias(&self, alias: &str) -> Option<Arc<TemplateVersion>> {
         let (name, version) = self.aliases.get(alias)?;
         self.resolve_version(name, version)
     }
 
+    /// Resolves an exact `(name, version)` pair, bypassing alias indirection.
     pub fn resolve_version(&self, name: &str, version: &str) -> Option<Arc<TemplateVersion>> {
         self.versions
             .get(&(name.to_owned(), version.to_owned()))
             .cloned()
     }
 
+    /// Re-verifies `artifact`'s identity (device/inode/length) and content
+    /// hash, then returns an open handle to it. Fails if either check no
+    /// longer matches what was pinned at registry construction time.
     pub fn open_verified(&self, artifact: &VerifiedArtifact) -> Result<File, TemplateError> {
         let file = open_beneath(&self.image_root, &artifact.relative_path)?;
         let metadata = regular_file_metadata(&file, &artifact.relative_path)?;
@@ -213,7 +277,10 @@ impl TemplateRegistry {
         let key = (metadata.dev(), metadata.ino());
         let mtime = (metadata.mtime(), metadata.mtime_nsec());
         {
-            let cache = self.verify_cache.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+            let cache = self
+                .verify_cache
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
             if let Some(cached) = cache.get(&key)
                 && cached.length == metadata.len()
                 && cached.mtime == mtime
@@ -237,6 +304,7 @@ impl TemplateRegistry {
     }
 }
 
+/// Rejects absolute paths, empty paths, and any `.`/`..` component.
 fn validate_relative_path(path: &Path) -> Result<(), TemplateError> {
     let mut has_component = false;
     for component in path.components() {
@@ -251,6 +319,8 @@ fn validate_relative_path(path: &Path) -> Result<(), TemplateError> {
     Ok(())
 }
 
+/// Opens the image root directory itself, as a dirfd for later `openat2`
+/// calls beneath it.
 fn open_image_root(path: &Path) -> io::Result<File> {
     OpenOptions::new()
         .read(true)
@@ -258,13 +328,20 @@ fn open_image_root(path: &Path) -> io::Result<File> {
         .open(path)
 }
 
+/// Argument struct for the raw `openat2(2)` syscall.
 #[repr(C)]
 struct OpenHow {
+    /// `open(2)`-style flags.
     flags: u64,
+    /// Mode bits, unused here (no file creation).
     mode: u64,
+    /// `RESOLVE_*` resolution-restriction flags.
     resolve: u64,
 }
 
+/// Opens `path` relative to `root` via `openat2` with `RESOLVE_BENEATH` (and
+/// no-symlinks/no-magiclinks/no-xdev), so a malicious or mistaken template
+/// path can't escape the image root even via a symlink.
 fn open_beneath(root: &File, path: &Path) -> Result<File, TemplateError> {
     validate_relative_path(path)?;
     let bytes = path.as_os_str().as_encoded_bytes();
@@ -293,6 +370,8 @@ fn open_beneath(root: &File, path: &Path) -> Result<File, TemplateError> {
     Ok(unsafe { File::from_raw_fd(fd as i32) })
 }
 
+/// Opens `path` beneath `root` and pins its identity/hash into a
+/// [`VerifiedArtifact`].
 fn verify_artifact(root: &File, path: &Path) -> Result<VerifiedArtifact, TemplateError> {
     let file = open_beneath(root, path)?;
     let metadata = regular_file_metadata(&file, path)?;
@@ -305,6 +384,7 @@ fn verify_artifact(root: &File, path: &Path) -> Result<VerifiedArtifact, Templat
     })
 }
 
+/// Fetches metadata and rejects anything that isn't a regular file.
 fn regular_file_metadata(file: &File, path: &Path) -> Result<Metadata, TemplateError> {
     let metadata = file.metadata()?;
     if !metadata.is_file() {
@@ -313,6 +393,7 @@ fn regular_file_metadata(file: &File, path: &Path) -> Result<Metadata, TemplateE
     Ok(metadata)
 }
 
+/// Streams the whole file through SHA256 in 64 KiB chunks.
 fn sha256_file(file: &File) -> io::Result<String> {
     let mut file = file.try_clone()?;
     let mut hasher = Sha256::new();
@@ -327,6 +408,7 @@ fn sha256_file(file: &File) -> io::Result<String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+/// SHA256 hex digest of an in-memory byte slice.
 fn sha256_bytes(bytes: &[u8]) -> String {
     format!("{:x}", Sha256::digest(bytes))
 }

--- a/firecrab-helper-protocol/src/framing.rs
+++ b/firecrab-helper-protocol/src/framing.rs
@@ -7,12 +7,19 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 /// violation and the connection must be closed.
 pub const MAX_FRAME_BYTES: usize = 64 * 1024;
 
+/// Failure reading or writing a length-prefixed frame.
 #[derive(Debug, Error)]
 pub enum FrameError {
+    /// The underlying socket read/write failed.
     #[error("connection I/O failed")]
     Io(#[from] std::io::Error),
+    /// Declared or actual frame length exceeds [`MAX_FRAME_BYTES`].
     #[error("frame of {len} bytes exceeds the {MAX_FRAME_BYTES}-byte limit")]
-    TooLarge { len: usize },
+    TooLarge {
+        /// The oversized length that was rejected.
+        len: usize,
+    },
+    /// Frame body didn't deserialize as the expected JSON type.
     #[error("frame payload is not valid protocol JSON")]
     Malformed(#[source] serde_json::Error),
 }
@@ -27,7 +34,9 @@ where
     if payload.len() > MAX_FRAME_BYTES {
         return Err(FrameError::TooLarge { len: payload.len() });
     }
-    writer.write_all(&(payload.len() as u32).to_be_bytes()).await?;
+    writer
+        .write_all(&(payload.len() as u32).to_be_bytes())
+        .await?;
     writer.write_all(&payload).await?;
     writer.flush().await?;
     Ok(())
@@ -63,7 +72,9 @@ mod tests {
             .await
             .expect("write frame");
 
-        let decoded: Vec<String> = read_frame(&mut buffer.as_slice()).await.expect("read frame");
+        let decoded: Vec<String> = read_frame(&mut buffer.as_slice())
+            .await
+            .expect("read frame");
         assert_eq!(decoded, ["a", "b"]);
     }
 

--- a/firecrab-helper-protocol/src/lib.rs
+++ b/firecrab-helper-protocol/src/lib.rs
@@ -1,31 +1,60 @@
+//! Wire protocol shared between `firecrab-api` and the privileged
+//! `firecrab-net-helper`/other helper daemons: framed request/response
+//! envelopes carried over a Unix socket, versioned so mismatched builds
+//! fail fast instead of misparsing each other's messages.
+
+/// Length-prefixed frame read/write helpers shared by all helper protocols.
 pub mod framing;
+/// Network-helper-specific request/response payloads (bridge, TAP, firewall).
 pub mod network;
 
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Wire protocol version; bumped on any breaking envelope/request change.
 pub const PROTOCOL_VERSION: u16 = 1;
+/// Linux `IFNAMSIZ - 1`: the longest name a network interface can have.
 pub const MAX_INTERFACE_NAME_LEN: usize = 15;
 
+/// A request understood by the (currently unused) generic helper protocol;
+/// see [`network::NetworkRequest`] for the network-helper's own requests.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum HelperRequest {
-    PrepareRuntime { vm_id: Uuid, runtime_id: Uuid },
-    RemoveRuntime { vm_id: Uuid, runtime_id: Uuid },
+    /// Provision runtime state for a starting VM.
+    PrepareRuntime {
+        /// The VM this runtime belongs to.
+        vm_id: Uuid,
+        /// Identifies this particular runtime instance.
+        runtime_id: Uuid,
+    },
+    /// Tear down runtime state for a stopped/deleted VM.
+    RemoveRuntime {
+        /// The VM this runtime belongs to.
+        vm_id: Uuid,
+        /// Identifies this particular runtime instance.
+        runtime_id: Uuid,
+    },
 }
 
+/// A request tagged with the protocol version the sender speaks.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RequestEnvelope {
+    /// Sender's [`PROTOCOL_VERSION`].
     pub version: u16,
+    /// The actual request payload.
     pub request: HelperRequest,
 }
 
+/// Errors from validating a [`RequestEnvelope`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ProtocolError {
+    /// The envelope's version doesn't match [`PROTOCOL_VERSION`].
     UnsupportedVersion(u16),
 }
 
 impl RequestEnvelope {
+    /// Unwraps the request if `version` matches [`PROTOCOL_VERSION`].
     pub fn validate(self) -> Result<HelperRequest, ProtocolError> {
         if self.version != PROTOCOL_VERSION {
             return Err(ProtocolError::UnsupportedVersion(self.version));

--- a/firecrab-helper-protocol/src/network.rs
+++ b/firecrab-helper-protocol/src/network.rs
@@ -12,6 +12,7 @@ use crate::PROTOCOL_VERSION;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MacAddr(pub [u8; 6]);
 
+/// Returned by [`MacAddr`]'s `FromStr` impl for malformed input.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[error("MAC address must be six ':'-separated hex octets")]
 pub struct MacAddrParseError;
@@ -62,35 +63,53 @@ impl<'de> Deserialize<'de> for MacAddr {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "operation", rename_all = "snake_case")]
 pub enum NetworkRequest {
+    /// Idempotently ensure the shared bridge/subnet/gateway exist.
     EnsureBridge,
+    /// Idempotently (re)apply the owned nftables tables.
     EnsureFirewall,
+    /// Create and attach a TAP device for a starting VM.
     CreateTap {
+        /// The VM the TAP belongs to.
         vm_id: Uuid,
     },
+    /// Remove a VM's TAP device.
     DeleteTap {
+        /// The VM the TAP belongs to.
         vm_id: Uuid,
     },
+    /// Apply per-VM firewall/anti-spoofing rules for its lease.
     ApplyVmPolicy {
+        /// The VM the policy applies to.
         vm_id: Uuid,
+        /// The VM's allocated IPv4 address.
         ipv4: Ipv4Addr,
+        /// The VM's Firecracker guest MAC.
         mac: MacAddr,
         /// ID resolved against the helper's allowlist; never a raw CIDR.
         egress_policy: String,
+        /// Whether host SSH access should be permitted for this VM.
         allow_host_ssh: bool,
     },
+    /// Remove a VM's firewall/anti-spoofing rules.
     RemoveVmPolicy {
+        /// The VM whose policy should be removed.
         vm_id: Uuid,
     },
 }
 
+/// A [`NetworkRequest`] tagged with protocol version and a correlation id.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NetworkRequestEnvelope {
+    /// Sender's [`crate::PROTOCOL_VERSION`].
     pub version: u16,
+    /// Correlates this request with its response.
     pub request_id: Uuid,
+    /// The actual request payload.
     pub request: NetworkRequest,
 }
 
 impl NetworkRequestEnvelope {
+    /// Wraps `request` with the current protocol version.
     pub fn new(request_id: Uuid, request: NetworkRequest) -> Self {
         Self {
             version: PROTOCOL_VERSION,
@@ -100,23 +119,41 @@ impl NetworkRequestEnvelope {
     }
 }
 
+/// Reasons a [`NetworkRequest`] can fail, sent back over the wire.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Error)]
 #[serde(tag = "code", rename_all = "snake_case")]
 pub enum HelperFailure {
+    /// Request envelope's version doesn't match the helper's.
     #[error("helper only speaks protocol version {supported}")]
-    UnsupportedVersion { supported: u16 },
+    UnsupportedVersion {
+        /// The version the helper actually supports.
+        supported: u16,
+    },
+    /// The requested operation exists but has no handler yet.
     #[error("operation is not implemented yet")]
     UnsupportedOperation,
+    /// Request failed validation before touching any host state.
     #[error("request rejected: {detail}")]
-    InvalidRequest { detail: String },
+    InvalidRequest {
+        /// Human-readable rejection reason.
+        detail: String,
+    },
+    /// Request was valid but applying it failed.
     #[error("helper internal failure: {detail}")]
-    Internal { detail: String },
+    Internal {
+        /// Human-readable failure detail.
+        detail: String,
+    },
 }
 
+/// Response to a [`NetworkRequestEnvelope`], echoing its correlation id.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct NetworkResponseEnvelope {
+    /// Responder's [`crate::PROTOCOL_VERSION`].
     pub version: u16,
+    /// Matches the request's `request_id`.
     pub request_id: Uuid,
+    /// Outcome of processing the request.
     pub result: Result<(), HelperFailure>,
 }
 
@@ -131,12 +168,21 @@ mod tests {
 
         let json = serde_json::to_string(&mac).expect("serialize");
         assert_eq!(json, "\"02:fc:0a:1b:2c:3d\"");
-        assert_eq!(serde_json::from_str::<MacAddr>(&json).expect("deserialize"), mac);
+        assert_eq!(
+            serde_json::from_str::<MacAddr>(&json).expect("deserialize"),
+            mac
+        );
     }
 
     #[test]
     fn malformed_mac_addrs_are_rejected() {
-        for text in ["", "02:fc", "02:fc:0a:1b:2c:3d:4e", "02:fc:0a:1b:2c:zz", "2:fc:0a:1b:2c:3d"] {
+        for text in [
+            "",
+            "02:fc",
+            "02:fc:0a:1b:2c:3d:4e",
+            "02:fc:0a:1b:2c:zz",
+            "2:fc:0a:1b:2c:3d",
+        ] {
             assert_eq!(text.parse::<MacAddr>(), Err(MacAddrParseError), "{text}");
         }
     }

--- a/firecrab-net-helper/src/bridge.rs
+++ b/firecrab-net-helper/src/bridge.rs
@@ -1,3 +1,6 @@
+//! Idempotent creation/repair of the single Firecrab-owned Linux bridge
+//! (`fcbr0`) that every VM's TAP device attaches to.
+
 use std::fs;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
@@ -13,26 +16,44 @@ use rtnetlink::{Handle, LinkBridge, LinkUnspec, new_connection};
 use thiserror::Error;
 use tokio::sync::Mutex;
 
+/// Name of the single Firecrab-owned Linux bridge shared by every VM.
 pub const BRIDGE_NAME: &str = "fcbr0";
+/// MTU applied to the bridge and its link.
 pub const BRIDGE_MTU: u32 = 1500;
+/// Bridge's own address on the VPC subnet, also the VMs' default gateway.
 pub const BRIDGE_GATEWAY: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 1);
+/// Network address of the Firecrab VPC subnet (172.30.0.0/24).
 const BRIDGE_NETWORK: Ipv4Addr = Ipv4Addr::new(172, 30, 0, 0);
+/// CIDR prefix length of the Firecrab VPC subnet.
 const BRIDGE_PREFIX: u8 = 24;
 
+/// Failure modes for [`ensure_bridge`].
 #[derive(Debug, Error)]
 pub enum BridgeError {
+    /// Couldn't open the rtnetlink socket.
     #[error("failed to open rtnetlink connection")]
     Connection(#[source] io::Error),
+    /// An rtnetlink request failed.
     #[error("rtnetlink operation failed")]
     Netlink(#[source] rtnetlink::Error),
+    /// A pre-existing host address overlaps the Firecrab subnet.
     #[error("Firecrab subnet 172.30.0.0/24 overlaps host address {0}")]
     AddressConflict(Ipv4Addr),
+    /// A pre-existing host route overlaps the Firecrab subnet.
     #[error("Firecrab subnet 172.30.0.0/24 overlaps host route {network}/{prefix}")]
-    RouteConflict { network: Ipv4Addr, prefix: u8 },
+    RouteConflict {
+        /// The conflicting route's network address.
+        network: Ipv4Addr,
+        /// The conflicting route's prefix length.
+        prefix: u8,
+    },
+    /// The bridge already has the gateway IP but at a different prefix.
     #[error("bridge gateway {BRIDGE_GATEWAY}/{BRIDGE_PREFIX} has a conflicting prefix")]
     GatewayPrefixConflict,
+    /// The bridge vanished between being created and being looked up again.
     #[error("bridge {BRIDGE_NAME} disappeared while it was being configured")]
     MissingAfterCreate,
+    /// Writing the per-interface IPv6-disable sysctl failed.
     #[error("failed to disable IPv6 on {BRIDGE_NAME}")]
     Ipv6Disable(#[source] io::Error),
 }
@@ -44,10 +65,12 @@ pub enum BridgeError {
 /// short-circuit), just mutual exclusion over the whole check-then-act flow.
 #[derive(Debug, Default)]
 pub struct BridgeActor {
+    /// Held for the duration of a whole check-then-act `ensure_bridge` call.
     lock: Mutex<()>,
 }
 
 impl BridgeActor {
+    /// Creates an actor with no bridge-creation call in flight yet.
     pub fn new() -> Self {
         Self::default()
     }
@@ -110,6 +133,7 @@ fn disable_ipv6() -> Result<(), BridgeError> {
     }
 }
 
+/// Looks up the Firecrab bridge by name, if it already exists.
 async fn find_bridge(handle: &Handle) -> Result<Option<LinkMessage>, BridgeError> {
     let mut links = handle
         .link()
@@ -119,15 +143,15 @@ async fn find_bridge(handle: &Handle) -> Result<Option<LinkMessage>, BridgeError
     match links.try_next().await {
         Ok(link) => Ok(link),
         // A get-by-name answers ENODEV when the link does not exist yet.
-        Err(rtnetlink::Error::NetlinkError(message))
-            if message.raw_code() == -libc::ENODEV =>
-        {
+        Err(rtnetlink::Error::NetlinkError(message)) if message.raw_code() == -libc::ENODEV => {
             Ok(None)
         }
         Err(error) => Err(BridgeError::Netlink(error)),
     }
 }
 
+/// Fails if any host address/route outside our own bridge already overlaps
+/// the Firecrab subnet.
 async fn assert_subnet_available(
     handle: &Handle,
     own_bridge_index: Option<u32>,
@@ -165,6 +189,7 @@ async fn assert_subnet_available(
     Ok(())
 }
 
+/// Adds [`BRIDGE_GATEWAY`] to the bridge if it isn't already assigned.
 async fn ensure_gateway(handle: &Handle, bridge_index: u32) -> Result<(), BridgeError> {
     let mut addresses = handle
         .address()
@@ -182,22 +207,22 @@ async fn ensure_gateway(handle: &Handle, bridge_index: u32) -> Result<(), Bridge
 
     handle
         .address()
-        .add(
-            bridge_index,
-            IpAddr::V4(BRIDGE_GATEWAY),
-            BRIDGE_PREFIX,
-        )
+        .add(bridge_index, IpAddr::V4(BRIDGE_GATEWAY), BRIDGE_PREFIX)
         .execute()
         .await
         .map_err(BridgeError::Netlink)
 }
 
+/// Extracts the IPv4 address from an rtnetlink address attribute list, if any.
 fn ipv4_address(address: &rtnetlink::packet_route::address::AddressMessage) -> Option<Ipv4Addr> {
-    address.attributes.iter().find_map(|attribute| match attribute {
-        AddressAttribute::Address(IpAddr::V4(ipv4))
-        | AddressAttribute::Local(IpAddr::V4(ipv4)) => Some(*ipv4),
-        _ => None,
-    })
+    address
+        .attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            AddressAttribute::Address(IpAddr::V4(ipv4))
+            | AddressAttribute::Local(IpAddr::V4(ipv4)) => Some(*ipv4),
+            _ => None,
+        })
 }
 
 /// Whether a route should be excluded from the conflict scan because it
@@ -211,34 +236,46 @@ fn route_belongs_to_own_bridge(route_oif: Option<u32>, own_bridge_index: Option<
     }
 }
 
+/// Extracts a route's outgoing interface index, if it has one.
 fn route_output_interface(route: &RouteMessage) -> Option<u32> {
-    route.attributes.iter().find_map(|attribute| match attribute {
-        RouteAttribute::Oif(index) => Some(*index),
-        _ => None,
-    })
+    route
+        .attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            RouteAttribute::Oif(index) => Some(*index),
+            _ => None,
+        })
 }
 
+/// Extracts a route's IPv4 destination network, if it has one.
 fn route_ipv4_destination(route: &RouteMessage) -> Option<Ipv4Addr> {
-    route.attributes.iter().find_map(|attribute| match attribute {
-        RouteAttribute::Destination(RouteAddress::Inet(ipv4)) => Some(*ipv4),
-        _ => None,
-    })
+    route
+        .attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            RouteAttribute::Destination(RouteAddress::Inet(ipv4)) => Some(*ipv4),
+            _ => None,
+        })
 }
 
+/// Whether `address` falls within `network/prefix`.
 fn subnet_contains(address: Ipv4Addr, network: Ipv4Addr, prefix: u8) -> bool {
     ipv4_to_u32(address) & prefix_mask(prefix) == ipv4_to_u32(network) & prefix_mask(prefix)
 }
 
+/// Whether two CIDR ranges share any address.
 fn cidrs_overlap(a_network: Ipv4Addr, a_prefix: u8, b_network: Ipv4Addr, b_prefix: u8) -> bool {
     let shared_prefix = a_prefix.min(b_prefix);
     ipv4_to_u32(a_network) & prefix_mask(shared_prefix)
         == ipv4_to_u32(b_network) & prefix_mask(shared_prefix)
 }
 
+/// Big-endian numeric form of an IPv4 address, for bitmask arithmetic.
 fn ipv4_to_u32(address: Ipv4Addr) -> u32 {
     u32::from_be_bytes(address.octets())
 }
 
+/// Bitmask covering the top `prefix` bits of a 32-bit address.
 fn prefix_mask(prefix: u8) -> u32 {
     match prefix {
         0 => 0,

--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -1,3 +1,7 @@
+//! Per-VM and global nftables rules: NAT/egress dispatch (`inet firecrab`)
+//! and L2 anti-spoofing (`bridge firecrab_l2`), both idempotently rendered
+//! and applied as single atomic `nft -f -` transactions.
+
 use std::net::Ipv4Addr;
 use std::process::Stdio;
 
@@ -16,8 +20,11 @@ use uuid::Uuid;
 
 use crate::bridge::BRIDGE_NAME;
 
+/// Name of the owned `inet` table (NAT/egress dispatch).
 const TABLE_INET: &str = "firecrab";
+/// Name of the owned `bridge` table (L2 anti-spoofing).
 const TABLE_BRIDGE: &str = "firecrab_l2";
+/// The Firecrab VPC subnet, as an nftables-literal CIDR string.
 const BRIDGE_SUBNET: &str = "172.30.0.0/24";
 /// TAP interface names are bounded by IFNAMSIZ (16 incl. NUL). `fct` + 12 hex
 /// of sha256(vm_id) = 15 chars. The prefix is distinct from `fcbr0` so an
@@ -38,6 +45,8 @@ pub enum EgressPolicy {
 }
 
 impl EgressPolicy {
+    /// Resolves an API-supplied policy ID, or `None` if it's not on the
+    /// allowlist (the helper never accepts a raw CIDR from the API).
     pub fn from_id(id: &str) -> Option<Self> {
         match id {
             "internet" => Some(EgressPolicy::Internet),
@@ -52,9 +61,13 @@ impl EgressPolicy {
 /// source address that does not match them.
 #[derive(Debug, Clone, Copy)]
 pub struct VmPolicy {
+    /// The VM this policy applies to.
     pub vm_id: Uuid,
+    /// The VM's leased IPv4 address.
     pub ipv4: Ipv4Addr,
+    /// The VM's Firecracker guest MAC.
     pub mac: MacAddr,
+    /// Outbound (egress) posture for this VM.
     pub egress: EgressPolicy,
     /// Open forwarded inbound TCP 22 to this VM. Note: host-*originated*
     /// traffic traverses the output hook, which this initial scope does not
@@ -63,22 +76,33 @@ pub struct VmPolicy {
     pub allow_host_ssh: bool,
 }
 
+/// Failure modes shared by every firewall operation.
 #[derive(Debug, Error)]
 pub enum FirewallError {
+    /// Couldn't open the rtnetlink socket.
     #[error("failed to open rtnetlink connection")]
     Connection(#[source] std::io::Error),
+    /// An rtnetlink request failed.
     #[error("rtnetlink operation failed")]
     Netlink(#[source] rtnetlink::Error),
+    /// No IPv4 default route exists, so the uplink can't be detected.
     #[error("host has no IPv4 default route to detect an uplink interface")]
     NoUplink,
+    /// Detected uplink name isn't safe to embed in an nftables ruleset.
     #[error("uplink interface name {0:?} is not valid for an nftables rule")]
     InvalidUplinkName(String),
+    /// Couldn't spawn the `nft` binary.
     #[error("failed to spawn nft")]
     Spawn(#[source] std::io::Error),
+    /// Writing the ruleset to `nft`'s stdin failed.
     #[error("failed to write ruleset to nft stdin")]
     WriteStdin(#[source] std::io::Error),
+    /// `nft` rejected the ruleset.
     #[error("nft rejected the ruleset: {stderr}")]
-    NftFailed { stderr: String },
+    NftFailed {
+        /// `nft`'s stderr output.
+        stderr: String,
+    },
 }
 
 /// Single-writer actor: every `nft` write goes through one mutex, so
@@ -88,17 +112,21 @@ pub enum FirewallError {
 /// IP it needs to delete this VM's IP-keyed map elements.
 #[derive(Debug)]
 pub struct FirewallActor {
+    /// The one lock every `nft` write goes through.
     state: Mutex<FirewallState>,
 }
 
+/// The actor's cached view of what's currently applied to `nft`.
 #[derive(Debug, Default)]
 struct FirewallState {
+    /// Uplink interface name the global ruleset was last rendered for.
     applied_uplink: Option<String>,
     /// vm_id -> leased IPv4 of every VM whose policy is currently installed.
     applied_vms: std::collections::HashMap<Uuid, Ipv4Addr>,
 }
 
 impl FirewallActor {
+    /// Creates an actor with nothing recorded as applied yet.
     pub fn new() -> Self {
         Self {
             state: Mutex::new(FirewallState::default()),
@@ -107,6 +135,7 @@ impl FirewallActor {
 }
 
 impl Default for FirewallActor {
+    /// Same as [`FirewallActor::new`].
     fn default() -> Self {
         Self::new()
     }
@@ -166,6 +195,7 @@ pub async fn remove_firewall(actor: &FirewallActor) -> Result<(), FirewallError>
     Ok(())
 }
 
+/// Whether `name` is safe to embed unescaped in an nftables ruleset string.
 fn validate_uplink(name: &str) -> Result<(), FirewallError> {
     let is_valid = !name.is_empty()
         && name.len() < 16 // IFNAMSIZ
@@ -331,6 +361,8 @@ fn render_remove_ruleset() -> String {
     )
 }
 
+/// Resolves the host's uplink by following its IPv4 default route to an
+/// interface name.
 async fn detect_uplink(handle: &Handle) -> Result<String, FirewallError> {
     let mut routes = handle.route().get(RouteMessage::default()).execute();
     let mut oif_index = None;
@@ -338,10 +370,13 @@ async fn detect_uplink(handle: &Handle) -> Result<String, FirewallError> {
         if route.header.address_family == AddressFamily::Inet
             && route.header.destination_prefix_length == 0
         {
-            oif_index = route.attributes.iter().find_map(|attribute| match attribute {
-                RouteAttribute::Oif(index) => Some(*index),
-                _ => None,
-            });
+            oif_index = route
+                .attributes
+                .iter()
+                .find_map(|attribute| match attribute {
+                    RouteAttribute::Oif(index) => Some(*index),
+                    _ => None,
+                });
             if oif_index.is_some() {
                 break;
             }
@@ -384,7 +419,10 @@ async fn run_nft(ruleset: &str) -> Result<(), FirewallError> {
         .map_err(FirewallError::WriteStdin)?;
     drop(stdin);
 
-    let output = child.wait_with_output().await.map_err(FirewallError::Spawn)?;
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(FirewallError::Spawn)?;
     if !output.status.success() {
         return Err(FirewallError::NftFailed {
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -412,7 +450,9 @@ mod tests {
         assert!(ruleset.contains("policy accept"));
         assert!(ruleset.contains("iifname \"fcbr0\" jump firecrab_egress"));
         assert!(ruleset.contains("oifname \"fcbr0\" jump firecrab_ingress"));
-        assert!(ruleset.contains("ip saddr 172.30.0.0/24 oifname \"eth0\" jump firecrab_postrouting"));
+        assert!(
+            ruleset.contains("ip saddr 172.30.0.0/24 oifname \"eth0\" jump firecrab_postrouting")
+        );
         assert!(ruleset.contains("masquerade"));
     }
 
@@ -551,19 +591,39 @@ mod tests {
         let vm = Uuid::from_u128(0x1234);
         let ruleset = render_vm_policy_removal(vm, Ipv4Addr::new(172, 30, 0, 42));
         let tag = vm.simple();
-        let l2_elem = ruleset.find("delete element bridge firecrab_l2 l2_ingress").unwrap();
-        let l2_chain = ruleset.find(&format!("delete chain bridge firecrab_l2 vm_{tag}_l2")).unwrap();
-        assert!(l2_elem < l2_chain, "map element must be deleted before its chain");
+        let l2_elem = ruleset
+            .find("delete element bridge firecrab_l2 l2_ingress")
+            .unwrap();
+        let l2_chain = ruleset
+            .find(&format!("delete chain bridge firecrab_l2 vm_{tag}_l2"))
+            .unwrap();
+        assert!(
+            l2_elem < l2_chain,
+            "map element must be deleted before its chain"
+        );
 
-        let eg_elem = ruleset.find("delete element inet firecrab vm_egress").unwrap();
-        let eg_chain = ruleset.find(&format!("delete chain inet firecrab vm_{tag}_eg")).unwrap();
-        assert!(eg_elem < eg_chain, "egress element must be deleted before its chain");
+        let eg_elem = ruleset
+            .find("delete element inet firecrab vm_egress")
+            .unwrap();
+        let eg_chain = ruleset
+            .find(&format!("delete chain inet firecrab vm_{tag}_eg"))
+            .unwrap();
+        assert!(
+            eg_elem < eg_chain,
+            "egress element must be deleted before its chain"
+        );
     }
 
     #[test]
     fn unknown_egress_policy_id_is_rejected() {
-        assert_eq!(EgressPolicy::from_id("internet"), Some(EgressPolicy::Internet));
-        assert_eq!(EgressPolicy::from_id("isolated"), Some(EgressPolicy::Isolated));
+        assert_eq!(
+            EgressPolicy::from_id("internet"),
+            Some(EgressPolicy::Internet)
+        );
+        assert_eq!(
+            EgressPolicy::from_id("isolated"),
+            Some(EgressPolicy::Isolated)
+        );
         assert_eq!(EgressPolicy::from_id("0.0.0.0/0"), None);
         assert_eq!(EgressPolicy::from_id("wide-open"), None);
     }
@@ -602,6 +662,10 @@ mod tests {
     async fn remove_vm_policy_is_a_no_op_when_nothing_was_applied() {
         // No applied_vms entry -> returns Ok without ever invoking nft.
         let actor = FirewallActor::new();
-        assert!(remove_vm_policy(&actor, Uuid::from_u128(0x1234)).await.is_ok());
+        assert!(
+            remove_vm_policy(&actor, Uuid::from_u128(0x1234))
+                .await
+                .is_ok()
+        );
     }
 }

--- a/firecrab-net-helper/src/main.rs
+++ b/firecrab-net-helper/src/main.rs
@@ -1,3 +1,8 @@
+//! Privileged helper daemon: owns bridge/firewall host operations behind a
+//! Unix socket so `firecrab-api` never needs root. Peers are authenticated
+//! via `SO_PEERCRED` against an explicit UID allowlist, not the socket's
+//! filesystem permissions alone.
+
 use std::collections::HashSet;
 use std::env;
 use std::fs;
@@ -8,7 +13,9 @@ use std::process::ExitCode;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Firecrab bridge (`fcbr0`) creation/repair.
 mod bridge;
+/// Per-VM and global nftables firewall rules.
 mod firewall;
 
 use firecrab_helper_protocol::PROTOCOL_VERSION;
@@ -21,43 +28,61 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Semaphore;
 use tokio::time::timeout;
 
+/// Default Unix socket path, overridable via `FIRECRAB_NET_HELPER_SOCK`.
 const DEFAULT_SOCKET_PATH: &str = "/run/firecrab/net-helper.sock";
+/// Upper bound on concurrently handled connections; excess ones are dropped.
 const MAX_CONNECTIONS: usize = 16;
+/// How long to wait for a full request frame before closing the connection.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Failures that can prevent the helper from starting up.
 #[derive(Debug, Error)]
 enum StartupError {
+    /// `FIRECRAB_NET_HELPER_ALLOWED_UID` isn't a valid `u32`.
     #[error("invalid FIRECRAB_NET_HELPER_ALLOWED_UID: {0}")]
     InvalidAllowedUid(String),
+    /// Couldn't create the socket's parent directory.
     #[error("failed to prepare socket directory {path}")]
     SocketDir {
+        /// The directory that couldn't be created.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't bind the Unix socket.
     #[error("failed to bind helper socket {path}")]
     Bind {
+        /// The socket path that couldn't be bound.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
+    /// Couldn't restrict the socket file's permissions after binding.
     #[error("failed to restrict permissions on helper socket {path}")]
     Permissions {
+        /// The socket path whose permissions couldn't be set.
         path: PathBuf,
         #[source]
         source: io::Error,
     },
 }
 
+/// Resolved startup configuration plus the shared actors every connection
+/// dispatches into.
 #[derive(Debug)]
 struct HelperConfig {
+    /// Where the Unix socket is bound.
     socket_path: PathBuf,
+    /// UIDs allowed to connect, checked via `SO_PEERCRED`.
     allowed_peer_uids: HashSet<u32>,
+    /// Shared firewall state (single-writer mutex inside).
     firewall: firewall::FirewallActor,
+    /// Shared bridge-creation state (single-writer mutex inside).
     bridge: bridge::BridgeActor,
 }
 
 impl HelperConfig {
+    /// Reads configuration from the process environment.
     fn load() -> Result<Self, StartupError> {
         let socket_path =
             env::var("FIRECRAB_NET_HELPER_SOCK").unwrap_or_else(|_| DEFAULT_SOCKET_PATH.to_owned());
@@ -65,6 +90,7 @@ impl HelperConfig {
         Self::from_values(&socket_path, allowed_uid.as_deref())
     }
 
+    /// Builds config from already-parsed values (used directly by tests).
     fn from_values(socket_path: &str, allowed_uid: Option<&str>) -> Result<Self, StartupError> {
         // The helper always trusts its own uid so unprivileged local
         // development needs no extra configuration; production adds the
@@ -86,16 +112,20 @@ impl HelperConfig {
         })
     }
 
+    /// Whether `uid` is on the allowlist.
     fn peer_allowed(&self, uid: u32) -> bool {
         self.allowed_peer_uids.contains(&uid)
     }
 }
 
+/// This process's effective UID, always implicitly trusted.
 fn effective_uid() -> u32 {
     // SAFETY: geteuid has no failure modes or preconditions.
     unsafe { libc::geteuid() }
 }
 
+/// Entry point: runs the server and prints any startup error's full cause
+/// chain before exiting non-zero.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
     match run().await {
@@ -112,6 +142,7 @@ async fn main() -> ExitCode {
     }
 }
 
+/// Loads config, binds the socket, and serves until shutdown.
 async fn run() -> Result<(), StartupError> {
     let config = Arc::new(HelperConfig::load()?);
     let listener = bind_socket(&config.socket_path)?;
@@ -125,6 +156,8 @@ async fn run() -> Result<(), StartupError> {
     Ok(())
 }
 
+/// Creates the socket's parent directory if needed, removes a stale socket
+/// file, binds, and restricts permissions to owner/group only.
 fn bind_socket(path: &Path) -> Result<UnixListener, StartupError> {
     if let Some(parent) = path.parent()
         && !parent.as_os_str().is_empty()
@@ -159,6 +192,7 @@ fn bind_socket(path: &Path) -> Result<UnixListener, StartupError> {
     Ok(listener)
 }
 
+/// Resolves once SIGTERM or Ctrl-C is received.
 async fn shutdown_signal() {
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
         .expect("install SIGTERM handler");
@@ -168,6 +202,8 @@ async fn shutdown_signal() {
     }
 }
 
+/// Accepts connections until `shutdown` resolves, spawning one task per
+/// connection bounded by [`MAX_CONNECTIONS`] concurrent permits.
 async fn serve(
     listener: UnixListener,
     config: Arc<HelperConfig>,
@@ -192,6 +228,8 @@ async fn serve(
     }
 }
 
+/// Serves requests on one accepted connection until it errors, times out, or
+/// a version-mismatch response is sent.
 async fn handle_connection(stream: UnixStream, config: Arc<HelperConfig>) {
     let Ok(peer) = stream.peer_cred() else { return };
     // Silent close: unauthenticated peers learn nothing about the protocol.
@@ -220,6 +258,7 @@ async fn handle_connection(stream: UnixStream, config: Arc<HelperConfig>) {
     }
 }
 
+/// Validates the envelope's protocol version, then dispatches its request.
 async fn respond_to(
     envelope: NetworkRequestEnvelope,
     config: &HelperConfig,
@@ -238,18 +277,21 @@ async fn respond_to(
     }
 }
 
+/// Routes a validated request to the matching bridge/firewall operation.
 async fn dispatch(request: NetworkRequest, config: &HelperConfig) -> Result<(), HelperFailure> {
     match request {
-        NetworkRequest::EnsureBridge => bridge::ensure_bridge(&config.bridge).await.map_err(|error| HelperFailure::Internal {
-            detail: error_chain(&error),
-        }),
-        NetworkRequest::EnsureFirewall => {
-            firewall::ensure_firewall(&config.firewall)
+        NetworkRequest::EnsureBridge => {
+            bridge::ensure_bridge(&config.bridge)
                 .await
                 .map_err(|error| HelperFailure::Internal {
                     detail: error_chain(&error),
                 })
         }
+        NetworkRequest::EnsureFirewall => firewall::ensure_firewall(&config.firewall)
+            .await
+            .map_err(|error| HelperFailure::Internal {
+                detail: error_chain(&error),
+            }),
         NetworkRequest::ApplyVmPolicy {
             vm_id,
             ipv4,
@@ -394,9 +436,13 @@ mod tests {
         for _ in 0..2 {
             // DeleteTap answers deterministically without touching netlink,
             // so the framing loop is testable without privileges.
-            let envelope =
-                NetworkRequestEnvelope::new(Uuid::new_v4(), NetworkRequest::DeleteTap { vm_id: Uuid::nil() });
-            write_frame(&mut stream, &envelope).await.expect("send request");
+            let envelope = NetworkRequestEnvelope::new(
+                Uuid::new_v4(),
+                NetworkRequest::DeleteTap { vm_id: Uuid::nil() },
+            );
+            write_frame(&mut stream, &envelope)
+                .await
+                .expect("send request");
             let response: NetworkResponseEnvelope =
                 read_frame(&mut stream).await.expect("receive response");
             assert_eq!(response.version, PROTOCOL_VERSION);
@@ -417,7 +463,9 @@ mod tests {
         let mut envelope =
             NetworkRequestEnvelope::new(Uuid::new_v4(), NetworkRequest::EnsureBridge);
         envelope.version = PROTOCOL_VERSION + 1;
-        write_frame(&mut stream, &envelope).await.expect("send request");
+        write_frame(&mut stream, &envelope)
+            .await
+            .expect("send request");
 
         let response: NetworkResponseEnvelope =
             read_frame(&mut stream).await.expect("receive response");
@@ -429,7 +477,9 @@ mod tests {
         );
 
         assert!(
-            read_frame::<_, NetworkResponseEnvelope>(&mut stream).await.is_err(),
+            read_frame::<_, NetworkResponseEnvelope>(&mut stream)
+                .await
+                .is_err(),
             "connection should be closed after a version rejection"
         );
     }
@@ -440,12 +490,17 @@ mod tests {
         let (path, _stop, _handle) = start_helper(&dir);
 
         let mut stream = UnixStream::connect(&path).await.expect("connect");
-        let oversized = ((firecrab_helper_protocol::framing::MAX_FRAME_BYTES + 1) as u32)
-            .to_be_bytes();
-        stream.write_all(&oversized).await.expect("send length prefix");
+        let oversized =
+            ((firecrab_helper_protocol::framing::MAX_FRAME_BYTES + 1) as u32).to_be_bytes();
+        stream
+            .write_all(&oversized)
+            .await
+            .expect("send length prefix");
 
         assert!(
-            read_frame::<_, NetworkResponseEnvelope>(&mut stream).await.is_err(),
+            read_frame::<_, NetworkResponseEnvelope>(&mut stream)
+                .await
+                .is_err(),
             "helper must drop the connection instead of answering"
         );
     }


### PR DESCRIPTION
Adds /// doc comments across firecrab-api, firecrab-api-types, firecrab-helper-protocol, and firecrab-net-helper (public and private items, since the CI gate uses --document-private-items). Overall coverage goes from 14.2% to 84.1%.

Also runs cargo fmt --all, which reformats three files (console.rs, handlers/console.rs, handlers/vms.rs) that were already unformatted — no content change there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded technical documentation for VM lifecycle states, API errors, networking, firewall behavior, templates, persistence, and helper protocols.
  * Updated Week 3 task tracking, priorities, completion status, and networking scope guidance.

* **Refactor**
  * Improved code formatting and internal organization without changing existing behavior.
  * Clarified network bridge error reporting and handling.

* **Tests**
  * Reformatted and maintained existing unit tests with no changes to expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->