### PR TITLE
feat: automate per-VM TAP lifecycle on start/stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/docs/tests/net-helper-client.py
+++ b/docs/tests/net-helper-client.py
@@ -13,8 +13,23 @@ import struct
 import sys
 import uuid
 
-PATH = sys.argv[1] if len(sys.argv) > 1 else sys.exit("usage: net-helper-client.py <socket-path> [operation]")
+PATH = sys.argv[1] if len(sys.argv) > 1 else sys.exit(
+    "usage: net-helper-client.py <socket-path> [operation] [key=value ...]"
+)
 OPERATION = sys.argv[2] if len(sys.argv) > 2 else "ensure_firewall"
+
+# Operations beyond ensure_bridge/ensure_firewall take extra fields
+# (create_tap/delete_tap need vm_id, apply_vm_policy needs more) — the
+# request is internally tagged on "operation", so these merge in alongside
+# it. Passing a bare UUID with no "vm_id=" prefix is silently dropped by the
+# server as an unparseable request (no vm_id field at all), which looks like
+# a hang/EOF on the client side, not a helpful error — always use key=value.
+EXTRA_FIELDS = {}
+for arg in sys.argv[3:]:
+    key, sep, value = arg.partition("=")
+    if not sep:
+        sys.exit(f"잘못된 인자 {arg!r} — key=value 형식으로 주세요 (예: vm_id=<uuid>)")
+    EXTRA_FIELDS[key] = value
 
 
 def recv_exact(sock, length):
@@ -43,5 +58,9 @@ try:
 except OSError as error:
     sys.exit(f"소켓 연결 실패 ({PATH}): {error} — helper 실행 여부와 경로를 확인하세요")
 
-req = {"version": 1, "request_id": str(uuid.uuid4()), "request": {"operation": OPERATION}}
+req = {
+    "version": 1,
+    "request_id": str(uuid.uuid4()),
+    "request": {"operation": OPERATION, **EXTRA_FIELDS},
+}
 print(call(s, req))

--- a/docs/vm-tap-automation-smoke.md
+++ b/docs/vm-tap-automation-smoke.md
@@ -1,0 +1,107 @@
+# VM별 TAP 자동화 스모크 테스트
+
+## 시퀀스 다이어그램
+
+```mermaid
+sequenceDiagram
+    participant A as firecrab-api
+    participant H as firecrab-net-helper
+    participant K as kernel
+
+    A->>A: create_vm → IPAM lease 할당
+    A->>H: ensure_bridge
+    H->>K: fcbr0 확인/생성
+    A->>H: ensure_firewall
+    H->>K: nftables 테이블 적용
+    A->>H: create_tap(vm_id)
+    H->>K: /dev/net/tun ioctl(TUNSETIFF+PERSIST)
+    H->>K: rtnetlink(alias+master fcbr0+up)
+    A->>H: apply_vm_policy(lease)
+    H->>K: nftables per-VM 정책
+    A->>A: firecracker.json에 TAP 이름 기록 후 spawn
+    Note over K: Firecracker가 TAP open → guest eth0
+
+    A->>H: stop_vm → remove_vm_policy + delete_tap
+    H->>K: TAP 삭제(lease는 유지)
+```
+
+### AWS 비유
+
+| firecrab | AWS 대응 |
+|---|---|
+| Firecracker microVM | EC2 인스턴스 |
+| `fcbr0` 브리지 + `172.30.0.0/24` | VPC 서브넷 |
+| IPAM lease (IP+MAC) | ENI에 할당되는 private IP |
+| TAP 디바이스 | ENI(Elastic Network Interface) |
+| `create_tap` + bridge attach | ENI 생성 + 인스턴스 attach |
+| alias `firecrab:<vm_id>` | ENI attachment 메타데이터(소유 인스턴스 식별) |
+| `apply_vm_policy`(nftables) | ENI에 붙는 Security Group |
+| `stop_vm`: TAP 삭제, lease 유지 | 인스턴스 Stop: private IP 유지, 실연결만 해제 |
+| `start_vm`: 같은 lease로 TAP 재생성 | 인스턴스 Start: 같은 private IP로 재연결 |
+| `delete_vm`: lease 해제 | 인스턴스 Terminate: ENI 삭제, private IP 반납 |
+
+## 자동 테스트 (root 불필요)
+
+```sh
+cargo test -p firecrab-helper-protocol network::
+cargo test -p firecrab-net-helper tap::
+cargo test -p firecrab-net-helper deleting_a_tap
+cargo test -p firecrab-api network::
+cargo test -p firecrab-api ipam:: persistence::
+cargo test -p firecrab-api handlers::vms::
+```
+
+## 확인 항목
+
+- TAP 이름: `vm_id` 결정적, IFNAMSIZ 이내, API·helper 공유 함수로 재계산(임의 이름 불가)
+- ownership alias `firecrab:<vm_uuid>` 포맷 검증
+- `ifreq` 인코딩(NUL 종료, `IFF_TAP|IFF_NO_PI`) 검증
+- 미존재 TAP 삭제 no-op
+- lease 할당(`create_vm`)·해제(`delete_vm`), 실패 시 rollback
+- `setup_vm_network` 성공 경로 — fake net-helper로 전체 lifecycle 확인
+- 중간 실패 시 TAP·policy compensation (Drop 비의존)
+- `stop_vm` 시 teardown(remove_vm_policy+delete_tap), lease는 delete까지 유지
+
+## 수동 확인 (root/CAP_NET_ADMIN 필요)
+
+- 개발 sandbox: 미검증(CAP_NET_ADMIN 없음)
+- 실제 root 환경 검증 완료(2026-07-22): 서로 다른 두 `vm_id` → 다른 TAP 2개, 둘 다 `master fcbr0`, alias 일치, `ifreq` 플래그 반영 확인
+- 미검증: 실패 주입 시 고아 TAP 없음, daemon 재시작 후 orphan 없음, `delete_tap` ownership 재확인
+
+### 터미널 세션 1 — helper 실행
+
+```sh
+cargo build -p firecrab-net-helper
+sudo FIRECRAB_NET_HELPER_SOCK=/tmp/firecrab-net.sock \
+     FIRECRAB_NET_HELPER_ALLOWED_UID="$(id -u)" \
+     ./target/debug/firecrab-net-helper
+```
+
+### 터미널 세션 2 — TAP 생성·조회
+
+- `create_tap`/`delete_tap`은 `vm_id=<uuid>` 형식 필수(맨 uuid만 넘기면 파싱 실패로 무응답 종료)
+- `create_tap` 전 `ensure_bridge` 선행 필요(없으면 `MissingBridge`)
+- `state DOWN`/`NO-CARRIER`는 정상(Firecracker가 열기 전까지)
+
+```sh
+sudo python3 docs/tests/net-helper-client.py /tmp/firecrab-net.sock ensure_bridge
+sudo python3 docs/tests/net-helper-client.py /tmp/firecrab-net.sock create_tap vm_id=<vm-uuid-1>
+sudo python3 docs/tests/net-helper-client.py /tmp/firecrab-net.sock create_tap vm_id=<vm-uuid-2>
+ip link show master fcbr0
+ip -d link show <tap-name-1>
+```
+
+### 완료 기준 대조
+
+- 두 VM이 다른 TAP으로 같은 bridge에 연결 — 확인 완료(2026-07-22)
+- 실패 주입에도 고아 TAP 없음 — 미검증
+- daemon 복구 후 고아 TAP 없음 — 미검증
+
+```sh
+sudo ip link delete <tap-name-1>
+sudo ip link delete <tap-name-2>
+```
+
+## 정리
+
+`Ctrl-C`로 helper 종료 시 socket 제거, TAP은 커널에 남으므로 `ip link delete`로 직접 정리.

--- a/docs/vm-tap-automation-smoke.md
+++ b/docs/vm-tap-automation-smoke.md
@@ -57,16 +57,19 @@ cargo test -p firecrab-api handlers::vms::
 - ownership alias `firecrab:<vm_uuid>` 포맷 검증
 - `ifreq` 인코딩(NUL 종료, `IFF_TAP|IFF_NO_PI`) 검증
 - 미존재 TAP 삭제 no-op
+- `create_tap`도 재사용 전 소유권 확인 — alias 안 맞는 기존 링크는 거부(덮어쓰기 안 함)
 - lease 할당(`create_vm`)·해제(`delete_vm`), 실패 시 rollback
 - `setup_vm_network` 성공 경로 — fake net-helper로 전체 lifecycle 확인
-- 중간 실패 시 TAP·policy compensation (Drop 비의존)
+- `apply_vm_policy` 실패 시 `remove_vm_policy`+`delete_tap` 순서로 호출됨을 call-sequence 테스트로 확인
+- 중간 실패 시 새로 만든 TAP도 compensation으로 삭제 (Drop 비의존)
 - `stop_vm` 시 teardown(remove_vm_policy+delete_tap), lease는 delete까지 유지
+- 게스트 자체 종료(poweroff)·프로세스 kill로 인한 종료도 exit monitor가 teardown 호출(이전엔 `stop_vm` 경유 종료만 정리됨)
 
 ## 수동 확인 (root/CAP_NET_ADMIN 필요)
 
-- 개발 sandbox: 미검증(CAP_NET_ADMIN 없음)
+- 개발 sandbox: 미검증(CAP_NET_ADMIN 없음) — `create_tap`의 소유권 선확인·실패 시 신규 디바이스 삭제 로직도 포함
 - 실제 root 환경 검증 완료(2026-07-22): 서로 다른 두 `vm_id` → 다른 TAP 2개, 둘 다 `master fcbr0`, alias 일치, `ifreq` 플래그 반영 확인
-- 미검증: 실패 주입 시 고아 TAP 없음, daemon 재시작 후 orphan 없음, `delete_tap` ownership 재확인
+- 미검증: 이름 충돌(다른 소유자) 시 거부, 실패 주입 시 고아 TAP 없음, daemon 재시작 후 orphan 없음, `delete_tap` ownership 재확인
 
 ### 터미널 세션 1 — helper 실행
 

--- a/firecrab-api/src/firecracker.rs
+++ b/firecrab-api/src/firecracker.rs
@@ -382,6 +382,10 @@ pub fn register_and_watch(state: &AppState, id: Uuid, process: FirecrackerProces
                 state = ?record.state,
                 "vm process exited"
             );
+            // Only stop_vm's own SIGTERM path tears the network down today;
+            // a guest-initiated poweroff or an external kill lands here
+            // instead and would otherwise leave the TAP/policy orphaned.
+            crate::handlers::vms::teardown_vm_network(&state, id).await;
             let store = state.store.clone();
             match tokio::task::spawn_blocking(move || store.update(&record)).await {
                 Ok(Ok(())) => {}

--- a/firecrab-api/src/firecracker.rs
+++ b/firecrab-api/src/firecracker.rs
@@ -19,7 +19,7 @@ use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::console::ConsoleBroker;
-use crate::model::{VmRecord, VmState};
+use crate::model::{MacAddr, VmRecord, VmState};
 use crate::rootfs;
 use crate::state::AppState;
 
@@ -114,6 +114,9 @@ pub struct FirecrackerConfig {
     boot_source: BootSource,
     /// Block devices, always exactly the one root drive today.
     drives: Vec<Drive>,
+    /// The VM's TAP interface, absent until TAP automation assigns one.
+    #[serde(rename = "network-interfaces", skip_serializing_if = "Vec::is_empty")]
+    network_interfaces: Vec<NetworkInterface>,
     /// vCPU/memory sizing.
     #[serde(rename = "machine-config")]
     machine_config: MachineConfig,
@@ -150,13 +153,36 @@ struct MachineConfig {
     mem_size_mib: u32,
 }
 
+/// One entry in [`FirecrackerConfig`]'s `network-interfaces` list.
+#[derive(Debug, Serialize)]
+struct NetworkInterface {
+    /// Firecracker-side interface identifier.
+    iface_id: String,
+    /// MAC address presented to the guest.
+    guest_mac: String,
+    /// Host-side TAP device name this interface is backed by.
+    host_dev_name: String,
+}
+
+/// The VM's TAP attachment: its host TAP device name (from
+/// [`crate::network::tap_name`]) and the guest MAC its IPAM lease pins.
+#[derive(Debug, Clone)]
+pub struct VmNetwork {
+    /// Host-side TAP device name.
+    pub tap_name: String,
+    /// MAC address the guest's `eth0` presents.
+    pub guest_mac: MacAddr,
+}
+
 impl FirecrackerConfig {
-    /// Builds the config for `vm`'s single root drive at `rootfs_path`.
+    /// Builds the config for `vm`'s single root drive at `rootfs_path`, and
+    /// its network interface if TAP automation has attached one.
     pub fn for_vm(
         vm: &VmRecord,
         kernel_image_path: &Path,
         boot_args: &str,
         rootfs_path: &Path,
+        network: Option<&VmNetwork>,
     ) -> Self {
         Self {
             boot_source: BootSource {
@@ -169,6 +195,15 @@ impl FirecrackerConfig {
                 is_root_device: true,
                 is_read_only: false,
             }],
+            network_interfaces: network
+                .map(|network| {
+                    vec![NetworkInterface {
+                        iface_id: "eth0".to_owned(),
+                        guest_mac: network.guest_mac.to_string(),
+                        host_dev_name: network.tap_name.clone(),
+                    }]
+                })
+                .unwrap_or_default(),
             machine_config: MachineConfig {
                 vcpu_count: vm.cpu,
                 mem_size_mib: vm.ram,
@@ -185,6 +220,7 @@ pub fn write_config(
     vm: &VmRecord,
     kernel_image_path: &Path,
     boot_args: &str,
+    network: Option<&VmNetwork>,
 ) -> Result<PathBuf, FirecrackerError> {
     let vm_dir = vms_dir.join(vm.id.to_string());
     fs::create_dir_all(&vm_dir).map_err(|source| FirecrackerError::CreateDirectory {
@@ -198,6 +234,7 @@ pub fn write_config(
         kernel_image_path,
         boot_args,
         &rootfs::rootfs_path(vms_dir, vm.id),
+        network,
     );
     let json =
         serde_json::to_vec_pretty(&config).map_err(|source| FirecrackerError::Serialize {
@@ -629,8 +666,14 @@ mod tests {
         let vms_dir = directory.path().join("vms");
         let vm = record(3, 768);
 
-        let path =
-            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
+        let path = write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
 
         assert_eq!(
             path,
@@ -647,8 +690,14 @@ mod tests {
         let vms_dir = directory.path().join("vms");
         let vm = record(1, 512);
 
-        let path =
-            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
+        let path = write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
 
         let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(
@@ -673,11 +722,24 @@ mod tests {
         let vms_dir = directory.path().join("vms");
         let mut vm = record(1, 512);
 
-        write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
+        write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
         vm.cpu = 2;
         vm.ram = 1024;
-        let path =
-            write_config(&vms_dir, &vm, Path::new("/images/vmlinux"), "console=ttyS0").unwrap();
+        let path = write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
 
         let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
         assert_eq!(config["machine-config"]["vcpu_count"], 2);

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -10,8 +10,10 @@ use uuid::Uuid;
 
 use crate::error::AppError;
 use crate::extract::ValidatedJson;
-use crate::firecracker::{self, FirecrackerProcess, VmProcess};
+use crate::firecracker::{self, FirecrackerProcess, VmNetwork, VmProcess};
+use crate::ipam::IpamError;
 use crate::model::{CreateVmRequest, StartupStep, UpdateVmResourcesRequest, VmRecord, VmState};
+use crate::network_policy::EgressPolicy;
 use crate::persistence::PersistenceError;
 use crate::rootfs;
 use crate::server::RequestId;
@@ -134,6 +136,22 @@ pub async fn create_vm(
             tracing::error!(request_id = %request_id.0, %error, "failed to persist VM state");
             AppError::internal(request_id.0)
         })?;
+
+    // Allocated up front (not on first start) so it persists across every
+    // stop/start of this VM and is only ever freed by a successful delete —
+    // see Store::active_lease's doc comment.
+    let store = state.store.clone();
+    let vm_id = vm.id;
+    if let Err(error) = tokio::task::spawn_blocking(move || store.allocate_lease(vm_id))
+        .await
+        .map_err(|_| AppError::internal(request_id.0))?
+    {
+        tracing::error!(request_id = %request_id.0, vm_id = %vm_id, %error, "failed to allocate vm lease");
+        let store = state.store.clone();
+        let _ = tokio::task::spawn_blocking(move || store.delete(vm_id)).await;
+        return Err(AppError::internal(request_id.0));
+    }
+
     tracing::info!(
         request_id = %request_id.0,
         vm_id = %vm.id,
@@ -355,6 +373,12 @@ pub async fn stop_vm(
         }
     }
 
+    // Only a running VM can reach Stopping (see VmState::can_transition), so
+    // setup_vm_network always ran for it — tear its TAP/policy back down.
+    // The underlying lease is untouched; it's freed only by a successful
+    // delete, so a later start reuses the same IP/MAC.
+    teardown_vm_network(&state, id).await;
+
     // The exit monitor normally lands the record on stopped; cover the
     // process-less and raced cases by finishing the transition ourselves.
     let stopped = {
@@ -408,7 +432,15 @@ pub async fn delete_vm(
             }
         }
         match store.delete(id) {
-            Ok(()) | Err(PersistenceError::MissingVm { .. }) => Ok(()),
+            Ok(()) | Err(PersistenceError::MissingVm { .. }) => {}
+            Err(error) => return Err(error.to_string()),
+        }
+        // Only ever freed here, after everything else about the VM is gone
+        // — see Store::active_lease's doc comment. NotLeased shouldn't
+        // happen (every VM gets one at create_vm), but isn't worth failing
+        // an otherwise-successful delete over.
+        match store.release_lease(id) {
+            Ok(()) | Err(IpamError::NotLeased { .. }) => Ok(()),
             Err(error) => Err(error.to_string()),
         }
     })
@@ -520,6 +552,24 @@ async fn run_start(state: &AppState, vm: &VmRecord) -> Result<FirecrackerProcess
 
     set_startup_step(state, vm.id, StartupStep::PreparingDisk);
 
+    // Set up before the disk copy so a network failure fails fast, without
+    // paying for a multi-GB copy first. Any failure *after* this succeeds
+    // must tear the TAP + policy back down — see the loop below.
+    let network = setup_vm_network(state, vm.id).await?;
+
+    let result = finish_run_start(state, vm, template, &network).await;
+    if result.is_err() {
+        teardown_vm_network(state, vm.id).await;
+    }
+    result
+}
+
+async fn finish_run_start(
+    state: &AppState,
+    vm: &VmRecord,
+    template: std::sync::Arc<crate::templates::TemplateVersion>,
+    network: &VmNetwork,
+) -> Result<FirecrackerProcess, String> {
     // Bounds how many VMs copy/grow a rootfs disk at once — see
     // `DISK_PREP_CONCURRENCY`'s doc comment. Held across the blocking task
     // below, released once that VM's disk+config are ready.
@@ -534,6 +584,7 @@ async fn run_start(state: &AppState, vm: &VmRecord) -> Result<FirecrackerProcess
     let runtime = state.runtime.clone();
     let record = vm.clone();
     let state_for_blocking = state.clone();
+    let network = network.clone();
     let config_path = tokio::task::spawn_blocking(move || -> Result<PathBuf, String> {
         let _permit = permit;
         let mut source = templates
@@ -549,8 +600,14 @@ async fn run_start(state: &AppState, vm: &VmRecord) -> Result<FirecrackerProcess
             StartupStep::GeneratingConfig,
         );
         let kernel = templates.artifact_path(&template.kernel);
-        firecracker::write_config(&runtime.vms_dir, &record, &kernel, &template.boot_args)
-            .map_err(|error| format!("config generation failed: {error}"))
+        firecracker::write_config(
+            &runtime.vms_dir,
+            &record,
+            &kernel,
+            &template.boot_args,
+            Some(&network),
+        )
+        .map_err(|error| format!("config generation failed: {error}"))
     })
     .await
     .map_err(|error| format!("start preparation task failed: {error}"))??;
@@ -566,6 +623,64 @@ async fn run_start(state: &AppState, vm: &VmRecord) -> Result<FirecrackerProcess
     )
     .await
     .map_err(|error| error.to_string())
+}
+
+/// Ensures the bridge/firewall are up, creates `vm_id`'s TAP, and applies its
+/// isolation policy for its (already-allocated, see `create_vm`) lease. Any
+/// failure after the TAP is created tears the TAP itself back down before
+/// returning, so a partial failure here never leaves an unprotected TAP
+/// attached to the bridge.
+async fn setup_vm_network(state: &AppState, vm_id: Uuid) -> Result<VmNetwork, String> {
+    let store = state.store.clone();
+    let lease = tokio::task::spawn_blocking(move || store.active_lease(vm_id))
+        .await
+        .map_err(|error| format!("lease lookup task failed: {error}"))?
+        .map_err(|error| format!("lease lookup failed: {error}"))?
+        .ok_or_else(|| format!("vm {vm_id} has no allocated lease"))?;
+
+    state
+        .network
+        .ensure_bridge()
+        .await
+        .map_err(|error| format!("ensure_bridge failed: {error}"))?;
+    state
+        .network
+        .ensure_firewall()
+        .await
+        .map_err(|error| format!("ensure_firewall failed: {error}"))?;
+
+    let tap_name = state
+        .network
+        .create_tap(vm_id)
+        .await
+        .map_err(|error| format!("tap creation failed: {error}"))?;
+
+    if let Err(error) = state
+        .network
+        .apply_vm_policy(vm_id, lease.ipv4, lease.mac, EgressPolicy::default(), false)
+        .await
+    {
+        let _ = state.network.delete_tap(vm_id).await;
+        return Err(format!("firewall policy application failed: {error}"));
+    }
+
+    Ok(VmNetwork {
+        tap_name,
+        guest_mac: lease.mac,
+    })
+}
+
+/// Reverses [`setup_vm_network`]: removes the firewall policy then the TAP.
+/// Best-effort and always called from an already-failing or already-stopping
+/// path, so failures here are logged rather than propagated — the VM's own
+/// lifecycle state still needs to move forward either way.
+async fn teardown_vm_network(state: &AppState, vm_id: Uuid) {
+    if let Err(error) = state.network.remove_vm_policy(vm_id).await {
+        tracing::warn!(vm_id = %vm_id, %error, "failed to remove vm firewall policy");
+    }
+    if let Err(error) = state.network.delete_tap(vm_id).await {
+        tracing::warn!(vm_id = %vm_id, %error, "failed to delete vm tap device");
+    }
 }
 
 /// Records the current phase of an in-flight start so pollers can show *why*
@@ -812,6 +927,12 @@ mod tests {
             }],
         )
         .unwrap();
+        // Unique per call (not just per `root`): some tests reopen state
+        // against the same directory to simulate a restart, and a stale
+        // listener would still hold the previous socket path.
+        let socket_path = root.join(format!("net-helper-{}.sock", Uuid::new_v4()));
+        crate::network::test_support::spawn_always_ok_helper(&socket_path);
+
         AppState::with_db_file(templates, root.join("data/firecrab.db"))
             .await
             .unwrap()
@@ -821,11 +942,13 @@ mod tests {
                 ready_timeout: Duration::from_secs(5),
                 stop_grace: Duration::from_millis(500),
             })
+            .with_test_network(crate::network::NetworkClient::with_socket_path(socket_path))
     }
 
     fn seed_vm(state: &AppState, vm: &VmRecord) {
         state.store.insert(vm).unwrap();
         state.vms.lock().unwrap().insert(vm.id, vm.clone());
+        state.store.allocate_lease(vm.id).unwrap();
     }
 
     fn memory_state(state: &AppState, id: Uuid) -> Option<VmState> {

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -660,6 +660,12 @@ async fn setup_vm_network(state: &AppState, vm_id: Uuid) -> Result<VmNetwork, St
         .apply_vm_policy(vm_id, lease.ipv4, lease.mac, EgressPolicy::default(), false)
         .await
     {
+        // A failed apply_vm_policy leaves nothing installed (nft applies a
+        // ruleset as one atomic transaction), so remove_vm_policy is a
+        // guaranteed no-op today — called anyway so cleanup here doesn't
+        // silently rely on that nft implementation detail staying true, and
+        // so this matches teardown_vm_network's own order everywhere else.
+        let _ = state.network.remove_vm_policy(vm_id).await;
         let _ = state.network.delete_tap(vm_id).await;
         return Err(format!("firewall policy application failed: {error}"));
     }
@@ -673,8 +679,11 @@ async fn setup_vm_network(state: &AppState, vm_id: Uuid) -> Result<VmNetwork, St
 /// Reverses [`setup_vm_network`]: removes the firewall policy then the TAP.
 /// Best-effort and always called from an already-failing or already-stopping
 /// path, so failures here are logged rather than propagated — the VM's own
-/// lifecycle state still needs to move forward either way.
-async fn teardown_vm_network(state: &AppState, vm_id: Uuid) {
+/// lifecycle state still needs to move forward either way. `pub(crate)` so
+/// the exit monitor (`firecracker::register_and_watch`) can call it too —
+/// a guest-initiated poweroff or crash never goes through `stop_vm`, so it
+/// has to run from there instead.
+pub(crate) async fn teardown_vm_network(state: &AppState, vm_id: Uuid) {
     if let Err(error) = state.network.remove_vm_policy(vm_id).await {
         tracing::warn!(vm_id = %vm_id, %error, "failed to remove vm firewall policy");
     }
@@ -1181,6 +1190,64 @@ mod tests {
         assert!(state.processes.lock().unwrap().is_empty());
     }
 
+    async fn stop_tolerates_a_failed_teardown_step(fail_operation: &'static str) {
+        let directory = short_tempdir();
+        let root = directory.path();
+        let binary = fake_firecracker(
+            root,
+            &format!("signal.signal(signal.SIGTERM, lambda *_: sys.exit(0)){SERVE_LOOP}"),
+        );
+        let state = test_state_with_binary(root, binary).await;
+
+        let socket_path = root.join("net-helper-teardown-fail.sock");
+        let (_helper, log) = crate::network::test_support::spawn_recording_helper(
+            &socket_path,
+            Some(fail_operation),
+        );
+        let state =
+            state.with_test_network(crate::network::NetworkClient::with_socket_path(socket_path));
+
+        let vm = record("teardown-partial-fail", Uuid::new_v4());
+        seed_vm(&state, &vm);
+
+        start_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap();
+
+        let Json(stopped) = stop_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stopped.state,
+            VmState::Stopped,
+            "a failed {fail_operation} must not block landing on stopped"
+        );
+        let calls = log.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"remove_vm_policy") && calls.contains(&"delete_tap"),
+            "both teardown steps must still run even when {fail_operation} fails, got {calls:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_vm_tolerates_a_failed_remove_vm_policy() {
+        stop_tolerates_a_failed_teardown_step("remove_vm_policy").await;
+    }
+
+    #[tokio::test]
+    async fn stop_vm_tolerates_a_failed_delete_tap() {
+        stop_tolerates_a_failed_teardown_step("delete_tap").await;
+    }
+
     #[tokio::test]
     async fn start_rejects_disallowed_states_with_conflict() {
         let directory = tempdir().unwrap();
@@ -1244,6 +1311,52 @@ mod tests {
             "a failed start must not leave a stale startup step behind"
         );
         assert!(state.processes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn apply_vm_policy_failure_still_removes_policy_and_tap() {
+        let directory = short_tempdir();
+        let root = directory.path();
+        let state = test_state(root).await;
+
+        let socket_path = root.join("net-helper-fail.sock");
+        let (_helper, log) = crate::network::test_support::spawn_recording_helper(
+            &socket_path,
+            Some("apply_vm_policy"),
+        );
+        let state =
+            state.with_test_network(crate::network::NetworkClient::with_socket_path(socket_path));
+
+        let vm = record("policy-fail", Uuid::new_v4());
+        seed_vm(&state, &vm);
+
+        let error = start_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(
+            error.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(db_state(&state, vm.id), Some(VmState::Error));
+
+        let calls = log.lock().unwrap().clone();
+        let apply_at = calls
+            .iter()
+            .position(|&op| op == "apply_vm_policy")
+            .expect("apply_vm_policy must have been called");
+        assert!(
+            calls[apply_at + 1..].contains(&"remove_vm_policy"),
+            "expected remove_vm_policy after a failed apply_vm_policy, got {calls:?}"
+        );
+        assert!(
+            calls[apply_at + 1..].contains(&"delete_tap"),
+            "expected delete_tap after a failed apply_vm_policy, got {calls:?}"
+        );
     }
 
     #[tokio::test]
@@ -1367,6 +1480,16 @@ mod tests {
         let root = directory.path();
         let binary = fake_firecracker(root, SERVE_LOOP);
         let state = test_state_with_binary(root, binary).await;
+
+        // Swap in a recording helper so this test can confirm the exit
+        // monitor (not stop_vm) is the one tearing the network down when
+        // the process dies without ever going through the stop API.
+        let socket_path = root.join("net-helper-recording.sock");
+        let (_helper, log) =
+            crate::network::test_support::spawn_recording_helper(&socket_path, None);
+        let state =
+            state.with_test_network(crate::network::NetworkClient::with_socket_path(socket_path));
+
         let vm = record("crashy", Uuid::new_v4());
         seed_vm(&state, &vm);
 
@@ -1384,6 +1507,16 @@ mod tests {
         wait_for_state(&state, vm.id, VmState::Error).await;
         assert_eq!(db_state(&state, vm.id), Some(VmState::Error));
         assert!(state.processes.lock().unwrap().is_empty());
+
+        let calls = log.lock().unwrap().clone();
+        assert!(
+            calls.contains(&"remove_vm_policy"),
+            "exit monitor must tear down the firewall policy on an unclean exit, got {calls:?}"
+        );
+        assert!(
+            calls.contains(&"delete_tap"),
+            "exit monitor must delete the TAP on an unclean exit, got {calls:?}"
+        );
     }
 
     #[tokio::test]
@@ -1408,22 +1541,72 @@ mod tests {
         let state = test_state(directory.path()).await;
         state.store.break_for_tests();
 
-        let request = CreateVmRequest {
-            name: "test-vm".to_owned(),
-            template: "ubuntu-rootfs-26.04".to_owned(),
-            ram: 512,
-            cpu: 1,
-            disk_gb: 2,
-        };
         let result = create_vm(
             State(state.clone()),
             Extension(RequestId(Uuid::new_v4())),
-            ValidatedJson(request),
+            ValidatedJson(create_request("test-vm")),
         )
         .await;
 
         assert!(result.is_err());
         assert!(state.vms.lock().unwrap().is_empty());
+    }
+
+    fn create_request(name: &str) -> CreateVmRequest {
+        CreateVmRequest {
+            name: name.to_owned(),
+            template: "ubuntu-rootfs-26.04".to_owned(),
+            ram: 512,
+            cpu: 1,
+            disk_gb: 2,
+        }
+    }
+
+    #[tokio::test]
+    async fn create_vm_succeeds_and_allocates_a_lease() {
+        let directory = tempdir().unwrap();
+        let state = test_state(directory.path()).await;
+
+        let (status, Json(created)) = create_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            ValidatedJson(create_request("fresh-vm")),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert!(state.vms.lock().unwrap().contains_key(&created.id));
+        assert!(
+            state.store.active_lease(created.id).unwrap().is_some(),
+            "create_vm must allocate a lease up front, not on first start"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_vm_rolls_back_the_record_when_lease_allocation_fails() {
+        let directory = tempdir().unwrap();
+        let state = test_state(directory.path()).await;
+
+        // Exhaust the 253-address pool so the lease allocation inside
+        // create_vm fails after the VM record has already been inserted.
+        for _ in 0..253 {
+            state.store.allocate_lease(Uuid::new_v4()).unwrap();
+        }
+
+        let result = create_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            ValidatedJson(create_request("doomed-vm")),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            state.vms.lock().unwrap().is_empty(),
+            "a failed lease allocation must roll back the just-inserted VM record"
+        );
+        assert!(state.store.load_all().unwrap().is_empty());
     }
 
     fn update_request(cpu: u8, ram: u32, disk_gb: u16) -> UpdateVmResourcesRequest {

--- a/firecrab-api/src/ipam.rs
+++ b/firecrab-api/src/ipam.rs
@@ -247,6 +247,26 @@ mod tests {
     }
 
     #[test]
+    fn active_lease_reports_a_corrupt_stored_ipv4() {
+        let mut conn = open();
+        let vm_id = Uuid::new_v4();
+        let tx = begin(&mut conn);
+        allocate(&tx, vm_id).unwrap();
+        tx.commit().unwrap();
+
+        conn.execute(
+            "UPDATE network_leases SET ipv4 = 'not-an-ip' WHERE vm_id = ?1",
+            params![vm_id.to_string()],
+        )
+        .unwrap();
+
+        assert!(matches!(
+            active_lease(&conn, vm_id),
+            Err(IpamError::CorruptLease { .. })
+        ));
+    }
+
+    #[test]
     fn pool_exhaustion_is_reported_once_all_253_hosts_are_leased() {
         let mut conn = open();
         for _ in 0..253 {

--- a/firecrab-api/src/ipam.rs
+++ b/firecrab-api/src/ipam.rs
@@ -67,6 +67,16 @@ pub enum IpamError {
         /// The VM with no active lease.
         vm_id: Uuid,
     },
+    /// A lease row's stored ipv4/mac text didn't parse — the schema only
+    /// ever accepts values this module itself wrote, so this means the
+    /// database was altered out from under it.
+    #[error("vm {vm_id}'s stored lease is corrupt: {reason}")]
+    CorruptLease {
+        /// The VM whose lease row is corrupt.
+        vm_id: Uuid,
+        /// Human-readable reason.
+        reason: String,
+    },
 }
 
 /// Allocate an IPv4 + MAC for `vm_id`. Must run inside a `BEGIN IMMEDIATE`
@@ -112,6 +122,30 @@ pub fn release(tx: &Transaction<'_>, vm_id: Uuid) -> Result<(), IpamError> {
         return Err(IpamError::NotLeased { vm_id });
     }
     Ok(())
+}
+
+/// Looks up `vm_id`'s current active lease, if it has one. Unlike
+/// [`allocate`]/[`release`], this is a plain read with no need for a
+/// `BEGIN IMMEDIATE` transaction.
+pub fn active_lease(conn: &rusqlite::Connection, vm_id: Uuid) -> Result<Option<Lease>, IpamError> {
+    conn.query_row(
+        "SELECT ipv4, mac FROM network_leases WHERE vm_id = ?1 AND released_at IS NULL",
+        params![vm_id.to_string()],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+    )
+    .optional()?
+    .map(|(ipv4, mac)| {
+        let ipv4 = ipv4.parse().map_err(|_| IpamError::CorruptLease {
+            vm_id,
+            reason: format!("stored ipv4 {ipv4:?} does not parse"),
+        })?;
+        let mac = mac.parse().map_err(|_| IpamError::CorruptLease {
+            vm_id,
+            reason: format!("stored mac {mac:?} does not parse"),
+        })?;
+        Ok(Lease { vm_id, ipv4, mac })
+    })
+    .transpose()
 }
 
 /// Whether `vm_id` currently holds an unreleased lease.

--- a/firecrab-api/src/main.rs
+++ b/firecrab-api/src/main.rs
@@ -5,6 +5,7 @@ mod firecracker;
 mod handlers;
 mod ipam;
 mod model;
+mod network;
 mod network_policy;
 mod persistence;
 mod rootfs;

--- a/firecrab-api/src/network.rs
+++ b/firecrab-api/src/network.rs
@@ -1,0 +1,304 @@
+use std::env;
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use firecrab_helper_protocol::framing::{FrameError, read_frame, write_frame};
+pub use firecrab_helper_protocol::network::tap_name;
+use firecrab_helper_protocol::network::{
+    HelperFailure, MacAddr, NetworkRequest, NetworkRequestEnvelope, NetworkResponseEnvelope,
+};
+use thiserror::Error;
+use tokio::net::UnixStream;
+use uuid::Uuid;
+
+use crate::network_policy::EgressPolicy;
+
+pub const DEFAULT_HELPER_SOCKET: &str = "/run/firecrab/net-helper.sock";
+const HELPER_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Error)]
+pub enum NetworkError {
+    #[error("network helper is unavailable at {path}")]
+    Unavailable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("network helper did not answer in time")]
+    Timeout,
+    #[error("network helper connection failed")]
+    Frame(#[from] FrameError),
+    #[error("network helper answered for a different request")]
+    MismatchedResponse,
+    #[error("network helper rejected the request")]
+    Helper(#[source] HelperFailure),
+}
+
+/// Client for the privileged firecrab-net-helper; one connection per call.
+#[derive(Debug, Clone)]
+pub struct NetworkClient {
+    socket_path: PathBuf,
+    timeout: Duration,
+}
+
+impl NetworkClient {
+    pub fn from_env() -> Self {
+        let socket_path = env::var("FIRECRAB_NET_HELPER_SOCK")
+            .map_or_else(|_| PathBuf::from(DEFAULT_HELPER_SOCKET), PathBuf::from);
+        Self {
+            socket_path,
+            timeout: HELPER_TIMEOUT,
+        }
+    }
+
+    pub async fn call(&self, request: NetworkRequest) -> Result<(), NetworkError> {
+        tokio::time::timeout(self.timeout, self.exchange(request))
+            .await
+            .map_err(|_| NetworkError::Timeout)?
+    }
+
+    /// Idempotently ensures the shared bridge exists.
+    pub async fn ensure_bridge(&self) -> Result<(), NetworkError> {
+        self.call(NetworkRequest::EnsureBridge).await
+    }
+
+    /// Idempotently (re)applies the owned nftables tables.
+    pub async fn ensure_firewall(&self) -> Result<(), NetworkError> {
+        self.call(NetworkRequest::EnsureFirewall).await
+    }
+
+    /// Creates `vm_id`'s TAP device, attaches it to the bridge, and returns
+    /// its deterministic name (also derivable locally via [`tap_name`], so
+    /// callers that already know it don't have to wait on this to build a
+    /// Firecracker config referencing it).
+    pub async fn create_tap(&self, vm_id: Uuid) -> Result<String, NetworkError> {
+        self.call(NetworkRequest::CreateTap { vm_id }).await?;
+        Ok(tap_name(vm_id))
+    }
+
+    /// Removes `vm_id`'s TAP device; a no-op if it's already gone.
+    pub async fn delete_tap(&self, vm_id: Uuid) -> Result<(), NetworkError> {
+        self.call(NetworkRequest::DeleteTap { vm_id }).await
+    }
+
+    /// Applies `vm_id`'s isolation + egress firewall policy for its lease.
+    pub async fn apply_vm_policy(
+        &self,
+        vm_id: Uuid,
+        ipv4: Ipv4Addr,
+        mac: MacAddr,
+        egress_policy: EgressPolicy,
+        allow_host_ssh: bool,
+    ) -> Result<(), NetworkError> {
+        self.call(NetworkRequest::ApplyVmPolicy {
+            vm_id,
+            ipv4,
+            mac,
+            egress_policy: egress_policy.id().to_owned(),
+            allow_host_ssh,
+        })
+        .await
+    }
+
+    /// Removes `vm_id`'s firewall policy; a no-op if none is installed.
+    pub async fn remove_vm_policy(&self, vm_id: Uuid) -> Result<(), NetworkError> {
+        self.call(NetworkRequest::RemoveVmPolicy { vm_id }).await
+    }
+
+    /// Builds a client pointed at an explicit socket path, for lifecycle
+    /// tests that spin up a fake net-helper (see `test_support`).
+    #[cfg(test)]
+    pub(crate) fn with_socket_path(socket_path: PathBuf) -> Self {
+        Self {
+            socket_path,
+            timeout: HELPER_TIMEOUT,
+        }
+    }
+
+    async fn exchange(&self, request: NetworkRequest) -> Result<(), NetworkError> {
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|source| NetworkError::Unavailable {
+                path: self.socket_path.clone(),
+                source,
+            })?;
+
+        let envelope = NetworkRequestEnvelope::new(Uuid::new_v4(), request);
+        write_frame(&mut stream, &envelope).await?;
+
+        let response: NetworkResponseEnvelope = read_frame(&mut stream).await?;
+        if response.request_id != envelope.request_id {
+            return Err(NetworkError::MismatchedResponse);
+        }
+        response.result.map_err(NetworkError::Helper)
+    }
+}
+
+/// Test-only stand-in for the privileged net-helper daemon, for lifecycle
+/// tests elsewhere in the crate that need `NetworkClient` calls to succeed
+/// without a real (privileged) helper process.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::path::Path;
+
+    use firecrab_helper_protocol::PROTOCOL_VERSION;
+    use tokio::net::UnixListener;
+
+    use super::*;
+
+    /// Spawns a fake net-helper bound to `socket_path` that answers every
+    /// request with `Ok(())`, looping until the returned task is dropped —
+    /// tied to the test's own tokio runtime, so it needs no explicit
+    /// shutdown.
+    pub fn spawn_always_ok_helper(socket_path: &Path) -> tokio::task::JoinHandle<()> {
+        let listener = UnixListener::bind(socket_path).expect("bind fake net-helper socket");
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(serve_always_ok(stream));
+            }
+        })
+    }
+
+    async fn serve_always_ok(mut stream: UnixStream) {
+        loop {
+            let envelope: NetworkRequestEnvelope = match read_frame(&mut stream).await {
+                Ok(envelope) => envelope,
+                Err(_) => return,
+            };
+            let response = NetworkResponseEnvelope {
+                version: PROTOCOL_VERSION,
+                request_id: envelope.request_id,
+                result: Ok(()),
+            };
+            if write_frame(&mut stream, &response).await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+
+    use firecrab_helper_protocol::PROTOCOL_VERSION;
+    use tokio::net::UnixListener;
+
+    // Unix socket paths are limited to ~108 bytes; keep test sockets short.
+    fn short_tempdir() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("fc-net")
+            .tempdir_in("/tmp")
+            .expect("create tempdir")
+    }
+
+    fn client(path: &Path, timeout: Duration) -> NetworkClient {
+        NetworkClient {
+            socket_path: path.to_owned(),
+            timeout,
+        }
+    }
+
+    fn fake_helper(
+        listener: UnixListener,
+        respond: impl FnOnce(NetworkRequestEnvelope) -> NetworkResponseEnvelope + Send + 'static,
+    ) {
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            let envelope: NetworkRequestEnvelope =
+                read_frame(&mut stream).await.expect("read request");
+            write_frame(&mut stream, &respond(envelope))
+                .await
+                .expect("write response");
+        });
+    }
+
+    #[tokio::test]
+    async fn call_round_trips_a_successful_response() {
+        let dir = short_tempdir();
+        let path = dir.path().join("helper.sock");
+        let listener = UnixListener::bind(&path).expect("bind");
+        fake_helper(listener, |envelope| NetworkResponseEnvelope {
+            version: PROTOCOL_VERSION,
+            request_id: envelope.request_id,
+            result: Ok(()),
+        });
+
+        let result = client(&path, HELPER_TIMEOUT)
+            .call(NetworkRequest::EnsureBridge)
+            .await;
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    #[tokio::test]
+    async fn helper_failures_surface_as_helper_errors() {
+        let dir = short_tempdir();
+        let path = dir.path().join("helper.sock");
+        let listener = UnixListener::bind(&path).expect("bind");
+        fake_helper(listener, |envelope| NetworkResponseEnvelope {
+            version: PROTOCOL_VERSION,
+            request_id: envelope.request_id,
+            result: Err(HelperFailure::UnsupportedOperation),
+        });
+
+        let result = client(&path, HELPER_TIMEOUT)
+            .call(NetworkRequest::EnsureFirewall)
+            .await;
+        assert!(matches!(
+            result,
+            Err(NetworkError::Helper(HelperFailure::UnsupportedOperation))
+        ));
+    }
+
+    #[tokio::test]
+    async fn responses_for_other_requests_are_rejected() {
+        let dir = short_tempdir();
+        let path = dir.path().join("helper.sock");
+        let listener = UnixListener::bind(&path).expect("bind");
+        fake_helper(listener, |_| NetworkResponseEnvelope {
+            version: PROTOCOL_VERSION,
+            request_id: Uuid::new_v4(),
+            result: Ok(()),
+        });
+
+        let result = client(&path, HELPER_TIMEOUT)
+            .call(NetworkRequest::EnsureBridge)
+            .await;
+        assert!(matches!(result, Err(NetworkError::MismatchedResponse)));
+    }
+
+    #[tokio::test]
+    async fn missing_socket_reports_unavailable() {
+        let dir = short_tempdir();
+        let path = dir.path().join("absent.sock");
+
+        let result = client(&path, HELPER_TIMEOUT)
+            .call(NetworkRequest::EnsureBridge)
+            .await;
+        assert!(matches!(result, Err(NetworkError::Unavailable { .. })));
+    }
+
+    #[tokio::test]
+    async fn unresponsive_helper_times_out() {
+        let dir = short_tempdir();
+        let path = dir.path().join("helper.sock");
+        let listener = UnixListener::bind(&path).expect("bind");
+        tokio::spawn(async move {
+            // Accept and hold the connection without ever answering.
+            let (stream, _) = listener.accept().await.expect("accept");
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            drop(stream);
+        });
+
+        let result = client(&path, Duration::from_millis(100))
+            .call(NetworkRequest::EnsureBridge)
+            .await;
+        assert!(matches!(result, Err(NetworkError::Timeout)));
+    }
+}

--- a/firecrab-api/src/network.rs
+++ b/firecrab-api/src/network.rs
@@ -141,6 +141,7 @@ impl NetworkClient {
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
 
     use firecrab_helper_protocol::PROTOCOL_VERSION;
     use tokio::net::UnixListener;
@@ -173,6 +174,77 @@ pub(crate) mod test_support {
                 version: PROTOCOL_VERSION,
                 request_id: envelope.request_id,
                 result: Ok(()),
+            };
+            if write_frame(&mut stream, &response).await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Short name for each request variant, for tests asserting a call
+    /// sequence rather than each request's full payload.
+    fn operation_name(request: &NetworkRequest) -> &'static str {
+        match request {
+            NetworkRequest::EnsureBridge => "ensure_bridge",
+            NetworkRequest::EnsureFirewall => "ensure_firewall",
+            NetworkRequest::CreateTap { .. } => "create_tap",
+            NetworkRequest::DeleteTap { .. } => "delete_tap",
+            NetworkRequest::ApplyVmPolicy { .. } => "apply_vm_policy",
+            NetworkRequest::RemoveVmPolicy { .. } => "remove_vm_policy",
+        }
+    }
+
+    /// Spawns a fake net-helper that records each request's operation name
+    /// (in arrival order) and answers `fail_operation` (if any) with an
+    /// error while answering everything else `Ok` — for tests asserting a
+    /// call sequence, whether that's a compensation path (e.g. "a failed
+    /// apply_vm_policy is still followed by remove_vm_policy and
+    /// delete_tap") or just that some path was reached at all (`None`).
+    pub fn spawn_recording_helper(
+        socket_path: &Path,
+        fail_operation: Option<&'static str>,
+    ) -> (tokio::task::JoinHandle<()>, Arc<Mutex<Vec<&'static str>>>) {
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let log_for_task = Arc::clone(&log);
+        let listener = UnixListener::bind(socket_path).expect("bind fake net-helper socket");
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    return;
+                };
+                tokio::spawn(serve_recording(
+                    stream,
+                    Arc::clone(&log_for_task),
+                    fail_operation,
+                ));
+            }
+        });
+        (handle, log)
+    }
+
+    async fn serve_recording(
+        mut stream: UnixStream,
+        log: Arc<Mutex<Vec<&'static str>>>,
+        fail_operation: Option<&'static str>,
+    ) {
+        loop {
+            let envelope: NetworkRequestEnvelope = match read_frame(&mut stream).await {
+                Ok(envelope) => envelope,
+                Err(_) => return,
+            };
+            let operation = operation_name(&envelope.request);
+            log.lock().unwrap().push(operation);
+            let result = if fail_operation == Some(operation) {
+                Err(HelperFailure::Internal {
+                    detail: "forced failure for test".to_owned(),
+                })
+            } else {
+                Ok(())
+            };
+            let response = NetworkResponseEnvelope {
+                version: PROTOCOL_VERSION,
+                request_id: envelope.request_id,
+                result,
             };
             if write_frame(&mut stream, &response).await.is_err() {
                 return;

--- a/firecrab-api/src/persistence.rs
+++ b/firecrab-api/src/persistence.rs
@@ -264,6 +264,14 @@ impl Store {
         Ok(())
     }
 
+    /// Looks up `vm_id`'s current active lease (its allocated IPv4 + MAC),
+    /// if it has one — the lease persists across stop/start, so a start
+    /// after the VM's first fetches the same one back rather than
+    /// allocating again.
+    pub fn active_lease(&self, vm_id: Uuid) -> Result<Option<Lease>, IpamError> {
+        ipam::active_lease(&self.lock(), vm_id)
+    }
+
     /// Startup cleanup: a VM left in a live state by a previous run has no
     /// process behind it anymore, so demote it to stopped.
     pub fn reset_active_states(&self) -> Result<usize, PersistenceError> {

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::firecracker::{self, VmProcess};
 use crate::model::VmRecord;
+use crate::network::NetworkClient;
 use crate::persistence::{self, PersistenceError, Store};
 use crate::rootfs;
 use crate::templates::TemplateRegistry;
@@ -63,6 +64,8 @@ pub struct AppState {
     pub(crate) runtime: Arc<RuntimeConfig>,
     /// Bounds how many `start_vm` calls copy/grow a rootfs disk at once.
     pub(crate) disk_prep_permits: Arc<Semaphore>,
+    /// Client for the privileged `firecrab-net-helper` (bridge/TAP/firewall).
+    pub(crate) network: NetworkClient,
 }
 
 impl AppState {
@@ -96,7 +99,16 @@ impl AppState {
             processes: Arc::new(Mutex::new(HashMap::new())),
             runtime: Arc::new(RuntimeConfig::from_defaults()),
             disk_prep_permits: Arc::new(Semaphore::new(DISK_PREP_CONCURRENCY)),
+            network: NetworkClient::from_env(),
         })
+    }
+
+    /// Overrides the net-helper client, for tests that spin up a fake
+    /// net-helper (see `network::test_support`) instead of a real one.
+    #[cfg(test)]
+    pub(crate) fn with_test_network(mut self, network: NetworkClient) -> Self {
+        self.network = network;
+        self
     }
 
     /// Overrides the runtime config, for tests that need a fake Firecracker

--- a/firecrab-helper-protocol/Cargo.toml
+++ b/firecrab-helper-protocol/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["io-util"] }
 uuid = { workspace = true }

--- a/firecrab-helper-protocol/src/network.rs
+++ b/firecrab-helper-protocol/src/network.rs
@@ -3,10 +3,32 @@ use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 use uuid::Uuid;
 
 use crate::PROTOCOL_VERSION;
+
+/// Prefix for every Firecrab-owned TAP interface name. TAP interface names
+/// are bounded by IFNAMSIZ (16 bytes incl. NUL): `fct` + 12 hex of
+/// sha256(vm_id) = 15 chars. The prefix is distinct from the bridge name
+/// (`fcbr0`) so an east-west wildcard (`fct*`) never matches the bridge
+/// itself.
+pub const TAP_PREFIX: &str = "fct";
+
+/// The deterministic TAP interface name for a VM. Both `firecrab-api` (to
+/// reference it in the Firecracker config) and `firecrab-net-helper` (to
+/// create/attach/delete the real device, and to name nftables objects)
+/// derive the same name from the same `vm_id` — the API never gets to pass
+/// the helper an arbitrary interface name.
+pub fn tap_name(vm_id: Uuid) -> String {
+    let digest = Sha256::digest(vm_id.as_bytes());
+    let mut name = String::from(TAP_PREFIX);
+    for byte in &digest[..6] {
+        name.push_str(&format!("{byte:02x}"));
+    }
+    name
+}
 
 /// MAC address in `aa:bb:cc:dd:ee:ff` form; serialized as that string.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -172,6 +194,15 @@ mod tests {
             serde_json::from_str::<MacAddr>(&json).expect("deserialize"),
             mac
         );
+    }
+
+    #[test]
+    fn tap_name_is_deterministic_and_within_ifnamsiz() {
+        let vm = Uuid::from_u128(0x1234);
+        assert_eq!(tap_name(vm), tap_name(vm));
+        assert!(tap_name(vm).len() <= 15, "{}", tap_name(vm));
+        assert!(tap_name(vm).starts_with(TAP_PREFIX));
+        assert_ne!(tap_name(vm), tap_name(Uuid::from_u128(0x1235)));
     }
 
     #[test]

--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -5,13 +5,12 @@
 use std::net::Ipv4Addr;
 use std::process::Stdio;
 
-use firecrab_helper_protocol::network::MacAddr;
+use firecrab_helper_protocol::network::{MacAddr, TAP_PREFIX, tap_name};
 use futures_util::TryStreamExt;
 use rtnetlink::packet_route::link::LinkAttribute;
 use rtnetlink::packet_route::route::RouteAttribute;
 use rtnetlink::packet_route::{AddressFamily, route::RouteMessage};
 use rtnetlink::{Handle, new_connection};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -26,12 +25,6 @@ const TABLE_INET: &str = "firecrab";
 const TABLE_BRIDGE: &str = "firecrab_l2";
 /// The Firecrab VPC subnet, as an nftables-literal CIDR string.
 const BRIDGE_SUBNET: &str = "172.30.0.0/24";
-/// TAP interface names are bounded by IFNAMSIZ (16 incl. NUL). `fct` + 12 hex
-/// of sha256(vm_id) = 15 chars. The prefix is distinct from `fcbr0` so an
-/// east-west wildcard (`fct*`) never matches the bridge itself. The
-/// tap-automation helper derives the same name from the same vm_id, so policy
-/// rules and the real device agree.
-const TAP_PREFIX: &str = "fct";
 
 /// The egress posture the helper resolves an API-supplied policy ID into.
 /// The API selects the ID; the helper is the trust boundary and owns the
@@ -273,17 +266,6 @@ fn render_apply_ruleset(uplink: &str) -> Result<String, FirewallError> {
     ))
 }
 
-/// The deterministic TAP name for a VM. Both this module and the
-/// tap-automation helper derive it from the same vm_id.
-pub fn tap_name(vm_id: Uuid) -> String {
-    let digest = Sha256::digest(vm_id.as_bytes());
-    let mut name = String::from(TAP_PREFIX);
-    for byte in &digest[..6] {
-        name.push_str(&format!("{byte:02x}"));
-    }
-    name
-}
-
 /// Renders one VM's isolation rules: L2 anti-spoofing tied to the lease, plus
 /// L3 egress/ingress verdicts. Every per-VM object is named after the vm_id
 /// and (re)built with add+flush, so re-applying or replacing this VM's policy
@@ -509,15 +491,6 @@ mod tests {
             egress,
             allow_host_ssh,
         }
-    }
-
-    #[test]
-    fn tap_name_is_deterministic_and_within_ifnamsiz() {
-        let vm = Uuid::from_u128(0x1234);
-        assert_eq!(tap_name(vm), tap_name(vm));
-        assert!(tap_name(vm).len() <= 15, "{}", tap_name(vm));
-        assert!(tap_name(vm).starts_with("fct"));
-        assert_ne!(tap_name(vm), tap_name(Uuid::from_u128(0x1235)));
     }
 
     #[test]

--- a/firecrab-net-helper/src/main.rs
+++ b/firecrab-net-helper/src/main.rs
@@ -17,6 +17,8 @@ use std::time::Duration;
 mod bridge;
 /// Per-VM and global nftables firewall rules.
 mod firewall;
+/// Per-VM TAP device lifecycle.
+mod tap;
 
 use firecrab_helper_protocol::PROTOCOL_VERSION;
 use firecrab_helper_protocol::framing::{read_frame, write_frame};
@@ -326,8 +328,19 @@ async fn dispatch(request: NetworkRequest, config: &HelperConfig) -> Result<(), 
                     detail: error_chain(&error),
                 })
         }
-        NetworkRequest::CreateTap { .. } | NetworkRequest::DeleteTap { .. } => {
-            Err(HelperFailure::UnsupportedOperation)
+        NetworkRequest::CreateTap { vm_id } => {
+            tap::create_tap(vm_id)
+                .await
+                .map_err(|error| HelperFailure::Internal {
+                    detail: error_chain(&error),
+                })
+        }
+        NetworkRequest::DeleteTap { vm_id } => {
+            tap::delete_tap(vm_id)
+                .await
+                .map_err(|error| HelperFailure::Internal {
+                    detail: error_chain(&error),
+                })
         }
     }
 }
@@ -394,21 +407,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unimplemented_operations_are_rejected() {
-        // Only TAP creation/deletion is still unimplemented; the policy
-        // operations are handled (RemoveVmPolicy is a no-op when nothing is
-        // installed, so it does not reach nft here).
+    async fn deleting_a_tap_that_was_never_created_is_a_no_op() {
+        // Read-only rtnetlink lookups need no special privilege, so this is
+        // safe to run unprivileged: the delete never reaches the point of
+        // needing CAP_NET_ADMIN because find_link reports nothing to delete.
         let config = HelperConfig::from_values("/tmp/x.sock", None).expect("helper config");
-        let requests = [
-            NetworkRequest::CreateTap { vm_id: Uuid::nil() },
-            NetworkRequest::DeleteTap { vm_id: Uuid::nil() },
-        ];
-        for request in requests {
-            assert_eq!(
-                dispatch(request, &config).await,
-                Err(HelperFailure::UnsupportedOperation)
-            );
-        }
+        let request = NetworkRequest::DeleteTap {
+            vm_id: Uuid::new_v4(),
+        };
+        assert_eq!(dispatch(request, &config).await, Ok(()));
     }
 
     #[tokio::test]
@@ -434,11 +441,14 @@ mod tests {
 
         let mut stream = UnixStream::connect(&path).await.expect("connect");
         for _ in 0..2 {
-            // DeleteTap answers deterministically without touching netlink,
+            // DeleteTap of a nonexistent device is a deterministic, read-only
+            // no-op (see deleting_a_tap_that_was_never_created_is_a_no_op),
             // so the framing loop is testable without privileges.
             let envelope = NetworkRequestEnvelope::new(
                 Uuid::new_v4(),
-                NetworkRequest::DeleteTap { vm_id: Uuid::nil() },
+                NetworkRequest::DeleteTap {
+                    vm_id: Uuid::new_v4(),
+                },
             );
             write_frame(&mut stream, &envelope)
                 .await
@@ -447,7 +457,7 @@ mod tests {
                 read_frame(&mut stream).await.expect("receive response");
             assert_eq!(response.version, PROTOCOL_VERSION);
             assert_eq!(response.request_id, envelope.request_id);
-            assert_eq!(response.result, Err(HelperFailure::UnsupportedOperation));
+            assert_eq!(response.result, Ok(()));
         }
 
         drop(stop);

--- a/firecrab-net-helper/src/tap.rs
+++ b/firecrab-net-helper/src/tap.rs
@@ -73,23 +73,56 @@ fn owner_alias(vm_id: Uuid) -> String {
     format!("firecrab:{vm_id}")
 }
 
-/// Creates `vm_id`'s TAP device (if it doesn't already exist), attaches it
-/// to the shared bridge, tags it with an ownership alias, and brings it up.
+/// Creates `vm_id`'s TAP device, attaches it to the shared bridge, tags it
+/// with an ownership alias, and brings it up.
+///
+/// A name collision with an existing link is only reused if that link is
+/// already ours (alias matches) — this never silently takes over a foreign
+/// or stale-from-before-this-check interface. And if anything after
+/// creating a fresh device fails (missing bridge, the device vanishing, the
+/// alias/attach/up call itself), that fresh device is deleted again before
+/// returning the error, so a partial failure never leaves an orphaned TAP.
 pub async fn create_tap(vm_id: Uuid) -> Result<(), TapError> {
     let name = tap_name(vm_id);
-    create_persistent_device(&name)?;
-
     let (connection, handle, _) = new_connection().map_err(TapError::Connection)?;
     tokio::spawn(connection);
 
-    let bridge_index = find_link(&handle, BRIDGE_NAME)
+    let created_now = match find_link(&handle, &name).await? {
+        Some(existing) => {
+            let alias = link_alias(&existing);
+            if alias.as_deref() != Some(owner_alias(vm_id).as_str()) {
+                return Err(TapError::OwnershipMismatch { name, vm_id, alias });
+            }
+            false
+        }
+        None => {
+            create_persistent_device(&name)?;
+            true
+        }
+    };
+
+    let result = attach_and_configure(&handle, &name, vm_id).await;
+    if result.is_err() && created_now {
+        // Best-effort: a cleanup failure here must not mask the original
+        // error, but a freshly-created device that we failed to finish
+        // configuring must not survive as an orphan either.
+        if let Ok(Some(link)) = find_link(&handle, &name).await {
+            let _ = handle.link().del(link.header.index).execute().await;
+        }
+    }
+    result
+}
+
+/// Looks up `name` and the shared bridge, then attaches/aliases/brings it up.
+async fn attach_and_configure(handle: &Handle, name: &str, vm_id: Uuid) -> Result<(), TapError> {
+    let bridge_index = find_link(handle, BRIDGE_NAME)
         .await?
         .ok_or(TapError::MissingBridge)?
         .header
         .index;
-    let tap_index = find_link(&handle, &name)
+    let tap_index = find_link(handle, name)
         .await?
-        .ok_or_else(|| TapError::MissingAfterCreate(name.clone()))?
+        .ok_or_else(|| TapError::MissingAfterCreate(name.to_owned()))?
         .header
         .index;
 

--- a/firecrab-net-helper/src/tap.rs
+++ b/firecrab-net-helper/src/tap.rs
@@ -1,0 +1,238 @@
+//! Per-VM TAP device lifecycle: create a persistent TAP via `/dev/net/tun`,
+//! attach it to the shared bridge with an ownership alias, and tear it down
+//! again on stop. The interface name is never taken from the caller — both
+//! this module and the API side derive it deterministically from `vm_id`
+//! via `firecrab_helper_protocol::network::tap_name`.
+
+use std::io;
+use std::os::fd::AsRawFd;
+
+use firecrab_helper_protocol::network::tap_name;
+use futures_util::TryStreamExt;
+use rtnetlink::packet_route::link::{LinkAttribute, LinkMessage};
+use rtnetlink::{Handle, LinkUnspec, new_connection};
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::bridge::BRIDGE_NAME;
+
+/// Linux's `IFNAMSIZ`: the fixed size of `ifreq.ifr_name`.
+const IFNAMSIZ: usize = 16;
+
+/// Failure modes for creating, attaching, or removing a VM's TAP device.
+#[derive(Debug, Error)]
+pub enum TapError {
+    /// Couldn't open `/dev/net/tun`.
+    #[error("failed to open /dev/net/tun")]
+    OpenTun(#[source] io::Error),
+    /// The `TUNSETIFF` ioctl failed.
+    #[error("failed to create TAP device {name}")]
+    Create {
+        /// The interface name that failed to create.
+        name: String,
+        #[source]
+        source: io::Error,
+    },
+    /// The `TUNSETPERSIST` ioctl failed.
+    #[error("failed to make TAP device {name} persistent")]
+    Persist {
+        /// The interface name that failed to persist.
+        name: String,
+        #[source]
+        source: io::Error,
+    },
+    /// Couldn't open the rtnetlink connection.
+    #[error("failed to open rtnetlink connection")]
+    Connection(#[source] io::Error),
+    /// An rtnetlink request failed.
+    #[error("rtnetlink operation failed")]
+    Netlink(#[source] rtnetlink::Error),
+    /// The shared bridge hasn't been created yet.
+    #[error("bridge {BRIDGE_NAME} does not exist yet")]
+    MissingBridge,
+    /// The TAP device vanished between being created and being configured.
+    #[error("TAP device {0} disappeared while it was being configured")]
+    MissingAfterCreate(String),
+    /// The device with this name isn't the one this `vm_id` created —
+    /// refuses to delete an interface it doesn't recognize as its own.
+    #[error("TAP device {name} is not owned by vm {vm_id} (found alias {alias:?})")]
+    OwnershipMismatch {
+        /// The interface name in question.
+        name: String,
+        /// The VM that requested the delete.
+        vm_id: Uuid,
+        /// The interface's actual alias, if any.
+        alias: Option<String>,
+    },
+}
+
+/// The `IFLA_IFALIAS` value that marks a TAP as owned by `vm_id`, checked
+/// again before every delete so a name collision (or a stale/foreign
+/// interface reusing the name) is never torn down by mistake.
+fn owner_alias(vm_id: Uuid) -> String {
+    format!("firecrab:{vm_id}")
+}
+
+/// Creates `vm_id`'s TAP device (if it doesn't already exist), attaches it
+/// to the shared bridge, tags it with an ownership alias, and brings it up.
+pub async fn create_tap(vm_id: Uuid) -> Result<(), TapError> {
+    let name = tap_name(vm_id);
+    create_persistent_device(&name)?;
+
+    let (connection, handle, _) = new_connection().map_err(TapError::Connection)?;
+    tokio::spawn(connection);
+
+    let bridge_index = find_link(&handle, BRIDGE_NAME)
+        .await?
+        .ok_or(TapError::MissingBridge)?
+        .header
+        .index;
+    let tap_index = find_link(&handle, &name)
+        .await?
+        .ok_or_else(|| TapError::MissingAfterCreate(name.clone()))?
+        .header
+        .index;
+
+    handle
+        .link()
+        .set(
+            LinkUnspec::new_with_index(tap_index)
+                .append_extra_attribute(LinkAttribute::IfAlias(owner_alias(vm_id)))
+                .controller(bridge_index)
+                .up()
+                .build(),
+        )
+        .execute()
+        .await
+        .map_err(TapError::Netlink)
+}
+
+/// Removes `vm_id`'s TAP device after confirming its alias still matches —
+/// a no-op if the device is already gone (stop/delete may race a prior
+/// cleanup or a start that never got this far).
+pub async fn delete_tap(vm_id: Uuid) -> Result<(), TapError> {
+    let name = tap_name(vm_id);
+    let (connection, handle, _) = new_connection().map_err(TapError::Connection)?;
+    tokio::spawn(connection);
+
+    let Some(link) = find_link(&handle, &name).await? else {
+        return Ok(());
+    };
+
+    let alias = link_alias(&link);
+    if alias.as_deref() != Some(owner_alias(vm_id).as_str()) {
+        return Err(TapError::OwnershipMismatch { name, vm_id, alias });
+    }
+
+    handle
+        .link()
+        .del(link.header.index)
+        .execute()
+        .await
+        .map_err(TapError::Netlink)
+}
+
+fn link_alias(link: &LinkMessage) -> Option<String> {
+    link.attributes
+        .iter()
+        .find_map(|attribute| match attribute {
+            LinkAttribute::IfAlias(alias) => Some(alias.clone()),
+            _ => None,
+        })
+}
+
+async fn find_link(handle: &Handle, name: &str) -> Result<Option<LinkMessage>, TapError> {
+    let mut links = handle.link().get().match_name(name.to_owned()).execute();
+    match links.try_next().await {
+        Ok(link) => Ok(link),
+        // A get-by-name answers ENODEV when the link does not exist.
+        Err(rtnetlink::Error::NetlinkError(message)) if message.raw_code() == -libc::ENODEV => {
+            Ok(None)
+        }
+        Err(error) => Err(TapError::Netlink(error)),
+    }
+}
+
+/// Argument struct for the raw `TUNSETIFF`/`TUNSETPERSIST` ioctls on
+/// `/dev/net/tun`. Only `ifr_name` and the `ifr_flags` slot at the front of
+/// the kernel's `ifr_ifru` union are meaningful here; the rest is padding
+/// sized to match the kernel's `struct ifreq` so the ioctl doesn't read
+/// past this buffer.
+#[repr(C)]
+struct IfReq {
+    ifr_name: [u8; IFNAMSIZ],
+    ifr_flags: libc::c_short,
+    _reserved: [u8; 22],
+}
+
+impl IfReq {
+    fn for_tap(name: &str) -> Self {
+        let mut ifr_name = [0_u8; IFNAMSIZ];
+        // Name is at most 15 chars (see tap_name's doc comment), leaving
+        // room for the NUL the kernel expects to terminate ifr_name.
+        ifr_name[..name.len()].copy_from_slice(name.as_bytes());
+        Self {
+            ifr_name,
+            ifr_flags: (libc::IFF_TAP | libc::IFF_NO_PI) as libc::c_short,
+            _reserved: [0; 22],
+        }
+    }
+}
+
+/// Creates `name` as a TAP device via `/dev/net/tun`, marking it persistent
+/// so it survives past this process closing its file descriptor (Firecracker
+/// opens the device itself by name once it starts; this helper doesn't hand
+/// its fd off to anyone).
+fn create_persistent_device(name: &str) -> Result<(), TapError> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open("/dev/net/tun")
+        .map_err(TapError::OpenTun)?;
+    let fd = file.as_raw_fd();
+
+    let mut request = IfReq::for_tap(name);
+    // SAFETY: `request` is a valid, properly sized buffer for the duration
+    // of the call; `fd` is a valid, open file descriptor for /dev/net/tun.
+    let result = unsafe { libc::ioctl(fd, libc::TUNSETIFF, &mut request) };
+    if result < 0 {
+        return Err(TapError::Create {
+            name: name.to_owned(),
+            source: io::Error::last_os_error(),
+        });
+    }
+
+    // SAFETY: as above; the third argument is a plain integer (1 = enable),
+    // not a pointer.
+    let result = unsafe { libc::ioctl(fd, libc::TUNSETPERSIST, 1) };
+    if result < 0 {
+        return Err(TapError::Persist {
+            name: name.to_owned(),
+            source: io::Error::last_os_error(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_alias_embeds_the_vm_id() {
+        let vm_id = Uuid::from_u128(0x1234);
+        assert_eq!(owner_alias(vm_id), format!("firecrab:{vm_id}"));
+    }
+
+    #[test]
+    fn ifreq_encodes_the_name_and_tap_no_pi_flags() {
+        let request = IfReq::for_tap("fct0123456789ab");
+        assert_eq!(&request.ifr_name[..15], b"fct0123456789ab");
+        assert_eq!(request.ifr_name[15], 0, "name must stay NUL-terminated");
+        assert_eq!(
+            request.ifr_flags as i32,
+            libc::IFF_TAP | libc::IFF_NO_PI,
+            "must request a TAP (not TUN) device without packet info framing"
+        );
+    }
+}


### PR DESCRIPTION
- start: allocate IPAM lease → create deterministic TAP (recomputed independently by API and helper, never dictated) → attach to bridge → apply firewall policy
- on failure: explicit policy+TAP compensation (no Drop reliance)
- stop: delete TAP only, lease persists until delete
- real TAP/bridge creation unverified end-to-end (sandbox lacks CAP_NET_ADMIN) — see docs/vm-tap-automation-smoke.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-VM network setup with persistent TAP interfaces, firewall policies, and network details in VM configuration.
  * VM lifecycle operations now automatically create, configure, clean up, and safely remove networking resources.
  * Added deterministic TAP naming and ownership validation for safer network management.
* **Bug Fixes**
  * Improved networking cleanup on unexpected VM exits; safer TAP deletion (no-op when TAP is missing) and rollback on failure scenarios, including detection of corrupt lease data.
* **Documentation**
  * Added an end-to-end smoke-test guide covering automation, verification, manual testing, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->