### PR TITLE
feat: use each distro's own official kernel instead of a shared vanil…

### DIFF
--- a/docs/bugs/alpine-official-kernel-cant-mount-root.md
+++ b/docs/bugs/alpine-official-kernel-cant-mount-root.md
@@ -1,0 +1,77 @@
+# Alpine의 공식 linux-virt 커널로 바꾸니 root 마운트가 실패한다
+
+`task-distro-standard-kernels.md`(자체 빌드 vanilla 커널 대신 각 배포판의 공식 커널을 쓰도록
+전환) 작업 중 발견. Ubuntu는 문제없이 바로 부팅됐는데, Alpine만 매번 커널 패닉으로 끝났다.
+
+## 증상
+
+```
+virtio_blk virtio0: 1/0/0 default/read/poll queues
+virtio_blk virtio0: [vda] 4194304 512-byte logical blocks (2.15 GB/2.00 GiB)
+mount: mounting /dev/vda on /sysroot failed: No such file or directory
+Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000000
+```
+
+`/dev/vda`는 실제로 존재하고(`virtio_blk`가 정상적으로 디스크를 인식함), `/sysroot`도 존재하는데
+`mount`는 계속 "No such file or directory"로 실패했다.
+
+## 잘못 짚었던 원인: virtio-mmio 이중 등록
+
+처음엔 콘솔에 찍힌 이 메시지 때문에 ACPI 기반/커맨드라인 기반 virtio-mmio 장치 등록이 충돌하는
+줄 알았다:
+
+```
+virtio-mmio virtio-mmio.0: error -EBUSY: can't request region for resource [mem 0xc0001000-0xc0001fff]
+virtio-mmio virtio-mmio.1: error -EBUSY: can't request region for resource [mem 0xc0002000-0xc0002fff]
+```
+
+`boot_args`에 `acpi=off`를 넣고 firecracker를 직접(API 안 거치고) 실행해서 확인해보니 — network
+interface 없이 diskonly로 붙였을 때(mmio 장치가 1개뿐일 때)는 EBUSY가 아예 안 뜨는데도 **root
+마운트는 똑같이 실패**했다. 즉 EBUSY는 disk+network 두 장치를 동시에 붙일 때 나타나는 별개
+증상이고(원인 미상, 실제 부팅에는 영향 없음 — disk 자체는 정상 attach됨), 진짜 원인이 아니었다.
+
+## 진짜 원인: `ext4` 커널 모듈이 로드되기 전에 `mount`가 먼저 시도됨
+
+`panic=1`을 빼고 수동으로 firecracker를 띄워 Alpine의 initramfs 복구 셸(emergency shell)에
+직접 들어가 확인했다:
+
+```sh
+~ # ls -la /dev/        # /dev/vda 존재 확인됨
+~ # mkdir -p /sysroot   # 이미 존재
+~ # mount /dev/vda /sysroot
+mount: mounting /dev/vda on /sysroot failed: No such file or directory   # 여전히 실패
+
+~ # modprobe ext4
+~ # mount -t ext4 /dev/vda /sysroot
+EXT4-fs (vda): mounted filesystem ... r/w with ordered data mode.        # 성공!
+```
+
+Alpine 공식 커널(`linux-virt`)은 virtio_blk와 마찬가지로 **ext4도 모듈**(`=m`)로 빌드돼 있다.
+mkinitfs가 생성한 `/init` 스크립트는 root 마운트 시 `rootfstype`(커널 커맨드라인의
+`rootfstype=` 값)이 없으면 `mount`에 `-t` 없이 호출하는데, 이 상태에서 `mount`는 파일시스템
+타입을 자동 인식하지 못한다 — ext4 모듈이 아직 로드 안 됐으니 커널이 "이런 타입 압니다"라고
+답할 수 없고, 결과적으로 실제 원인과 무관한 "No such file or directory"라는 오해하기 쉬운
+에러로 실패한다. `-t ext4`로 명시하면 커널의 온디맨드 모듈 로딩(`request_module`)이 자동으로
+ext4.ko를 불러와 정상 동작한다.
+
+자체 빌드 vanilla 커널(`install-linux-kernel.sh`)은 이 문제가 아예 없었다 — virtio_blk/ext4를
+전부 커널에 빌트인(`=y`)으로 고정해뒀기 때문에 모듈 로딩 자체가 필요 없었다.
+
+## 수정
+
+`firecrab-api/src/templates.rs`의 Alpine `boot_args`에 `rootfstype=ext4` 추가:
+
+```
+console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rootfstype=ext4 rw
+```
+
+## 검증
+
+수정 전: `rootfstype=ext4` 없이 100% 재현(3회 연속 동일 패닉). 수정 후: 실제 API로 Alpine VM
+생성·시작 → `running` 도달, 실제 IP로 ping 0% 손실 확인. Ubuntu는 애초에 root=ext4 지원이
+빌트인이라 이 문제 자체가 없었음(그대로 무변경).
+
+## 산출물
+
+`firecrab-api/src/templates.rs`(boot_args 한 줄) — 코드 변경은 이게 전부, 나머지는 진단
+과정(수동 firecracker 실행, initramfs 복구 셸 직접 조작)이었음.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,6 +18,7 @@
 | Alpine 템플릿만 매번 `no-ipv4-address`(Ubuntu는 정상) | [네트워크](#네트워크) |
 | VM을 여러 대 동시에 시작하면 부팅 극초반에 죽음 | [네트워크](#네트워크) |
 | VM 내부에서 새 목적지로 나가는 연결(apt/apk update 등)이 타임아웃 | [네트워크](#네트워크) |
+| Alpine이 공식 커널로 바꾸니 부팅 중 커널 패닉("No such file or directory") | [VM 생성·시작](#vm-생성시작) |
 | 터미널 "연결 끊김"만 뜨고 안 붙음 | [터미널](#터미널) |
 | 터미널 프롬프트에 `;1R;80R;1R;80R...` 반복 | [터미널](#터미널) |
 
@@ -45,6 +46,13 @@
 
 - **원인·수정**: [bugs/vm-startup-stuck-under-concurrent-load.md](bugs/vm-startup-stuck-under-concurrent-load.md) —
   템플릿 재해싱 중복 + 타임아웃된 요청의 future가 drop되며 VM이 고아 상태가 되는 버그, 둘 다 수정됨
+
+### Alpine이 공식 커널로 바꾸니 부팅 중 커널 패닉("No such file or directory")
+
+- **원인·수정**: [bugs/alpine-official-kernel-cant-mount-root.md](bugs/alpine-official-kernel-cant-mount-root.md) —
+  Alpine 공식 `linux-virt` 커널은 ext4가 모듈이라, `rootfstype=` 없이 mount를 호출하면 모듈이
+  아직 안 실린 상태라 타입을 인식 못 해 실패한다("No such file or directory"는 이 상황을
+  오해하기 쉽게 표현한 에러). `boot_args`에 `rootfstype=ext4` 추가로 수정, 수정됨
 
 ### 호스트 디스크가 꽉 차서 VM 생성/시작이 느리거나 실패한다
 

--- a/docs/week3-tasks.md
+++ b/docs/week3-tasks.md
@@ -73,6 +73,17 @@
   `wait_for_network_ready`와 같은 패턴 재사용) — 실제 Ubuntu/Alpine VM에서 exit code 0으로 검증,
   프론트엔드 버튼은 아직 없음(백엔드만). CI(GitHub Actions)에 `dnsmasq` 미설치로 나던 테스트 실패
   수정, Codecov patch coverage 90.00%→92.24%로 보강. `cargo test --workspace` 126/18/12/46 green
+- 2026-07-24(계속): 배포판 표준 커널 사용 완료(`task-distro-standard-kernels.md`). Ubuntu는
+  `linux-image-generic`, Alpine은 `linux-virt`를 각자의 rootfs 빌드 스크립트에서 설치 후
+  `/boot/vmlinuz*`를 `extract-vmlinux`(커널 소스에서 그대로 가져옴, `scripts/firecracker-menual/
+  extract-vmlinux`에 vendor)로 ELF vmlinux로 변환해 `images/kernel/`에 저장. Alpine은
+  virtio_blk/ext4가 모듈이라 `initramfs-virt`도 그대로 initrd로 필요 — `TemplateSpec`/
+  `TemplateVersion`에 `initrd: Option<...>` 추가, Firecracker `boot-source`에 조건부
+  `initrd_path` 필드 추가. 실제 부팅 중 Alpine만 커널 패닉으로 실패하는 걸 발견·수정
+  (`docs/bugs/alpine-official-kernel-cant-mount-root.md` — ext4가 모듈이라 `rootfstype=ext4`
+  없이는 mount가 타입을 못 정하고 실패). 두 템플릿 다 실제 API로 생성·시작→`running` 도달,
+  ping 0% 손실, `uname`/`Linux version` 배너로 실제 배포판 커널(Ubuntu 7.0.0-28-generic,
+  Alpine 6.18.39-0-virt) 사용 확인. `cargo test --workspace` 129/18/12/46 green
 
 | 상태 | 제목 | 작업 | 완료 기준 | 산출물 |
 |---|---|---|---|---|
@@ -101,7 +112,7 @@
 
 | 상태 | 제목 | 작업 | 완료 기준 | 산출물 |
 |---|---|---|---|---|
-| 미완료 (네트워크 이후) | [배포판 표준 커널 사용](task-distro-standard-kernels.md) | Ubuntu/Alpine 템플릿이 공유하는 자체 빌드 vanilla 커널 대신, 각 배포판이 실제 배포하는 공식 커널(`linux-image-generic`, `linux-virt`)을 추출해 쓴다. | 두 템플릿 모두 실제 배포판 공식 커널로 부팅되고 기존 동작에 회귀가 없다(Alpine은 virtio_blk/ext4가 모듈이라 initrd 필요). | `firecrab-api/src/templates.rs`, `firecrab-api/src/firecracker.rs`, `images/kernel/` |
+| ✅ | [배포판 표준 커널 사용](task-distro-standard-kernels.md) | Ubuntu/Alpine 템플릿이 공유하던 자체 빌드 vanilla 커널 대신, 각 배포판이 실제 배포하는 공식 커널(`linux-image-generic`, `linux-virt`)을 추출해 쓴다. | 두 템플릿 모두 실제 배포판 공식 커널로 부팅되고 기존 동작에 회귀가 없다(Alpine은 virtio_blk/ext4가 모듈이라 initrd 필요). | `firecrab-api/src/templates.rs`, `firecrab-api/src/firecracker.rs`, `images/kernel/`, `scripts/firecracker-menual/install-{ubuntu,alpine}-rootfs.sh`, `scripts/firecracker-menual/extract-vmlinux` |
 | 미완료 (네트워크 이후) | [네트워크 구성 대시보드 — 다중 subnet/uplink 편집](task-network-configuration-dashboard.md) | (읽기 전용 조회 + VM별 egress 정책은 위 표에서 ✅ 완료됨) 대시보드에서 host 네트워크(subnet/uplink) 자체를 **직접 설정**하고, 여러 네트워크 중 VM이 속할 네트워크를 명시적으로 고를 수 있게 한다 — IPAM/bridge 다중화 리팩터가 선행돼야 함. | 대시보드에서 네트워크 설정을 바꿀 수 있고, VM 생성·상세 화면에서 소속 네트워크(복수 중 하나)를 확인할 수 있다. | `firecrab-api/src/handlers/network.rs`, `firecrab-api-types/src/lib.rs`, `firecrab-net-helper/src/nat.rs`, `firecrab-frontend/src/components/` |
 
 ### 네트워크 — 범위 밖으로 보류 (재개 시 참고용, 이번 대회 일정에는 포함 안 함)

--- a/firecrab-api/src/firecracker.rs
+++ b/firecrab-api/src/firecracker.rs
@@ -127,6 +127,11 @@ pub struct FirecrackerConfig {
 struct BootSource {
     /// Absolute path to the kernel image.
     kernel_image_path: PathBuf,
+    /// Absolute path to the initrd image, if this template's kernel needs
+    /// one (e.g. a distro kernel whose virtio_blk/ext4 are modules rather
+    /// than builtin).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    initrd_path: Option<PathBuf>,
     /// Kernel command line.
     boot_args: String,
 }
@@ -180,6 +185,7 @@ impl FirecrackerConfig {
     pub fn for_vm(
         vm: &VmRecord,
         kernel_image_path: &Path,
+        initrd_path: Option<&Path>,
         boot_args: &str,
         rootfs_path: &Path,
         network: Option<&VmNetwork>,
@@ -187,6 +193,7 @@ impl FirecrackerConfig {
         Self {
             boot_source: BootSource {
                 kernel_image_path: kernel_image_path.to_owned(),
+                initrd_path: initrd_path.map(Path::to_owned),
                 boot_args: boot_args.to_owned(),
             },
             drives: vec![Drive {
@@ -219,6 +226,7 @@ pub fn write_config(
     vms_dir: &Path,
     vm: &VmRecord,
     kernel_image_path: &Path,
+    initrd_path: Option<&Path>,
     boot_args: &str,
     network: Option<&VmNetwork>,
 ) -> Result<PathBuf, FirecrackerError> {
@@ -232,6 +240,7 @@ pub fn write_config(
     let config = FirecrackerConfig::for_vm(
         vm,
         kernel_image_path,
+        initrd_path,
         boot_args,
         &rootfs::rootfs_path(vms_dir, vm.id),
         network,
@@ -685,6 +694,7 @@ mod tests {
             &vms_dir,
             &vm,
             Path::new("/images/vmlinux"),
+            None,
             "console=ttyS0",
             None,
         )
@@ -709,6 +719,7 @@ mod tests {
             &vms_dir,
             &vm,
             Path::new("/images/vmlinux"),
+            None,
             "console=ttyS0",
             None,
         )
@@ -732,6 +743,46 @@ mod tests {
     }
 
     #[test]
+    fn initrd_path_is_omitted_when_the_template_has_none() {
+        let directory = tempdir().unwrap();
+        let vms_dir = directory.path().join("vms");
+        let vm = record(1, 512);
+
+        let path = write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            None,
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
+
+        let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert!(config["boot-source"].get("initrd_path").is_none());
+    }
+
+    #[test]
+    fn initrd_path_is_wired_through_when_the_template_has_one() {
+        let directory = tempdir().unwrap();
+        let vms_dir = directory.path().join("vms");
+        let vm = record(1, 512);
+
+        let path = write_config(
+            &vms_dir,
+            &vm,
+            Path::new("/images/vmlinux"),
+            Some(Path::new("/images/initrd")),
+            "console=ttyS0",
+            None,
+        )
+        .unwrap();
+
+        let config: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        assert_eq!(config["boot-source"]["initrd_path"], "/images/initrd");
+    }
+
+    #[test]
     fn rewriting_config_overwrites_previous_content() {
         let directory = tempdir().unwrap();
         let vms_dir = directory.path().join("vms");
@@ -741,6 +792,7 @@ mod tests {
             &vms_dir,
             &vm,
             Path::new("/images/vmlinux"),
+            None,
             "console=ttyS0",
             None,
         )
@@ -751,6 +803,7 @@ mod tests {
             &vms_dir,
             &vm,
             Path::new("/images/vmlinux"),
+            None,
             "console=ttyS0",
             None,
         )

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -656,10 +656,15 @@ async fn finish_run_start(
             StartupStep::GeneratingConfig,
         );
         let kernel = templates.artifact_path(&template.kernel);
+        let initrd = template
+            .initrd
+            .as_ref()
+            .map(|artifact| templates.artifact_path(artifact));
         firecracker::write_config(
             &runtime.vms_dir,
             &record,
             &kernel,
+            initrd.as_deref(),
             &template.boot_args,
             Some(&network),
         )
@@ -1089,6 +1094,7 @@ pub(crate) mod test_support {
                 alias: "ubuntu-rootfs-26.04".to_owned(),
                 version: "v1".to_owned(),
                 kernel: PathBuf::from("kernel"),
+                initrd: None,
                 rootfs: PathBuf::from("rootfs"),
                 boot_args: "console=ttyS0".to_owned(),
             }],

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -60,6 +60,10 @@ pub struct TemplateSpec {
     pub version: String,
     /// Path to the kernel image, relative to the image root.
     pub kernel: PathBuf,
+    /// Path to the initrd image, relative to the image root — only needed
+    /// when the kernel doesn't build virtio_blk/ext4 in (e.g. Alpine's
+    /// `linux-virt`, which ships them as modules).
+    pub initrd: Option<PathBuf>,
     /// Path to the rootfs image, relative to the image root.
     pub rootfs: PathBuf,
     /// Firecracker kernel command line for this template.
@@ -104,6 +108,8 @@ pub struct TemplateVersion {
     pub version: String,
     /// Verified kernel image.
     pub kernel: VerifiedArtifact,
+    /// Verified initrd image, if this template needs one.
+    pub initrd: Option<VerifiedArtifact>,
     /// Verified rootfs image.
     pub rootfs: VerifiedArtifact,
     /// Firecracker kernel command line.
@@ -163,19 +169,35 @@ impl TemplateRegistry {
             [
                 TemplateSpec {
                     alias: "ubuntu-26.04".to_owned(),
-                    version: "ubuntu-26.04-v1".to_owned(),
-                    kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
+                    version: "ubuntu-26.04-v2".to_owned(),
+                    // Ubuntu's own linux-image-generic kernel (see
+                    // install-ubuntu-roofs.sh) rather than a self-built
+                    // vanilla one — virtio_blk/ext4 are builtin, no initrd
+                    // needed (task-distro-standard-kernels.md).
+                    kernel: PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64"),
+                    initrd: None,
                     rootfs: PathBuf::from("rootfs/ubuntu-rootfs-26.04-amd64.ext4"),
                     boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
                 },
                 TemplateSpec {
                     alias: "alpine-3.24".to_owned(),
-                    version: "alpine-3.24.1-v1".to_owned(),
-                    // Same generic kernel as ubuntu-26.04: it's distro-agnostic
-                    // (virtio/ext4/serial support, no guest-specific config).
-                    kernel: PathBuf::from("kernel/vmlinux-7.1.2-x86_64"),
+                    version: "alpine-3.24.1-v3".to_owned(),
+                    // Alpine's own linux-virt kernel (see
+                    // install-alpine-rootfs.sh); unlike Ubuntu's, its
+                    // virtio_blk/ext4 are modules, so the initrd Alpine
+                    // itself builds for it is required to reach the root
+                    // device at all. `rootfstype=ext4` is also required —
+                    // without an explicit -t, mkinitfs's mount call can't
+                    // guess a filesystem type whose module (ext4, also not
+                    // builtin here) isn't loaded yet, and fails with a
+                    // misleading "No such file or directory" instead of
+                    // triggering the kernel's on-demand module load.
+                    kernel: PathBuf::from("kernel/vmlinux-alpine-virt-x86_64"),
+                    initrd: Some(PathBuf::from("kernel/initramfs-alpine-virt-x86_64")),
                     rootfs: PathBuf::from("rootfs/alpine-rootfs-3.24.1-x86_64.ext4"),
-                    boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
+                    boot_args:
+                        "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rootfstype=ext4 rw"
+                            .to_owned(),
                 },
             ],
         )
@@ -196,10 +218,16 @@ impl TemplateRegistry {
         let mut versions = HashMap::new();
 
         for spec in specs {
+            let initrd = spec
+                .initrd
+                .as_ref()
+                .map(|path| verify_artifact(&image_root, path))
+                .transpose()?;
             let version = Arc::new(TemplateVersion {
                 name: spec.alias.clone(),
                 version: spec.version.clone(),
                 kernel: verify_artifact(&image_root, &spec.kernel)?,
+                initrd,
                 rootfs: verify_artifact(&image_root, &spec.rootfs)?,
                 boot_args: spec.boot_args,
             });
@@ -433,6 +461,7 @@ mod tests {
                     alias: "ubuntu-rootfs-26.04".to_owned(),
                     version: "v1".to_owned(),
                     kernel: PathBuf::from("kernel"),
+                    initrd: None,
                     rootfs: PathBuf::from("rootfs"),
                     boot_args: "console=ttyS0".to_owned(),
                 },
@@ -440,6 +469,7 @@ mod tests {
                     alias: "ubuntu-26.04".to_owned(),
                     version: "v1".to_owned(),
                     kernel: PathBuf::from("kernel"),
+                    initrd: None,
                     rootfs: PathBuf::from("rootfs"),
                     boot_args: "console=ttyS0".to_owned(),
                 },
@@ -485,6 +515,7 @@ mod tests {
                 alias: "bad".to_owned(),
                 version: "v1".to_owned(),
                 kernel: PathBuf::from("../artifact"),
+                initrd: None,
                 rootfs: PathBuf::from("../artifact"),
                 boot_args: String::new(),
             }],
@@ -497,11 +528,43 @@ mod tests {
                 alias: "bad".to_owned(),
                 version: "v1".to_owned(),
                 kernel: PathBuf::from("link"),
+                initrd: None,
                 rootfs: PathBuf::from("link"),
                 boot_args: String::new(),
             }],
         );
         assert!(matches!(link_result, Err(TemplateError::Io(_))));
+    }
+
+    #[test]
+    fn initrd_is_verified_like_kernel_and_rootfs_when_present() {
+        let directory = tempdir().unwrap();
+        fs::write(directory.path().join("kernel"), b"kernel").unwrap();
+        fs::write(directory.path().join("rootfs"), b"rootfs").unwrap();
+        fs::write(directory.path().join("initrd"), b"initrd").unwrap();
+
+        let registry = TemplateRegistry::from_specs(
+            directory.path(),
+            [TemplateSpec {
+                alias: "alpine-virt".to_owned(),
+                version: "v1".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: Some(PathBuf::from("initrd")),
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: "console=ttyS0".to_owned(),
+            }],
+        )
+        .unwrap();
+        let template = registry.resolve_alias("alpine-virt").unwrap();
+
+        let initrd = template.initrd.as_ref().expect("initrd was declared");
+        assert_eq!(initrd.sha256(), sha256_bytes(b"initrd"));
+
+        fs::write(directory.path().join("initrd"), b"tampered").unwrap();
+        assert!(matches!(
+            registry.open_verified(initrd),
+            Err(TemplateError::ArtifactChanged(_))
+        ));
     }
 
     #[test]

--- a/scripts/firecracker-menual/extract-vmlinux
+++ b/scripts/firecracker-menual/extract-vmlinux
@@ -1,0 +1,65 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-2.0-only
+# ----------------------------------------------------------------------
+# extract-vmlinux - Extract uncompressed vmlinux from a kernel image
+#
+# Inspired from extract-ikconfig
+# (c) 2009,2010 Dick Streefland <dick@streefland.net>
+#
+# (c) 2011      Corentin Chary <corentin.chary@gmail.com>
+#
+# ----------------------------------------------------------------------
+
+me=${0##*/}
+
+check_vmlinux()
+{
+	if file "$1" | grep -q 'Linux kernel.*boot executable' ||
+		readelf -h "$1" > /dev/null 2>&1
+	then
+		cat "$1"
+		echo "$me: Extracted vmlinux using '$2' from offset $3" >&2
+		exit 0
+	fi
+}
+
+try_decompress()
+{
+	# The obscure use of the "tr" filter is to work around older versions of
+	# "grep" that report the byte offset of the line instead of the pattern.
+
+	# Try to find the header ($1) and decompress from here
+	for	pos in `tr "$1\n$2" "\n$2=" < "$img" | grep -abo "^$2"`
+	do
+		pos=${pos%%:*}
+		tail -c+$pos "$img" | $3 > $tmp 2> /dev/null
+		check_vmlinux $tmp "$3" $pos
+	done
+}
+
+# Check invocation:
+img=$1
+if	[ $# -ne 1 -o ! -s "$img" ]
+then
+	echo "Usage: $me <kernel-image>" >&2
+	exit 2
+fi
+
+# Prepare temp files:
+tmp=$(mktemp /tmp/vmlinux-XXX)
+trap "rm -f $tmp" 0
+
+# That didn't work, so retry after decompression.
+try_decompress '\037\213\010' xy    gunzip
+try_decompress '\3757zXZ\000' abcde unxz
+try_decompress 'BZh'          xy    bunzip2
+try_decompress '\135\0\0\0'   xxx   unlzma
+try_decompress '\211\114\132' xy    'lzop -d'
+try_decompress '\002!L\030'   xxx   'lz4 -d'
+try_decompress '(\265/\375'   xxx   unzstd
+
+# Finally check for uncompressed images or objects:
+check_vmlinux "$img" cat 0
+
+# Bail out:
+echo "$me: Cannot find vmlinux." >&2

--- a/scripts/firecracker-menual/install-alpine-rootfs.sh
+++ b/scripts/firecracker-menual/install-alpine-rootfs.sh
@@ -7,6 +7,10 @@ repo_dir=$(CDPATH= cd -- "${script_dir}/../.." && pwd -P)
 
 alpine_releases_base='https://dl-cdn.alpinelinux.org/alpine'
 artifact_dir="${repo_dir}/images/rootfs"
+kernel_artifact_dir="${repo_dir}/images/kernel"
+kernel_image_name='vmlinux-alpine-virt-x86_64'
+initrd_image_name='initramfs-alpine-virt-x86_64'
+extract_vmlinux="${script_dir}/extract-vmlinux"
 build_dir="${repo_dir}/build/alpine-rootfs"
 rootfs_size='512M'
 rootfs_hostname='firecrab'
@@ -18,7 +22,13 @@ rootfs_hostname='firecrab'
 # by that script's sudo re-exec). Docker gives us both without sudo.
 docker_bin='docker'
 docker_image='alpine:latest'
-rootfs_packages='alpine-baselayout busybox openrc agetty iproute2-minimal iputils-ping dhcpcd openssh-server ca-certificates curl procps'
+# linux-virt: Alpine's own officially-maintained cloud/virt kernel package
+# (task-distro-standard-kernels.md) — replaces the self-built vanilla kernel
+# every template used to share. Unlike Ubuntu's linux-image-generic,
+# virtio_blk/ext4 are modules here rather than builtin, so the initramfs-virt
+# Alpine builds alongside it (mkinitfs) has to ship as the VM's initrd too —
+# without it the kernel can never reach /dev/vda to mount the real root.
+rootfs_packages='alpine-baselayout busybox openrc agetty iproute2-minimal iputils-ping dhcpcd openssh-server ca-certificates curl procps linux-virt'
 
 info() {
   printf '[INFO] %s\n' "$1"
@@ -111,6 +121,7 @@ alpine_arch=$3
 hostname=$4
 rootfs_size=$5
 rootfs_packages=$6
+initrd_image_name=$7
 
 mkdir -p "$staging"
 tar -xzf /input/archive.tar.gz -C "$staging"
@@ -226,6 +237,18 @@ test -e "${staging}/usr/sbin/sshd" || { echo 'missing sshd' >&2; exit 1; }
 test -x "${staging}/etc/init.d/firecrab-network-ready" || { echo 'missing firecrab-network-ready init script' >&2; exit 1; }
 test -L "${staging}/etc/runlevels/default/firecrab-network-ready" || { echo 'firecrab-network-ready not enabled in default runlevel' >&2; exit 1; }
 
+# linux-virt's boot files land under the staging root, not this container's
+# own /boot — pulled out to /kernel-out (mounted from the host) so the host
+# side can convert the compressed vmlinuz-virt to the uncompressed ELF
+# vmlinux Firecracker needs (extract-vmlinux isn't guaranteed to be usable
+# from inside this throwaway alpine:latest container, and the host already
+# has every decompressor it might need).
+test -e "${staging}/boot/vmlinuz-virt" || { echo 'missing boot/vmlinuz-virt (linux-virt)' >&2; exit 1; }
+test -e "${staging}/boot/initramfs-virt" || { echo 'missing boot/initramfs-virt (linux-virt)' >&2; exit 1; }
+cp "${staging}/boot/vmlinuz-virt" /kernel-out/vmlinuz-virt-raw
+cp "${staging}/boot/initramfs-virt" "/kernel-out/${initrd_image_name}"
+chown 1000:1000 /kernel-out/vmlinuz-virt-raw "/kernel-out/${initrd_image_name}" 2>/dev/null || true
+
 apk add --no-cache e2fsprogs >/dev/null
 
 rootfs_image="/out/alpine-rootfs-${alpine_version}-${alpine_arch}.ext4"
@@ -240,6 +263,42 @@ echo "ROOTFS_IMAGE=${rootfs_image}"
 EOF
 }
 
+# Converts the raw vmlinuz-virt the container copied out to /kernel-out into
+# the uncompressed ELF vmlinux Firecracker expects (a compressed bzImage
+# fails with "Invalid Elf magic number") — run on the host, not inside the
+# throwaway alpine:latest container, since the host is already known to have
+# a usable decompressor (see extract-vmlinux's own fallback list) while a
+# fresh container might not.
+extract_kernel() {
+  raw_path="${kernel_artifact_dir}/vmlinuz-virt-raw"
+  if [ ! -s "$raw_path" ]; then
+    fail "linux-virt's vmlinuz-virt was not copied out to ${raw_path}"
+  fi
+
+  kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
+  kernel_image_tmp="${kernel_image_path}.tmp"
+  info "extracting ELF vmlinux from: ${raw_path}"
+  if ! "$extract_vmlinux" "$raw_path" >"$kernel_image_tmp"; then
+    rm -f "$kernel_image_tmp"
+    fail "extract-vmlinux could not extract an ELF vmlinux from ${raw_path}"
+  fi
+  if ! file "$kernel_image_tmp" | grep -q 'ELF'; then
+    rm -f "$kernel_image_tmp"
+    fail "extracted kernel is not an ELF image: ${raw_path}"
+  fi
+  chmod 0644 "$kernel_image_tmp"
+  mv "$kernel_image_tmp" "$kernel_image_path"
+  rm -f "$raw_path"
+  info "Alpine kernel image: ${kernel_image_path}"
+
+  initrd_image_path="${kernel_artifact_dir}/${initrd_image_name}"
+  if [ ! -s "$initrd_image_path" ]; then
+    fail "linux-virt's initramfs-virt was not copied out to ${initrd_image_path}"
+  fi
+  chmod 0644 "$initrd_image_path"
+  info "Alpine initrd image: ${initrd_image_path}"
+}
+
 main() {
   if [ "$#" -ne 0 ]; then
     fail 'install-alpine-rootfs.sh does not accept arguments.'
@@ -247,12 +306,16 @@ main() {
 
   require_command awk
   require_command curl
+  require_command file
   require_command grep
   require_command mkdir
   require_command mv
   require_command sha256sum
   require_command uname
   require_command "$docker_bin"
+  if [ ! -x "$extract_vmlinux" ]; then
+    fail "extract-vmlinux helper not found or not executable: ${extract_vmlinux}"
+  fi
 
   build_dir=$(abs_dir "$build_dir")
   artifact_dir=$(abs_dir "$artifact_dir")
@@ -296,6 +359,8 @@ main() {
   mkdir -p "$mount_dir"
   "$docker_bin" run --rm -v "${mount_dir}:/work/rootfs" "$docker_image" sh -c 'rm -rf /work/rootfs/* /work/rootfs/.[!.]* 2>/dev/null || true'
 
+  mkdir -p "$kernel_artifact_dir"
+
   info 'building Alpine rootfs staging + ext4 image via Docker (apk --root, no host root required)'
   "$docker_bin" run --rm \
     -v "${archive_path}:/input/archive.tar.gz:ro" \
@@ -303,7 +368,10 @@ main() {
     -v "${configure_script}:/configure.sh:ro" \
     -v "${mount_dir}:/work/rootfs" \
     -v "${artifact_dir}:/out" \
-    "$docker_image" sh /configure.sh "$alpine_branch" "$alpine_version" "$alpine_arch" "$rootfs_hostname" "$rootfs_size" "$rootfs_packages"
+    -v "${kernel_artifact_dir}:/kernel-out" \
+    "$docker_image" sh /configure.sh "$alpine_branch" "$alpine_version" "$alpine_arch" "$rootfs_hostname" "$rootfs_size" "$rootfs_packages" "$initrd_image_name"
+
+  extract_kernel
 
   rootfs_image="${artifact_dir}/alpine-rootfs-${alpine_version}-${alpine_arch}.ext4"
   rootfs_link="${artifact_dir}/alpine-rootfs.ext4"

--- a/scripts/firecracker-menual/install-ubuntu-roofs.sh
+++ b/scripts/firecracker-menual/install-ubuntu-roofs.sh
@@ -9,13 +9,21 @@ script_path="${script_dir}/$(basename -- "$0")"
 ubuntu_base_url='https://cdimage.ubuntu.com/ubuntu-base/releases'
 ubuntu_series_setting='latest'
 artifact_dir="${repo_dir}/images/rootfs"
+kernel_artifact_dir="${repo_dir}/images/kernel"
+kernel_image_name='vmlinux-ubuntu-26.04-x86_64'
+extract_vmlinux="${script_dir}/extract-vmlinux"
 build_dir="${repo_dir}/build/ubuntu-rootfs"
 rootfs_image=''
 rootfs_link=''
 rootfs_size='2G'
 rootfs_hostname='firecrab'
 
-rootfs_boot_packages='systemd systemd-sysv udev kmod util-linux'
+# linux-image-generic: Ubuntu's own officially-maintained cloud/generic
+# kernel package (task-distro-standard-kernels.md) — replaces the
+# self-built vanilla kernel every template used to share, so security
+# patches and driver support follow Ubuntu's own release cadence instead
+# of this project having to track kernel.org itself.
+rootfs_boot_packages='systemd systemd-sysv udev kmod util-linux linux-image-generic'
 rootfs_packages="${rootfs_boot_packages} iproute2 iputils-ping net-tools dnsutils curl ca-certificates procps openssh-server"
 
 mount_dir=''
@@ -292,6 +300,8 @@ restore_output_ownership() {
   if [ "$rootfs_link" != "$rootfs_image" ] && [ -L "$rootfs_link" ]; then
     chown -h "${SUDO_UID}:${SUDO_GID}" "$rootfs_link" 2>/dev/null || true
   fi
+
+  chown "${SUDO_UID}:${SUDO_GID}" "${kernel_artifact_dir}/${kernel_image_name}"
 }
 
 cleanup_chroot_mounts() {
@@ -420,7 +430,20 @@ install_network_ready_sentinel() {
   write_root_file "${mount_dir}/usr/local/sbin/firecrab-network-ready.sh" <<'EOF'
 #!/bin/sh
 set -eu
-ipv4=$(ip -4 -o addr show eth0 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+# network-online.target only orders unit *starts*, it doesn't guarantee
+# systemd-networkd's DHCP transaction has actually completed by the time
+# this runs — checking eth0 once right away routinely races a lease that
+# lands a few hundred ms later. Poll briefly instead of trusting the
+# ordering dependency to mean "has an address" (matches the retry loop
+# install-alpine-rootfs.sh already uses for the same race).
+ipv4=""
+for _ in $(seq 1 10); do
+  ipv4=$(ip -4 -o addr show eth0 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+  if [ -n "$ipv4" ]; then
+    break
+  fi
+  sleep 1
+done
 if [ -z "$ipv4" ]; then
   echo "FIRECRAB_NETWORK_FAILED no-ipv4-address"
 elif getent hosts example.com >/dev/null 2>&1; then
@@ -463,6 +486,34 @@ install_rootfs_packages() {
   chroot "$mount_dir" apt-get clean
   rm -rf "${mount_dir}/var/lib/apt/lists/"*
   cleanup_chroot_mounts
+}
+
+# Pulls the vmlinuz linux-image-generic just installed out of the rootfs
+# build and converts it to the uncompressed ELF vmlinux Firecracker expects
+# (a compressed bzImage fails with "Invalid Elf magic number") — mirrors
+# what install-linux-kernel.sh's from-source build got for free via
+# `make vmlinux`, since a packaged kernel only ships the compressed form.
+extract_kernel() {
+  vmlinuz_path=$(find "${mount_dir}/boot" -maxdepth 1 -name 'vmlinuz-*' | sort -V | tail -n 1)
+  if [ -z "$vmlinuz_path" ]; then
+    fail "linux-image-generic did not install a vmlinuz under ${mount_dir}/boot"
+  fi
+  info "extracting ELF vmlinux from: ${vmlinuz_path}"
+
+  mkdir -p "$kernel_artifact_dir"
+  kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
+  kernel_image_tmp="${kernel_image_path}.tmp"
+  if ! "$extract_vmlinux" "$vmlinuz_path" >"$kernel_image_tmp"; then
+    rm -f "$kernel_image_tmp"
+    fail "extract-vmlinux could not extract an ELF vmlinux from ${vmlinuz_path}"
+  fi
+  if ! file "$kernel_image_tmp" | grep -q 'ELF'; then
+    rm -f "$kernel_image_tmp"
+    fail "extracted kernel is not an ELF image: ${vmlinuz_path}"
+  fi
+  chmod 0644 "$kernel_image_tmp"
+  mv "$kernel_image_tmp" "$kernel_image_path"
+  info "Ubuntu kernel image: ${kernel_image_path}"
 }
 
 verify_rootfs_content() {
@@ -539,6 +590,14 @@ verify_rootfs_content() {
   if [ ! -e "${mount_dir}/bin/ping" ] && [ ! -e "${mount_dir}/usr/bin/ping" ]; then
     fail "Rootfs did not install ping. Check packages: ${rootfs_packages}"
   fi
+
+  kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
+  if [ ! -s "$kernel_image_path" ]; then
+    fail "extract_kernel did not produce a kernel image: ${kernel_image_path}"
+  fi
+  if ! file "$kernel_image_path" | grep -q 'ELF'; then
+    fail "Extracted kernel image is not ELF: ${kernel_image_path}"
+  fi
 }
 
 main() {
@@ -552,6 +611,8 @@ main() {
   require_command chroot
   require_command cp
   require_command curl
+  require_command file
+  require_command find
   require_command grep
   require_command install
   require_command ln
@@ -568,6 +629,9 @@ main() {
   require_command truncate
   require_command uname
   require_command umount
+  if [ ! -x "$extract_vmlinux" ]; then
+    fail "extract-vmlinux helper not found or not executable: ${extract_vmlinux}"
+  fi
 
   if [ "$(id -u)" -ne 0 ]; then
     require_command sudo
@@ -619,6 +683,7 @@ main() {
   tar --numeric-owner -xpf "$archive_path" -C "$mount_dir"
   configure_rootfs
   install_rootfs_packages
+  extract_kernel
   configure_guest_dns
   verify_rootfs_content
 


### PR DESCRIPTION
…la one

- Ubuntu: linux-image-generic + extract-vmlinux (vmlinuz -> ELF vmlinux)
- Alpine: linux-virt + its own initramfs kept as template initrd (virtio_blk/ext4 are modules on this kernel)
- TemplateSpec/TemplateVersion: add initrd field; boot-source passes it through when present
- fix: Alpine panics without rootfstype=ext4 in boot_args (kernel can't guess the root fs type before ext4's module loads) — docs/bugs/alpine-official-kernel-cant-mount-root.md
- fix: install-ubuntu-roofs.sh's network-ready sentinel had no retry loop, racing DHCP (no-ipv4-address) — added the same retry loop install-alpine-rootfs.sh already had

Verified: cargo fmt/clippy/test green. Real VMs on both templates boot, get real IPs, ping/curl out. Template versions bumped (ubuntu v1->v2, alpine v1->v3) — existing v1-pinned VMs need recreating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for distribution-provided Ubuntu and Alpine kernels.
  - Alpine VMs now include the required initramfs for storage and filesystem modules.
  - Kernel and initramfs artifacts are automatically prepared and validated during image setup.

- **Bug Fixes**
  - Fixed Alpine VMs failing to mount the root filesystem and entering a kernel panic.
  - Improved Ubuntu VM network readiness to reduce startup failures.

- **Documentation**
  - Added troubleshooting guidance, root-cause analysis, verification steps, and updated task status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->