### PR TITLE
feat: install firecrab with one command on a networked machine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,8 +187,13 @@ jobs:
         # the bridge (NET_ADMIN) and a dnsmasq the helper can still signal
         # (SETUID/SETGID/NET_BIND_SERVICE/KILL).
         run: |
-          ip -br addr show fcbr0
+          # The bridge exists with its address. It reads DOWN until a VM's TAP
+          # joins it, which is normal for a bridge with no ports.
+          ip -br addr show fcbr0 | grep -q 172.30.0.1/24
           sudo pgrep -af dnsmasq | grep -q firecrab
+          # dnsmasq bound the privileged DHCP port, so NET_BIND_SERVICE held.
+          sudo ss -lun | grep -q ':67'
+          # Anything the bounding set is missing shows up here, not at startup.
           ! sudo journalctl -u firecrab-net-helper --no-pager | grep -i 'operation not permitted'
 
       - name: Dashboard and API answer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
   pull_request:
+  # The VM-boot job below is too slow for every PR but is the only thing that
+  # proves a guest actually comes up, so it runs nightly and on demand.
+  schedule:
+    - cron: "0 17 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -170,7 +175,9 @@ jobs:
           systemctl is-active --quiet firecrab-api
           # The socket's group is what lets the unprivileged API reach the
           # helper at all; getting it wrong is a silent, confusing failure.
-          stat -c '%U %G %a' /run/firecrab/net-helper.sock | tee /dev/stderr | grep -qx 'root firecrab 660'
+          # Needs sudo to look at: /run/firecrab is 0750 root:firecrab, so the
+          # runner user cannot even traverse it - which is the point.
+          sudo stat -c '%U %G %a' /run/firecrab/net-helper.sock | tee /dev/stderr | grep -qx 'root firecrab 660'
           id -nG firecrab | tr ' ' '\n' | grep -qx kvm
 
       - name: Capability set is sufficient at runtime
@@ -181,8 +188,8 @@ jobs:
         # (SETUID/SETGID/NET_BIND_SERVICE/KILL).
         run: |
           ip -br addr show fcbr0
-          pgrep -af dnsmasq | grep -q firecrab
-          ! journalctl -u firecrab-net-helper --no-pager | grep -i 'operation not permitted'
+          sudo pgrep -af dnsmasq | grep -q firecrab
+          ! sudo journalctl -u firecrab-net-helper --no-pager | grep -i 'operation not permitted'
 
       - name: Dashboard and API answer
         run: |
@@ -217,9 +224,134 @@ jobs:
       - name: Daemon logs (on failure)
         if: failure()
         run: |
-          journalctl -u firecrab-net-helper --no-pager -n 60 || true
-          journalctl -u firecrab-api --no-pager -n 60 || true
+          sudo journalctl -u firecrab-net-helper --no-pager -n 60 || true
+          sudo journalctl -u firecrab-api --no-pager -n 60 || true
           systemctl status firecrab-net-helper firecrab-api --no-pager || true
+
+  install-distro:
+    name: Installer deps (${{ matrix.image }})
+    # GitHub only hosts Ubuntu for Linux, so other distributions are covered in
+    # containers. No systemd there, hence --deps-only: what actually differs per
+    # distribution is package naming and the toolchain, and that is what this
+    # exercises. Full install with units stays on the runner VM above.
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Alpine is deliberately absent: GitHub's own action runtime is
+        # glibc-linked and will not start in a musl container, and the upstream
+        # firecracker release binary has the same problem.
+        image:
+          - debian:12
+          - fedora:latest
+          - archlinux:latest
+          - opensuse/tumbleweed
+    steps:
+      - name: Bootstrap the container
+        # Enough to run a bash script and check out the repo; the installer
+        # takes it from there.
+        run: |
+          if command -v apt-get >/dev/null; then
+            apt-get update -qq && apt-get install -y -qq bash ca-certificates curl git
+          elif command -v dnf >/dev/null; then
+            dnf install -y -q bash ca-certificates curl git
+          elif command -v pacman >/dev/null; then
+            pacman -Sy --noconfirm --needed bash ca-certificates curl git
+          elif command -v zypper >/dev/null; then
+            zypper -n install bash ca-certificates curl git
+          fi
+        shell: sh -e {0}
+
+      - uses: actions/checkout@v4
+
+      - name: --check reports this distro's package manager
+        run: ./install.sh --check
+
+      - name: --deps-only installs them for real
+        # Containers run as root, so no sudo. A distro whose node packaging we
+        # cannot name drops the dashboard with a warning instead of failing —
+        # that path is exercised here too (Fedora ships only versioned streams).
+        run: ./install.sh --deps-only
+
+      - name: Everything the daemons need is present
+        run: |
+          for command in ip nft dnsmasq mkfs.ext4 firecracker cc; do
+            command -v "$command" >/dev/null || { echo "missing: $command"; exit 1; }
+          done
+          "$HOME/.cargo/bin/cargo" --version || cargo --version
+
+  vm-boot:
+    name: VM boot (nightly)
+    # The one thing the fast install job cannot cover: building a guest image
+    # and booting it. Needs KVM, docker and ~15 minutes.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - name: KVM is available
+        # Nested virtualisation is enabled on GitHub's Linux runners, but the
+        # device is root-only by default. If this step fails, the runner image
+        # has changed and this job cannot do its work — say so plainly instead
+        # of failing later with a confusing Firecracker error.
+        run: |
+          test -e /dev/kvm || { echo "no /dev/kvm on this runner"; exit 1; }
+          sudo chmod 666 /dev/kvm
+          ls -l /dev/kvm
+
+      - name: Install with a guest image
+        run: sudo -E env "PATH=$PATH" ./install.sh
+
+      - name: A template is registered
+        run: |
+          sudo ls -l /var/lib/firecrab/images/rootfs/
+          curl -fsS http://127.0.0.1:3000/api/vms
+
+      - name: Create, start and reach running
+        run: |
+          set -o pipefail
+          VM=$(curl -fsS -X POST http://127.0.0.1:3000/api/vms \
+                 -H 'content-type: application/json' \
+                 -d '{"name":"ci-boot","template":"alpine-3.24","cpu":1,"ram":512,"diskGb":2}' \
+               | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+          echo "VM=$VM" >> "$GITHUB_ENV"
+          curl -fsS -X POST "http://127.0.0.1:3000/api/vms/$VM/start" --max-time 180 > /dev/null
+          state=$(curl -fsS "http://127.0.0.1:3000/api/vms/$VM" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["state"], d.get("ipv4"))')
+          echo "state: $state"
+          case "$state" in running*) ;; *) echo "did not reach running"; exit 1 ;; esac
+
+      - name: The guest answers on its leased address
+        run: |
+          ipv4=$(curl -fsS "http://127.0.0.1:3000/api/vms/$VM" | python3 -c 'import json,sys; print(json.load(sys.stdin)["ipv4"])')
+          ping -c 3 -W 5 "$ipv4"
+
+      - name: Stop and delete
+        run: |
+          curl -fsS -X POST "http://127.0.0.1:3000/api/vms/$VM/stop" --max-time 120 > /dev/null
+          curl -fsS -X DELETE "http://127.0.0.1:3000/api/vms/$VM"
+
+      - name: Console log and journals (on failure)
+        if: failure()
+        run: |
+          sudo tail -n 120 /var/lib/firecrab/data/vms/*/console.log || true
+          sudo journalctl -u firecrab-api --no-pager -n 80 || true
+          sudo journalctl -u firecrab-net-helper --no-pager -n 80 || true
 
   frontend:
     name: Frontend (lint, typecheck, build)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,106 @@ jobs:
               sys.exit(1)
           PY
 
+  install:
+    name: Installer (shellcheck, --check, install/uninstall)
+    # A GitHub-hosted Linux runner is a throwaway VM with systemd, so the whole
+    # installer can be exercised for real — the one thing this cannot cover is
+    # booting a guest, which needs an image build (see --no-images below).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - name: shellcheck
+        run: shellcheck install.sh
+
+      - name: --help and --check
+        # --check has to work unprivileged and change nothing; a check that
+        # quietly mutates is worse than no check.
+        run: |
+          ./install.sh --help
+          ./install.sh --check
+          test ! -e /var/lib/firecrab || { echo "--check created the data directory"; exit 1; }
+
+      - name: Install
+        # --no-images: building a guest rootfs needs docker and ~10 minutes.
+        # Everything else — deps, account, directories, units, dashboard — is real.
+        #
+        # PATH is carried into sudo on purpose: rustup lives in the runner
+        # user's home, and without it the installer would decide cargo is
+        # missing and fetch a second toolchain for root, ignoring the cache.
+        run: sudo -E env "PATH=$PATH" ./install.sh --no-images
+
+      - name: Both daemons are up
+        run: |
+          systemctl is-active --quiet firecrab-net-helper
+          systemctl is-active --quiet firecrab-api
+          # The socket's group is what lets the unprivileged API reach the
+          # helper at all; getting it wrong is a silent, confusing failure.
+          stat -c '%U %G %a' /run/firecrab/net-helper.sock | tee /dev/stderr | grep -qx 'root firecrab 660'
+          id -nG firecrab | tr ' ' '\n' | grep -qx kvm
+
+      - name: Capability set is sufficient at runtime
+        # The helper runs as uid 0 with a bounded capability set. A missing
+        # capability does not stop it starting - it breaks one operation later,
+        # so assert the operations that actually need each one have happened:
+        # the bridge (NET_ADMIN) and a dnsmasq the helper can still signal
+        # (SETUID/SETGID/NET_BIND_SERVICE/KILL).
+        run: |
+          ip -br addr show fcbr0
+          pgrep -af dnsmasq | grep -q firecrab
+          ! journalctl -u firecrab-net-helper --no-pager | grep -i 'operation not permitted'
+
+      - name: Dashboard and API answer
+        run: |
+          curl -fsS -o /dev/null -w 'dashboard %{http_code} %{content_type}\n' http://127.0.0.1:3000/
+          test "$(curl -fsS http://127.0.0.1:3000/api/vms)" = '[]'
+          # A state-changing request from the dashboard's own origin must not be
+          # turned away by the origin check (see server.rs's is_same_origin).
+          curl -fsS -X POST http://127.0.0.1:3000/api/micro-networks \
+               -H 'Origin: http://127.0.0.1:3000' -H 'content-type: application/json' \
+               -d '{"name":"ci","subnetCidr":"172.31.0.0/24"}' > /dev/null
+          # ... while another site's is.
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:3000/api/micro-networks \
+               -H 'Origin: http://evil.example' -H 'content-type: application/json' \
+               -d '{"name":"nope","subnetCidr":"172.32.0.0/24"}')" = 403
+
+      - name: Re-running is safe
+        run: |
+          sudo -E env "PATH=$PATH" ./install.sh --no-images
+          systemctl is-active --quiet firecrab-api
+          # The MicroNetwork created above has to survive a re-install.
+          curl -fsS http://127.0.0.1:3000/api/micro-networks | grep -q '"ci"'
+
+      - name: Uninstall keeps data, purge removes it
+        run: |
+          sudo ./install.sh --uninstall
+          ! systemctl is-active --quiet firecrab-api
+          test ! -e /etc/systemd/system/firecrab-api.service
+          test -d /var/lib/firecrab
+          sudo ./install.sh --uninstall --purge
+          test ! -e /var/lib/firecrab
+
+      - name: Daemon logs (on failure)
+        if: failure()
+        run: |
+          journalctl -u firecrab-net-helper --no-pager -n 60 || true
+          journalctl -u firecrab-api --no-pager -n 60 || true
+          systemctl status firecrab-net-helper firecrab-api --no-pager || true
+
   frontend:
     name: Frontend (lint, typecheck, build)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +648,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -1227,6 +1243,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,8 +1279,19 @@ checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
+ "futures-core",
+ "futures-util",
  "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
 ]
@@ -1351,6 +1391,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"

--- a/README.ja.md
+++ b/README.ja.md
@@ -63,8 +63,8 @@ sudo ./install.sh --uninstall   # デーモンを削除。--purge を付けな�
 ```
 
 KVM だけは代わりに導入できません — `/dev/kvm` が無い場合は BIOS で仮想化を有効に
-してください(このホスト自体が VM ならネステッド仮想化)。詳細は
-[docs/task-host-install-script.md](docs/task-host-install-script.md) を参照。
+してください(このホスト自体が VM ならネステッド仮想化)。オプション・配置場所・アップグレード・アンインストール・トラブルシュートは
+[docs/install.md](docs/install.md) を参照。
 
 ## ソースから実行(開発)
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,26 +42,57 @@ Rust で書かれた API サーバー（`firecrab-api`）が VM の状態を SQL
 - WebSocket によるリアルタイムシリアルコンソール
 - SQLite によるステート管理、権限分離された helper プロセスによるホストネットワーク分離
 
-## クイックスタート
+## インストール(推奨)
 
-### ターミナルセッション 1 — API サーバー
-
-VM の状態管理と Firecracker プロセスの制御を担う Rust 製 REST API サーバー(`http://localhost:3000`)。
+KVM が使えてネットワークにつながる Linux ホストであれば:
 
 ```sh
-cargo run -p firecrab-api
+git clone https://github.com/SteelCrab/firecrab && cd firecrab
+sudo ./install.sh
 ```
 
-### ターミナルセッション 2 — フロントエンド
-
-VM の作成・確認・コンソール接続用 React ダッシュボードの開発サーバー(`http://localhost:8080`)。
+これだけです。インストーラーが足りないものを自分で見つけて導入します — パッケージは
+ホストにある管理コマンド(apt/dnf/zypper/pacman/apk)経由で、さらに Firecracker、
+Rust ツールチェーン、ゲストイメージまで。そのうえでサービスアカウントを作成し、
+systemd デーモン 2 つを導入して `http://127.0.0.1:3000/` にダッシュボードを提供します。
+再実行しても安全で、重複ではなく修復として動きます。
 
 ```sh
-cd firecrab-frontend
-npm run dev
+./install.sh --check            # 何が足りないかを先に確認(root 不要・変更なし)
+sudo ./install.sh --uninstall   # デーモンを削除。--purge を付けなければ VM データは残る
+```
+
+KVM だけは代わりに導入できません — `/dev/kvm` が無い場合は BIOS で仮想化を有効に
+してください(このホスト自体が VM ならネステッド仮想化)。詳細は
+[docs/task-host-install-script.md](docs/task-host-install-script.md) を参照。
+
+## ソースから実行(開発)
+
+インストールせずターミナル 3 つで動かします — 特権ネットワークヘルパー、API、そして
+ブラウザから API へ届かせるプロキシ付きの Vite 開発サーバーです。
+
+```sh
+# 1 — 特権ネットワークヘルパー(bridge, TAP, ファイアウォール, DHCP)
+cargo build -p firecrab-net-helper
+sudo -u root -g "$(id -gn)" FIRECRAB_NET_HELPER_ALLOWED_UID="$(id -u)" \
+     ./target/debug/firecrab-net-helper
+
+# 2 — API サーバー(リポジトリのルートで実行 — パスは作業ディレクトリ基準)
+cargo run -p firecrab-api
+
+# 3 — ダッシュボード開発サーバー
+cd firecrab-frontend && npm run dev
 ```
 
 `http://localhost:8080/` を開く。使い方の詳細は [docs/web.md](docs/web.md) を参照。
+
+3 番目のターミナルを使わず、ビルド済みダッシュボードを API から配信することもできます。
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
+# http://localhost:3000/
+```
 
 ## ライセンス
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -40,28 +40,56 @@ Unix 소켓을 통해서만 처리하며, API 서버 자체는 비특권 프로�
 - WebSocket 기반 실시간 시리얼 콘솔
 - SQLite 상태 저장, 권한 분리된 helper 프로세스를 통한 호스트 네트워크 격리
 
-## 빠른 시작
+## 설치 (권장)
 
-### 터미널 세션 1 — API 서버
-
-- `firecrab-api`: Rust REST API 서버(`http://localhost:3000`)
-- VM 상태 저장, Firecracker 프로세스 관리
+KVM과 네트워크만 되는 리눅스 호스트라면:
 
 ```sh
-cargo run -p firecrab-api
+git clone https://github.com/SteelCrab/firecrab && cd firecrab
+sudo ./install.sh
 ```
 
-### 터미널 세션 2 — 프론트엔드
-
-- `firecrab-frontend`: React 대시보드 개발 서버(`http://localhost:8080`)
-- VM 생성·조회 UI, 콘솔 접속 제공
+이게 전부입니다. 설치 스크립트가 없는 것을 찾아 직접 채웁니다 — 패키지는 호스트에 있는
+관리자(apt/dnf/zypper/pacman/apk)로, Firecracker·Rust 툴체인·게스트 이미지까지. 그다음
+서비스 계정을 만들고 systemd 데몬 2개를 설치해 `http://127.0.0.1:3000/`에 대시보드를 띄웁니다.
+다시 실행해도 안전합니다 — 중복이 아니라 복구로 동작합니다.
 
 ```sh
-cd firecrab-frontend
-npm run dev
+./install.sh --check            # 무엇이 없는지 먼저 확인 (root 불필요, 아무것도 바꾸지 않음)
+sudo ./install.sh --uninstall   # 데몬 제거. --purge 없이는 VM 데이터 보존
+```
+
+KVM은 스크립트가 대신 설치할 수 없는 유일한 항목입니다 — `/dev/kvm`이 없으면 BIOS에서
+가상화를 켜세요(이 호스트가 VM이면 중첩 가상화). 자세한 내용은
+[docs/task-host-install-script.md](docs/task-host-install-script.md)를 참고하세요.
+
+## 소스에서 실행 (개발)
+
+설치 없이 터미널 3개로 띄웁니다 — 특권 네트워크 헬퍼, API, 그리고 브라우저가 API에 닿게
+해주는 프록시가 붙은 Vite 개발 서버입니다.
+
+```sh
+# 1 — 특권 네트워크 헬퍼 (bridge, TAP, 방화벽, DHCP)
+cargo build -p firecrab-net-helper
+sudo -u root -g "$(id -gn)" FIRECRAB_NET_HELPER_ALLOWED_UID="$(id -u)" \
+     ./target/debug/firecrab-net-helper
+
+# 2 — API 서버 (저장소 루트에서 실행 — 경로가 작업 디렉터리 기준입니다)
+cargo run -p firecrab-api
+
+# 3 — 대시보드 개발 서버
+cd firecrab-frontend && npm run dev
 ```
 
 `http://localhost:8080/`에 접속하세요. 전체 사용법은 [docs/web.md](docs/web.md)를 참고하세요.
+
+3번 터미널 없이 빌드된 대시보드를 API가 직접 서빙하게 할 수도 있습니다.
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
+# http://localhost:3000/
+```
 
 ## 라이선스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -60,8 +60,8 @@ sudo ./install.sh --uninstall   # 데몬 제거. --purge 없이는 VM 데이터 
 ```
 
 KVM은 스크립트가 대신 설치할 수 없는 유일한 항목입니다 — `/dev/kvm`이 없으면 BIOS에서
-가상화를 켜세요(이 호스트가 VM이면 중첩 가상화). 자세한 내용은
-[docs/task-host-install-script.md](docs/task-host-install-script.md)를 참고하세요.
+가상화를 켜세요(이 호스트가 VM이면 중첩 가상화). 옵션·설치 위치·업그레이드·제거·문제 해결은
+[docs/install.md](docs/install.md)에 정리돼 있습니다.
 
 ## 소스에서 실행 (개발)
 

--- a/README.md
+++ b/README.md
@@ -42,26 +42,58 @@ their integrity by hash. Host network operations that need root — bridge, TAP,
 - Live serial console over WebSocket
 - SQLite-backed state, host network isolation via a privileged helper process
 
-## Quick start
+## Install (recommended)
 
-### Terminal session 1 — API server
-
-The Rust REST API server that stores VM state and manages Firecracker processes (`http://localhost:3000`).
+On any Linux host with KVM and network access:
 
 ```sh
-cargo run -p firecrab-api
+git clone https://github.com/SteelCrab/firecrab && cd firecrab
+sudo ./install.sh
 ```
 
-### Terminal session 2 — Frontend
-
-The React dashboard dev server for creating/viewing VMs and attaching to their console (`http://localhost:8080`).
+That is the whole thing. The installer finds what is missing and installs it —
+packages via whichever manager the host has (apt/dnf/zypper/pacman/apk), Firecracker,
+the Rust toolchain, and a guest image — then creates the service account, installs two
+systemd daemons, and serves the dashboard at `http://127.0.0.1:3000/`. Re-running it is
+safe; it repairs instead of duplicating.
 
 ```sh
-cd firecrab-frontend
-npm run dev
+./install.sh --check       # see what is missing first (no root, changes nothing)
+sudo ./install.sh --uninstall   # remove the daemons; VM data is kept unless --purge
+```
+
+KVM is the one thing it cannot install for you — if `/dev/kvm` is missing, enable
+virtualization in the BIOS (or nested virtualization, if this host is itself a VM).
+See [docs/task-host-install-script.md](docs/task-host-install-script.md) for the details.
+
+## Run from source (development)
+
+Three terminals, no installation: the privileged network helper, the API, and the Vite
+dev server whose proxy lets the browser reach the API.
+
+```sh
+# 1 — privileged network helper (bridge, TAP, firewall, DHCP)
+cargo build -p firecrab-net-helper
+sudo -u root -g "$(id -gn)" FIRECRAB_NET_HELPER_ALLOWED_UID="$(id -u)" \
+     ./target/debug/firecrab-net-helper
+
+# 2 — API server (run from the repo root: paths are relative to the working directory)
+cargo run -p firecrab-api
+
+# 3 — dashboard dev server
+cd firecrab-frontend && npm run dev
 ```
 
 Open `http://localhost:8080/`. See [docs/web.md](docs/web.md) for the full walkthrough.
+
+To serve the built dashboard from the API instead of running the third terminal, point
+it at the build output:
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
+# http://localhost:3000/
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ sudo ./install.sh --uninstall   # remove the daemons; VM data is kept unless --p
 
 KVM is the one thing it cannot install for you — if `/dev/kvm` is missing, enable
 virtualization in the BIOS (or nested virtualization, if this host is itself a VM).
-See [docs/task-host-install-script.md](docs/task-host-install-script.md) for the details.
+Full usage — options, layout, upgrades, uninstall, troubleshooting — is in
+[docs/install.md](docs/install.md).
 
 ## Run from source (development)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -59,8 +59,8 @@ sudo ./install.sh --uninstall   # 移除守护进程；不加 --purge 则保留 
 ```
 
 KVM 是唯一无法替你安装的东西 —— 如果没有 `/dev/kvm`，请在 BIOS 中开启虚拟化
-（若该主机本身是虚拟机，则开启嵌套虚拟化）。详情见
-[docs/task-host-install-script.md](docs/task-host-install-script.md)。
+（若该主机本身是虚拟机，则开启嵌套虚拟化）。完整用法（选项、安装位置、升级、卸载、故障排查）见
+[docs/install.md](docs/install.md)。
 
 ## 从源码运行（开发）
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -39,26 +39,55 @@ firecrab 是一个轻量级控制平面，用于在自建 Linux 主机上基于
 - 基于 WebSocket 的实时串行控制台
 - SQLite 状态存储，通过特权 helper 进程实现主机网络隔离
 
-## 快速开始
+## 安装（推荐）
 
-### 终端会话 1 — API 服务器
-
-负责存储 VM 状态并管理 Firecracker 进程的 Rust REST API 服务器（`http://localhost:3000`）。
+只要是支持 KVM 且能联网的 Linux 主机：
 
 ```sh
-cargo run -p firecrab-api
+git clone https://github.com/SteelCrab/firecrab && cd firecrab
+sudo ./install.sh
 ```
 
-### 终端会话 2 — 前端
-
-用于创建/查看 VM 并连接控制台的 React 仪表盘开发服务器（`http://localhost:8080`）。
+这就够了。安装脚本会自行找出缺失的部分并装好 —— 用主机自带的包管理器
+（apt/dnf/zypper/pacman/apk）安装依赖，再装 Firecracker、Rust 工具链和一个客户机镜像，
+然后创建服务账户、安装两个 systemd 守护进程，并在 `http://127.0.0.1:3000/` 提供仪表盘。
+重复执行是安全的 —— 它会修复而不是重复安装。
 
 ```sh
-cd firecrab-frontend
-npm run dev
+./install.sh --check            # 先看缺什么（无需 root，不改动任何东西）
+sudo ./install.sh --uninstall   # 移除守护进程；不加 --purge 则保留 VM 数据
+```
+
+KVM 是唯一无法替你安装的东西 —— 如果没有 `/dev/kvm`，请在 BIOS 中开启虚拟化
+（若该主机本身是虚拟机，则开启嵌套虚拟化）。详情见
+[docs/task-host-install-script.md](docs/task-host-install-script.md)。
+
+## 从源码运行（开发）
+
+无需安装，三个终端：特权网络 helper、API，以及带代理、让浏览器能访问 API 的 Vite 开发服务器。
+
+```sh
+# 1 — 特权网络 helper（bridge、TAP、防火墙、DHCP）
+cargo build -p firecrab-net-helper
+sudo -u root -g "$(id -gn)" FIRECRAB_NET_HELPER_ALLOWED_UID="$(id -u)" \
+     ./target/debug/firecrab-net-helper
+
+# 2 — API 服务器（在仓库根目录运行：路径相对于工作目录）
+cargo run -p firecrab-api
+
+# 3 — 仪表盘开发服务器
+cd firecrab-frontend && npm run dev
 ```
 
 打开 `http://localhost:8080/`。完整使用说明见 [docs/web.md](docs/web.md)。
+
+也可以让 API 直接提供已构建的仪表盘，省掉第三个终端：
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
+# http://localhost:3000/
+```
 
 ## 许可证
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,7 @@ RUST_LOG=firecrab_api=debug cargo run
 | `FIRECRAB_ALLOWED_ORIGINS` | `http://localhost:8080` (비-production) | 콤마로 구분된 허용 Origin 목록. CORS 및 `Origin` 헤더 검사에 사용 |
 | `FIRECRAB_IMAGE_ROOT` | `../images` (crate 기준 상대경로) | 템플릿 커널/rootfs 이미지가 위치한 루트 디렉터리 |
 | `FIRECRAB_FIRECRACKER_BIN` | `firecracker` (PATH 탐색) | VM 시작 시 실행할 Firecracker 바이너리 경로 |
-| `FIRECRAB_STATIC_ROOT` | (없음) | 대시보드 빌드 산출물(`dist/`) 경로. 지정하면 API가 직접 서빙하고 없는 경로는 `index.html`로 폴백. `index.html`이 없으면 무시하고 경고만 남김 |
+| `FIRECRAB_STATIC_ROOT` | (없음, 설치 시 유닛이 지정 — [install.md](install.md)) | 대시보드 빌드 산출물(`dist/`) 경로. 지정하면 API가 직접 서빙하고 없는 경로는 `index.html`로 폴백. `index.html`이 없으면 무시하고 경고만 남김 |
 
 ### 네트워크 helper 상태
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,7 @@ RUST_LOG=firecrab_api=debug cargo run
 | `FIRECRAB_ALLOWED_ORIGINS` | `http://localhost:8080` (비-production) | 콤마로 구분된 허용 Origin 목록. CORS 및 `Origin` 헤더 검사에 사용 |
 | `FIRECRAB_IMAGE_ROOT` | `../images` (crate 기준 상대경로) | 템플릿 커널/rootfs 이미지가 위치한 루트 디렉터리 |
 | `FIRECRAB_FIRECRACKER_BIN` | `firecracker` (PATH 탐색) | VM 시작 시 실행할 Firecracker 바이너리 경로 |
+| `FIRECRAB_STATIC_ROOT` | (없음) | 대시보드 빌드 산출물(`dist/`) 경로. 지정하면 API가 직접 서빙하고 없는 경로는 `index.html`로 폴백. `index.html`이 없으면 무시하고 경고만 남김 |
 
 ### 네트워크 helper 상태
 

--- a/docs/browser-test.md
+++ b/docs/browser-test.md
@@ -81,5 +81,5 @@ FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
 ```
 
 설치 스크립트(`./install.sh`)가 이 경로를 systemd 유닛에 넣어 주므로, 설치한 호스트에서는
-데몬 2개(net-helper, api)만으로 대시보드가 뜬다 — `docs/task-host-install-script.md`.
+데몬 2개(net-helper, api)만으로 대시보드가 뜬다 — 사용법은 [install.md](install.md).
 지정하지 않으면 예전처럼 API만 서빙하고, 개발은 아래 dev 서버 방식을 그대로 쓴다.

--- a/docs/browser-test.md
+++ b/docs/browser-test.md
@@ -70,7 +70,16 @@ Rust 툴체인 없이 `npm run dev`/`build`만으로 동작해야 하기 때문.
 
 ## 프로덕션 배포
 
-`firecrab-api`에는 정적 파일 서빙 코드가 없다 — 지금은 dev/production 구분 없이 두 프로세스(API +
-프록시 낀 프론트 dev 서버)로 동작한다. 단일 배포 아티팩트가 필요해지면 `tower-http`의 `ServeDir`로
-`npm run build`의 `dist/`를 `firecrab-api`가 직접 서빙하는 옵션을 추가할 수 있다(아직 미구현,
-`docs/task-packaging-systemd-upgrades.md` 범위).
+`FIRECRAB_STATIC_ROOT`에 `npm run build`의 `dist/`를 가리키면 `firecrab-api`가 대시보드를 직접
+서빙한다(`tower-http`의 `ServeDir` + SPA fallback). 그러면 Vite dev 서버가 필요 없고, 같은 origin이라
+`FIRECRAB_ALLOWED_ORIGINS`도 비워도 된다.
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
+# http://localhost:3000/
+```
+
+설치 스크립트(`./install.sh`)가 이 경로를 systemd 유닛에 넣어 주므로, 설치한 호스트에서는
+데몬 2개(net-helper, api)만으로 대시보드가 뜬다 — `docs/task-host-install-script.md`.
+지정하지 않으면 예전처럼 API만 서빙하고, 개발은 아래 dev 서버 방식을 그대로 쓴다.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,174 @@
+# 설치 (`install.sh`)
+
+`install.sh`는 리눅스 호스트 하나에 firecrab을 올린다. 없는 것을 찾아 설치하고, 빌드하고,
+systemd 데몬 2개(`firecrab-net-helper`, `firecrab-api`)를 띄우고, 대시보드까지 서빙한다.
+
+```sh
+git clone https://github.com/SteelCrab/firecrab && cd firecrab
+sudo ./install.sh
+```
+
+끝나면 `http://127.0.0.1:3000/`에서 대시보드가 뜬다. 개발용 3터미널 실행은
+[browser-test.md](browser-test.md)를 참고한다.
+
+## 요구사항
+
+| 항목 | 필요 | 없으면 |
+|---|---|---|
+| 리눅스 + systemd | 필수 | 유닛을 설치할 수 없어 중단 |
+| KVM (`/dev/kvm`) | 필수 | 설치는 계속되지만 VM이 시작되지 않음 — **스크립트가 대신 설치할 수 없는 유일한 항목** |
+| 네트워크 | 필수 | 패키지·firecracker·이미지를 받지 못함 |
+| root | 필수 (`--check`는 예외) | `sudo ./install.sh` |
+| 패키지 관리자 | apt-get / dnf / zypper / pacman / apk | 감지 실패 시 부족한 것을 안내만 하고 직접 설치해야 함 |
+
+KVM이 없다는 건 보통 BIOS에서 가상화가 꺼져 있거나, 이 호스트 자체가 VM인데 중첩 가상화가
+없는 경우다.
+
+## 먼저 확인만 하기
+
+```sh
+./install.sh --check
+```
+
+- **root 불필요**, 파일을 하나도 바꾸지 않는다
+- 무엇이 없고 무엇을 설치할지, KVM·systemd·이미지·UFW 상태까지 보고한다
+
+## 옵션
+
+| 옵션 | 동작 |
+|---|---|
+| (없음) | 없는 것을 설치하고 빌드·배치·기동까지 |
+| `--check` | 보고만. root 불필요, 무변경 |
+| `--no-deps` | 아무것도 설치하지 않고 부족한 것만 보고 (직접 준비한 호스트용) |
+| `--no-images` | 게스트 이미지를 준비하지 않음 |
+| `--with-ubuntu-image` | Alpine 외에 Ubuntu 이미지도 빌드 (용량 큼, root chroot 필요) |
+| `--no-frontend` | 대시보드를 빌드·설치하지 않음 (API만) |
+| `--uninstall` | 유닛·바이너리·대시보드 제거. **데이터는 보존** |
+| `--uninstall --purge` | 데이터 디렉터리까지 삭제 (VM 디스크·DB 전부) |
+| `-h`, `--help` | 도움말 |
+
+## 환경 변수
+
+경로와 계정 이름을 바꿀 수 있다. 지정하지 않으면 아래 기본값을 쓴다.
+
+| 변수 | 기본값 |
+|---|---|
+| `FIRECRAB_USER` / `FIRECRAB_GROUP` | `firecrab` / `firecrab` |
+| `PREFIX` | `/usr/local` (바이너리 `$PREFIX/lib/firecrab`, 대시보드 `$PREFIX/share/firecrab`) |
+| `DATADIR` | `/var/lib/firecrab` |
+| `CONFDIR` | `/etc/firecrab` |
+| `UNITDIR` | `/etc/systemd/system` |
+
+```sh
+sudo DATADIR=/srv/firecrab PREFIX=/opt ./install.sh
+```
+
+## 설치가 하는 일
+
+순서대로 진행하고, 각 단계는 이미 되어 있으면 건너뛴다.
+
+1. **의존성** — `ip`, `nft`, `dnsmasq`, `mkfs.ext4`, `curl`을 감지된 패키지 관리자로 설치
+   (`apt-get update`는 한 번만 실행)
+2. **firecracker** — 없으면 [`scripts/install-firecracker.sh`](../scripts/install-firecracker.sh)로 설치
+3. **빌드 도구** — `cargo`가 없으면 rustup 비대화형 설치, 대시보드를 만들 때만 `npm`
+4. **검사** — KVM(경고만), systemd(없으면 중단)
+5. **빌드** — `cargo build --release --workspace`, `npm ci && npm run build`
+6. **계정** — 시스템 사용자 `firecrab` 생성 + `kvm` 그룹 편입(firecracker가 `/dev/kvm`을 연다)
+7. **디렉터리** — `$DATADIR/{data,images}`(0750, firecrab 소유), `$CONFDIR`(0750, root:firecrab)
+8. **배치** — 바이너리, 대시보드, `$CONFDIR/api.env`(이미 있으면 보존)
+9. **유닛** — [`packaging/systemd/`](../packaging/systemd) 템플릿을 치환해 설치 후 `daemon-reload`
+10. **이미지** — 저장소에 있으면 복사, 없으면 docker로 Alpine 이미지 빌드
+11. **기동** — `systemctl enable --now` 후 두 유닛이 실제로 active인지 확인
+
+이미지 단계는 실패해도 경고만 남기고 계속 간다. 이미지가 없는 템플릿은 API가 건너뛰므로
+대시보드와 MicroNetwork는 그대로 동작하고, 이미지는 나중에 넣으면 된다.
+
+## 설치 후 배치
+
+| 경로 | 내용 |
+|---|---|
+| `/usr/local/lib/firecrab/` | `firecrab-api`, `firecrab-net-helper` |
+| `/usr/local/share/firecrab/dashboard/` | 빌드된 대시보드 정적 파일 |
+| `/var/lib/firecrab/data/` | SQLite DB, VM 아티팩트(`vms/<id>/`) |
+| `/var/lib/firecrab/images/` | 커널·rootfs 이미지 |
+| `/etc/firecrab/api.env` | API 설정(재설치해도 보존) |
+| `/run/firecrab/net-helper.sock` | helper 소켓 (`srw-rw---- root firecrab`) |
+| `/etc/systemd/system/firecrab-*.service` | 유닛 2개 |
+
+## 확인
+
+```sh
+systemctl status firecrab-net-helper firecrab-api   # 둘 다 active
+ls -l /run/firecrab/net-helper.sock                 # 그룹이 firecrab이어야 함
+sudo -u firecrab id                                 # kvm 그룹 포함
+curl -s -o /dev/null -w '%{http_code}\n' localhost:3000/   # 200 (대시보드)
+curl -s localhost:3000/api/vms                             # []
+```
+
+브라우저에서 `http://127.0.0.1:3000/` → VM 생성 → start → `running` 도달까지 확인한다.
+자세한 절차는 [tests/host-install.md](tests/host-install.md).
+
+## 운영
+
+```sh
+journalctl -u firecrab-api -f          # 로그
+journalctl -u firecrab-net-helper -f
+systemctl restart firecrab-api         # 설정 변경 후
+```
+
+- **설정 변경**: `/etc/firecrab/api.env` 수정 → `systemctl restart firecrab-api`
+  (사용 가능한 변수는 [api.md](api.md)의 환경 변수 표 참고)
+- **업그레이드**: `git pull` 후 `sudo ./install.sh` 재실행 — 빌드·배치만 갱신되고
+  데이터와 `api.env`는 그대로
+- **이미지 추가**: `$DATADIR/images/`에 넣고 `systemctl restart firecrab-api`
+  (템플릿 파일명은 `firecrab-api/src/templates.rs`의 `default_specs()` 기준)
+
+## 제거
+
+```sh
+sudo ./install.sh --uninstall           # 유닛·바이너리·대시보드만
+sudo ./install.sh --uninstall --purge   # 데이터까지 (되돌릴 수 없음)
+```
+
+- 남는 것: 서비스 계정, `$CONFDIR`, `$DATADIR` (`--purge` 없이는)
+- bridge와 nftables 테이블은 helper 소유라 데몬이 멈추면 다음 재부팅에 사라진다
+- 패키지(dnsmasq, firecracker 등)는 지우지 않는다 — 다른 용도로 쓰고 있을 수 있으므로
+
+## 문제 해결
+
+| 증상 | 원인·조치 |
+|---|---|
+| `--check`가 `/dev/kvm missing` | BIOS에서 가상화 활성화. 이 호스트가 VM이면 중첩 가상화 필요 |
+| `firecrab-api`가 helper에 연결 실패 | 소켓 그룹 확인(`ls -l /run/firecrab/net-helper.sock`). 유닛의 `Group=`이 API 계정과 같아야 함 |
+| VM 생성 폼에 템플릿이 없음 | 이미지 미설치. `$DATADIR/images/` 확인 후 API 재시작 |
+| guest가 `no-ipv4-address`로 실패 | UFW가 새 브리지의 DHCP를 막음 → [troubleshooting.md](troubleshooting.md) |
+| VM은 뜨는데 외부 통신 불가 | UFW가 라우팅 기본 거부 → [bugs/vm-outbound-forward-blocked-by-ufw.md](bugs/vm-outbound-forward-blocked-by-ufw.md) |
+| `no such column` 류 DB 오류 | 잘못된 작업 디렉터리에서 실행. 유닛은 `WorkingDirectory`가 고정돼 있으므로 손으로 띄운 프로세스가 남아 있는지 확인 |
+| arm64에서 VM이 안 뜸 | 이미지 파일명과 `console=ttyS0`가 x86_64 전용 — 아직 미지원 |
+
+## CI 검증
+
+`.github/workflows/ci.yml`의 `install` job이 PR마다 일회용 러너에서 실제로 설치한다.
+
+| 단계 | 확인하는 것 |
+|---|---|
+| shellcheck | 인용·단어 분리 실수 |
+| `--check` | 비특권 동작 + `/var/lib/firecrab`을 만들지 않음 |
+| `sudo ./install.sh --no-images` | 계정·디렉터리·유닛·기동 |
+| 소켓·그룹 확인 | `root firecrab 660`, firecrab이 kvm 그룹 |
+| capability | `fcbr0` 생성, dnsmasq 생존, `operation not permitted` 없음 |
+| HTTP | 대시보드 200, `/api/vms` `[]`, 같은 origin POST 통과 / 타 사이트 403 |
+| 재실행 | 멱등성 + 기존 MicroNetwork 보존 |
+| 제거 | `--uninstall`은 데이터 보존, `--purge`는 삭제 |
+
+게스트 이미지 빌드(=VM 부팅)는 docker와 10분 이상이 필요해 범위 밖이다.
+
+## 관련 문서
+
+- 설계 배경과 완료 기준: [task-host-install-script.md](task-host-install-script.md),
+  [task-host-systemd-daemons.md](task-host-systemd-daemons.md),
+  [task-host-frontend-serving.md](task-host-frontend-serving.md)
+- 검증 절차: [tests/host-install.md](tests/host-install.md)
+- API 설정·엔드포인트: [api.md](api.md)
+- 개발용 실행(3터미널): [browser-test.md](browser-test.md)
+- 특권 helper: [net-helper.md](net-helper.md)

--- a/docs/install.md
+++ b/docs/install.md
@@ -156,7 +156,7 @@ sudo ./install.sh --uninstall --purge   # 데이터까지 (되돌릴 수 없음)
 | `--check` | 비특권 동작 + `/var/lib/firecrab`을 만들지 않음 |
 | `sudo ./install.sh --no-images` | 계정·디렉터리·유닛·기동 |
 | 소켓·그룹 확인 | `root firecrab 660`, firecrab이 kvm 그룹 |
-| capability | `fcbr0` 생성, dnsmasq 생존, `operation not permitted` 없음 |
+| capability | `fcbr0` 주소, dnsmasq 생존, 67번 포트 바인딩, `operation not permitted` 없음 |
 | HTTP | 대시보드 200, `/api/vms` `[]`, 같은 origin POST 통과 / 타 사이트 403 |
 | 재실행 | 멱등성 + 기존 MicroNetwork 보존 |
 | 제거 | `--uninstall`은 데이터 보존, `--purge`는 삭제 |

--- a/docs/task-host-frontend-serving.md
+++ b/docs/task-host-frontend-serving.md
@@ -3,7 +3,7 @@ tags:
   - firecrab
   - host
   - frontend
-status: 미완료
+status: 완료
 scope: 4주차
 updated: 2026-07-29
 ---
@@ -36,11 +36,27 @@ updated: 2026-07-29
 - dev 흐름은 그대로 유지 — dist가 없으면 서빙을 끄고 안내만(개발자는 계속 `npm run dev` 사용)
 - 같은 origin에서 서빙되므로 CORS 허용 origin이 필요 없어짐 — 설정 문서 갱신
 
+## 구현 (2026-07-29)
+
+- `HttpConfig.static_root` — `FIRECRAB_STATIC_ROOT`로 지정. **`index.html`이 있을 때만** 켜짐
+  (반쯤 빌드된 `dist/`가 라우터 fallback을 가로채지 않게, 없으면 경고만 남기고 API만 서빙)
+- `ServeDir(root).fallback(ServeFile(index.html))`을 라우터 fallback으로 —
+  실제 파일이 있으면 그 파일, 없으면 `index.html`(브라우저에서 `/vms/<id>` 새로고침이 404가 되면 안 됨)
+- `/api/{*rest}`·`/ws/{*rest}` catch-all을 먼저 둬서 **오타 난 API 경로는 계속 JSON 404** —
+  HTML이 돌아오면 클라이언트가 파싱에서 죽는다
+- dev 흐름 무변경: `FIRECRAB_STATIC_ROOT`를 안 주면 예전과 똑같이 동작
+
 ## 완료 기준
 
 - 운영에서 **데몬 2개**(net-helper, api)만으로 브라우저 대시보드가 동작
 - 터미널 접속·WebSocket 콘솔이 같은 포트에서 그대로 동작
 - `npm run dev` 개발 흐름에 회귀 없음
+
+> [!note] 실제 확인 (2026-07-29)
+> 빌드된 `dist/`를 가리켜 API를 띄우고 확인:
+> `/` → 200 text/html, `/assets/*.js` → 200 text/javascript,
+> `/vms/abc` → 200(SPA fallback), `/api/vms` → 200,
+> `/api/nope` → JSON 404, `/ws/vms/<id>/console` → WebSocket 핸들러 도달(catch-all에 안 가려짐).
 
 ## 참고
 

--- a/docs/task-host-install-script.md
+++ b/docs/task-host-install-script.md
@@ -3,47 +3,89 @@ tags:
   - firecrab
   - host
   - install
-status: 미완료
+status: 구현 완료 (실 호스트 설치 미검증)
 scope: 4주차
-updated: 2026-07-29
+updated: 2026-07-30
 ---
 
 # Host 설치 — `install.sh`
 
 > [!summary] 한 줄 요약
-> 지금 firecrab을 새 머신에 올리려면 문서를 보며 손으로 여러 단계를 밟아야 한다.
-> 한 번 실행으로 끝나는 설치 스크립트를 만든다.
+> **네트워크만 되는 리눅스 머신**에서 `sudo ./install.sh` 한 번으로
+> 없는 것을 찾아 설치하고, 빌드하고, 데몬 2개를 띄우고, 대시보드까지 뜨게 한다.
+> 별도의 부트스트랩 옵션 없이 **기본 실행**이 그 일을 한다.
 
 ## 왜
 
-- 흩어져 있는 것들: [firecracker 설치](../scripts/install-firecracker.sh),
+- 흩어져 있던 것들: [firecracker 설치](../scripts/install-firecracker.sh),
   [KVM 확인](../scripts/kvm-check.sh), rootfs 빌드 스크립트, net-helper 실행 방법,
   `/run/firecrab` 디렉터리와 소켓 그룹 권한
-- 실제로 이번 주에만 소켓 그룹을 잘못 줘서 API가 helper에 붙지 못하는 일이 있었음
+- 실제로 이번 주에 소켓 그룹을 잘못 줘서 API가 helper에 붙지 못하는 일이 있었음
   (`sudo -u root -g <group>`을 빠뜨리면 재현)
-- 데모·심사 환경에서 "clone → install → 실행"이 안 되면 아무것도 못 보여줌
+- 데모·심사 환경에서 "clone → 한 줄 → 브라우저"가 안 되면 아무것도 보여줄 수 없음
 
-## 작업
+## 구현 (2026-07-30)
 
-- `install.sh` — 의존성 확인·안내(KVM, `nft`, `dnsmasq`, `firecracker`, `e2fsprogs`)
-- 서비스 계정/그룹 생성, `/etc/firecrab`, `/var/lib/firecrab`, `/run/firecrab` 생성 + 권한
-- 빌드 산출물(`firecrab-api`, `firecrab-net-helper`) 배치, 이미지 디렉터리 준비
-- 프론트엔드 `npm ci && npm run build` → `dist/` 배치
-  ([프론트엔드 서빙](task-host-frontend-serving.md)이 이걸 서빙)
-- [systemd 유닛](task-host-systemd-daemons.md) 설치·활성화 호출
-- `--uninstall` — 유닛 정지·제거, 디렉터리 정리(데이터는 명시적 플래그가 있을 때만)
-- 재실행 안전(idempotent) — 이미 있는 것은 건너뛰고 바뀐 것만 적용
+### 모드
+
+| 실행 | 동작 |
+|---|---|
+| `sudo ./install.sh` | 없는 것을 **설치**하고 빌드·배치·기동까지 |
+| `./install.sh --check` | 무엇이 없고 무엇을 설치할지 보고만. **root 불필요, 아무것도 바꾸지 않음** |
+| `sudo ./install.sh --uninstall` | 유닛·바이너리·대시보드 제거 (데이터 보존) |
+| `… --uninstall --purge` | 데이터 디렉터리까지 삭제 |
+
+억제 플래그: `--no-deps`(설치는 하지 않고 부족한 것만 보고), `--no-images`, `--no-frontend`,
+`--with-ubuntu-image`(큰 Ubuntu 이미지도 함께)
+
+### 스스로 채우는 것
+
+| 대상 | 방법 |
+|---|---|
+| `ip`, `nft`, `dnsmasq`, `mkfs.ext4`, `curl` | 패키지 관리자 자동 감지 — apt-get / dnf / zypper / pacman / apk |
+| `firecracker` | `scripts/install-firecracker.sh` 호출 |
+| Rust 툴체인 | `cargo`가 없으면 rustup 비대화형 설치 |
+| Node/npm | 대시보드를 빌드할 때만 필요 |
+| **게스트 이미지** | 저장소에 있으면 복사, 없으면 docker로 Alpine 이미지 빌드 |
+| KVM | 설치 대상이 아님 — BIOS/중첩 가상화 문제라 안내만 |
+
+패키지 이름은 관리자별로 매핑한다(apt는 `docker.io`, apk는 `e2fsprogs-extra` 등).
+`apt-get update`는 한 번만 돈다.
+
+### 배치
+
+- 계정: 시스템 사용자 `firecrab` + `kvm` 그룹 편입(firecracker가 `/dev/kvm`을 연다)
+- `/var/lib/firecrab/{data,images}`(0750, firecrab 소유), `/etc/firecrab`(0750, root:firecrab)
+- 바이너리 → `/usr/local/lib/firecrab`, 대시보드 → `/usr/local/share/firecrab/dashboard`
+- 이미지는 **복사**(심볼릭 링크 아님) — 저장소를 옮기거나 지워도 살아 있어야 한다. 이미 있으면 건너뜀
+- `/etc/firecrab/api.env` 생성(0640), 이미 있으면 보존
+- 유닛은 [systemd 태스크](task-host-systemd-daemons.md)의 템플릿을 `sed`로 치환해 설치
+- 경로는 전부 환경 변수로 덮어쓸 수 있음 — `PREFIX`, `DATADIR`, `CONFDIR`, `UNITDIR`,
+  `FIRECRAB_USER/GROUP`
+
+> [!important] 이미지가 없어도 설치는 성공한다
+> 이미지 빌드는 실패해도 경고만 남기고 계속 간다. 이를 위해
+> `TemplateRegistry::load_default()`가 **파일이 없는 템플릿은 건너뛰도록** 바뀌었다
+> (예전엔 아티팩트가 하나라도 없으면 API 기동 자체가 실패했다).
+> 대시보드·MicroNetwork는 이미지 없이도 동작하고, 이미지는 나중에 넣으면 된다.
+> 있는 파일은 여전히 전부 해시 검증한다.
 
 ## 완료 기준
 
-- 깨끗한 머신에서 `./install.sh` 한 번으로 데몬 2개가 뜨고, 브라우저에서 VM 생성까지 됨
-  (터미널을 3개 띄울 필요 없음)
+- 깨끗한 머신에서 `sudo ./install.sh` 한 번으로 데몬 2개가 뜨고 브라우저에서 VM 생성까지
 - 두 번 실행해도 같은 결과(오류·중복 없음)
-- 의존성이 없으면 **무엇이 없는지** 정확히 알려주고 중단
+- 설치할 수 없는 것(KVM)은 **무엇이 문제인지** 알려주고, 나머지는 알아서 채움
+- `--check`는 root 없이 돌고 **아무것도 바꾸지 않음**
 - `--uninstall` 후 firecrab이 만든 것만 사라지고 host의 다른 설정은 그대로
+
+> [!warning] 검증 상태
+> `--check`(비특권·무변경)·`--help`·문법(`bash -n`)·유닛 렌더링(`systemd-analyze verify`)은 확인했다.
+> **깨끗한 머신에서의 전체 설치는 아직 안 돌려봤다** — 개발 머신에 시스템 계정과 유닛을 만들면
+> 지금의 수동 실행 방식과 충돌하기 때문. 절차는 [tests/host-install](tests/host-install.md).
 
 ## 참고
 
 - 패키지(.deb/.rpm)·업그레이드·롤백은 [5주차](week5-tasks.md)의
   [패키징·systemd·upgrade](task-packaging-systemd-upgrades.md) 범위 —
   이 태스크는 그 전 단계인 **소스에서의 설치**
+- 진단만 따로 떼어낸 것이 [Host 진단](task-host-doctor.md) — 지금은 `--check`가 그 일부를 한다

--- a/docs/task-host-systemd-daemons.md
+++ b/docs/task-host-systemd-daemons.md
@@ -48,6 +48,13 @@ updated: 2026-07-29
 - `firecrab-api.service` — 비특권 `firecrab` 계정, `WorkingDirectory=/var/lib/firecrab`
   - `FIRECRAB_IMAGE_ROOT`, `FIRECRAB_STATIC_ROOT` 지정, `EnvironmentFile=-/etc/firecrab/api.env`
 - 샌드박싱은 `ProtectSystem=full`까지만 — `strict`는 `/var`를 잠가 dnsmasq의 lease 파일을 깨뜨린다
+- `CapabilityBoundingSet`으로 uid 0을 유지한 채 쓰지 않는 권한을 전부 회수:
+  `NET_ADMIN` `NET_RAW` `NET_BIND_SERVICE` `SETUID` `SETGID` `KILL` `CHOWN`
+  - 하나가 빠지면 **기동은 되고 특정 동작만 런타임에 깨진다** — 그래서 CI가 실제로 확인한다
+  - `KILL`: dnsmasq가 비특권 사용자로 내려간 뒤 시그널을 보내야 함(커널은 uid가 아니라
+    capability를 본다)
+  - `CHOWN`: dnsmasq가 pid 파일 소유자를 그 사용자로 넘긴다. **CI가 이걸 잡아냈다** —
+    없으면 매 기동마다 `chown of PID file ... Operation not permitted`
 
 ## 완료 기준
 

--- a/docs/task-host-systemd-daemons.md
+++ b/docs/task-host-systemd-daemons.md
@@ -3,7 +3,7 @@ tags:
   - firecrab
   - host
   - systemd
-status: 미완료
+status: 구현 완료 (실 호스트 기동 미검증)
 scope: 4주차
 updated: 2026-07-29
 ---
@@ -35,6 +35,19 @@ updated: 2026-07-29
 - `firecrab-api.service`가 `dnsmasq`·`nftables`와 충돌하지 않는지 확인
 - 3번(dev 서버)은 유닛으로 만들지 않는다 — [프론트엔드 서빙](task-host-frontend-serving.md)에서
   API가 정적 자산을 직접 서빙하게 바꿔 데몬 2개로 끝낸다
+
+## 구현 (2026-07-29)
+
+`packaging/systemd/`에 템플릿 2개. `install.sh`가 `@PLACEHOLDER@`를 실제 경로/계정으로 치환해 설치.
+
+- `firecrab-net-helper.service` — `User=root` + `Group=firecrab`.
+  **그룹이 핵심**: helper가 소켓을 0660으로 만들고 그룹은 프로세스에서 가져가므로,
+  이걸 빠뜨리면 API가 소켓에 못 붙는다(이번 주에 실제로 겪은 실패)
+  - `RuntimeDirectory=firecrab`(0750)로 `/run/firecrab` 생성·정리
+  - `Before=firecrab-api.service` — API의 시작 시 재적용이 helper를 찾을 수 있도록
+- `firecrab-api.service` — 비특권 `firecrab` 계정, `WorkingDirectory=/var/lib/firecrab`
+  - `FIRECRAB_IMAGE_ROOT`, `FIRECRAB_STATIC_ROOT` 지정, `EnvironmentFile=-/etc/firecrab/api.env`
+- 샌드박싱은 `ProtectSystem=full`까지만 — `strict`는 `/var`를 잠가 dnsmasq의 lease 파일을 깨뜨린다
 
 ## 완료 기준
 

--- a/docs/tests/host-install.md
+++ b/docs/tests/host-install.md
@@ -1,0 +1,108 @@
+# Host 설치 테스트
+
+`install.sh`와 systemd 유닛, API의 대시보드 서빙을 확인한다
+([task-host-install-script](../task-host-install-script.md),
+[task-host-systemd-daemons](../task-host-systemd-daemons.md),
+[task-host-frontend-serving](../task-host-frontend-serving.md)).
+
+> [!warning] 개발 머신에서 전체 설치를 돌리지 말 것
+> 시스템 계정과 유닛이 생겨서 지금의 수동 실행(터미널 3개)과 충돌한다.
+> 전체 설치는 VM이나 컨테이너 같은 **버려도 되는 호스트**에서 한다.
+
+## 자동 테스트 (root 불필요)
+
+```sh
+cargo test -p firecrab-api server::                    # 5
+cargo test -p firecrab-api templates::                 # 9
+bash -n install.sh                                     # 문법
+./install.sh --help
+./install.sh --check                                   # 비특권 + 무변경이어야 함
+```
+
+전체: `cargo test --workspace` → 158/20/16/56
+
+확인 항목:
+
+- `FIRECRAB_STATIC_ROOT`가 없거나 `index.html`이 없으면 정적 서빙이 꺼지고 모든 경로가 JSON 404
+- 지정돼 있으면 `/`와 자산은 파일로, 없는 경로는 `index.html`(SPA fallback)
+- 그 상태에서도 `/api/*`·`/ws/*`의 없는 경로는 **JSON 404**(HTML 아님)
+- 이미지가 없는 image root로도 API가 뜨고, 파일이 갖춰진 템플릿만 resolve됨
+  (`load_from_skips_templates_whose_images_are_not_built_yet`)
+
+`--check`가 정말 아무것도 바꾸지 않는지도 같이 본다:
+
+```sh
+BEFORE=$(ls -la /var/lib/firecrab 2>&1); ./install.sh --check >/dev/null
+[ "$BEFORE" = "$(ls -la /var/lib/firecrab 2>&1)" ] && echo "무변경 OK"
+```
+
+## 정적 서빙 확인 (root 불필요)
+
+```sh
+cd firecrab-frontend && npm run build && cd ..
+FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" FIRECRAB_ALLOWED_ORIGINS="" \
+  cargo run -p firecrab-api
+
+# 다른 터미널에서
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' localhost:3000/          # 200 text/html
+curl -s -o /dev/null -w '%{http_code} %{content_type}\n' localhost:3000/vms/abc   # 200 text/html
+curl -s -o /dev/null -w '%{http_code}\n'                localhost:3000/api/vms    # 200
+curl -s localhost:3000/api/nope                                                   # JSON 404
+```
+
+브라우저에서 `http://localhost:3000/` — **Vite dev 서버 없이** 대시보드가 뜨고,
+VM 목록·생성·터미널이 그대로 동작해야 한다.
+
+## 유닛 파일 확인 (root 불필요)
+
+```sh
+# 설치와 같은 방식으로 치환해 문법만 본다
+sed -e 's|@LIBDIR@|/usr/local/lib/firecrab|g' -e 's|@SHAREDIR@|/usr/local/share/firecrab|g' \
+    -e 's|@DATADIR@|/var/lib/firecrab|g' -e 's|@CONFDIR@|/etc/firecrab|g' \
+    -e 's|@FIRECRAB_USER@|firecrab|g' -e 's|@FIRECRAB_GROUP@|firecrab|g' -e 's|@FIRECRAB_UID@|998|g' \
+    packaging/systemd/firecrab-api.service > /tmp/firecrab-api.service
+grep -c '@[A-Z_]*@' /tmp/firecrab-api.service     # 0 이어야 함
+systemd-analyze verify /tmp/firecrab-api.service  # 바이너리 없음 경고만 나오면 정상
+```
+
+## 전체 설치 (버려도 되는 호스트에서, root 필요)
+
+네트워크만 되는 머신이면 된다 — 나머지는 스크립트가 채운다.
+
+```sh
+git clone <repo> && cd firecrab
+sudo ./install.sh          # 없는 것(nft/dnsmasq/firecracker/rust/node/docker+이미지)을 알아서 설치
+```
+
+먼저 무엇이 설치될지 보고 싶으면:
+
+```sh
+./install.sh --check       # root 없이, 아무것도 바꾸지 않음
+```
+
+확인 항목:
+
+```sh
+systemctl status firecrab-net-helper firecrab-api    # 둘 다 active
+ls -l /run/firecrab/net-helper.sock                  # srw-rw---- root firecrab
+sudo -u firecrab id                                  # kvm 그룹 포함
+curl -s -o /dev/null -w '%{http_code}\n' localhost:3000/       # 200 (대시보드)
+curl -s localhost:3000/api/vms                                 # []
+```
+
+- 브라우저에서 대시보드 접속 → VM 생성 → start → `running` 도달
+- **재부팅** 후 두 데몬이 자동으로 뜨고, MicroNetwork bridge가 복구되는지
+  (`ip -br addr show type bridge`)
+- `sudo ./install.sh` 재실행 → 오류 없이 같은 상태(idempotent)
+- `sudo ./install.sh --uninstall` → 유닛·바이너리 사라지고 `/var/lib/firecrab`은 남음
+- `sudo ./install.sh --uninstall --purge` → 데이터까지 삭제
+
+## 완료 기준 대조
+
+- 깨끗한 머신에서 한 번의 실행으로 데몬 2개가 뜨고 브라우저에서 VM 생성까지 — **미검증**
+- 재실행해도 같은 결과(idempotent) — 미검증
+- 의존성을 스스로 설치(패키지 관리자 5종, firecracker, rustup, node, docker+이미지) — **미검증**
+- `--check`가 비특권으로 돌고 아무것도 바꾸지 않음 — **확인**(2026-07-30)
+- 이미지가 없어도 설치가 끝나고 API가 뜸 — 자동 테스트로 확인
+- 정적 서빙(dev 서버 없이 대시보드) — **확인**(2026-07-29)
+- 유닛 문법·플레이스홀더 치환 — **확인**(2026-07-29)

--- a/docs/tests/host-install.md
+++ b/docs/tests/host-install.md
@@ -5,9 +5,16 @@
 [task-host-systemd-daemons](../task-host-systemd-daemons.md),
 [task-host-frontend-serving](../task-host-frontend-serving.md)).
 
+사용법(옵션·경로·운영·제거)은 [install.md](../install.md).
+
 > [!warning] 개발 머신에서 전체 설치를 돌리지 말 것
 > 시스템 계정과 유닛이 생겨서 지금의 수동 실행(터미널 3개)과 충돌한다.
 > 전체 설치는 VM이나 컨테이너 같은 **버려도 되는 호스트**에서 한다.
+
+> [!note] CI가 대신 돌린다
+> `.github/workflows/ci.yml`의 `install` job이 일회용 러너 VM에서 전체 설치를 실행한다 —
+> shellcheck, `--check` 무변경, 설치, 데몬 2개 기동, capability 런타임 확인, 대시보드 200,
+> 재실행 멱등성, `--uninstall`/`--purge`까지. 게스트 이미지 빌드(=VM 부팅)만 범위 밖.
 
 ## 자동 테스트 (root 불필요)
 

--- a/docs/week4-tasks.md
+++ b/docs/week4-tasks.md
@@ -42,19 +42,20 @@ updated: 2026-07-29
 
 ## Host — 설치·데몬 기반
 
-지금 firecrab은 터미널 **3개**(net-helper / API / 프론트 dev 서버)를 손으로 띄우는 상태다.
-재부팅하면 아무것도 안 뜨고, 새 머신에 올리려면 문서를 보며 여러 단계를 밟아야 한다.
-목표는 **설치 한 번 + 데몬 2개**.
+터미널 **3개**(net-helper / API / 프론트 dev 서버)를 손으로 띄우던 것을
+**설치 한 번 + 데몬 2개**로 바꾼다. 아래 셋은 2026-07-29 구현 완료 — 검증 절차는
+[tests/host-install](tests/host-install.md).
 
-- [ ] [Host 설치 — `install.sh`](task-host-install-script.md)
-      — 의존성 점검, 계정·디렉터리·권한, 바이너리 배치, `--uninstall`
-      — 재실행해도 같은 결과(idempotent)
-- [ ] [Host 데몬 — systemd 유닛](task-host-systemd-daemons.md)
-      — helper → API 순서 보장, 재시작 정책, `WorkingDirectory` 고정(옛 DB 여는 사고 방지)
-      — 재부팅 후 사람 개입 없이 MicroNetwork bridge까지 복구될 것
-- [ ] [프론트엔드 서빙](task-host-frontend-serving.md)
-      — 빌드된 `dist/`를 API가 직접 서빙(`ServeDir` + SPA fallback), Vite dev 서버 없이 동작
-      — same-origin이 되므로 CORS 허용 origin 설정도 필요 없어짐
+- [x] [Host 설치 — `install.sh`](task-host-install-script.md)
+      — **네트워크만 되는 머신에서 한 줄**: 없는 의존성(nft·dnsmasq·firecracker·rustup·node·docker)과
+      게스트 이미지까지 스스로 채우고 데몬 2개를 띄움. `--check`는 비특권·무변경
+      — 실 호스트 전체 설치는 아직 미검증(버려도 되는 머신 필요)
+- [x] [Host 데몬 — systemd 유닛](task-host-systemd-daemons.md)
+      — `packaging/systemd/` 템플릿 2종. helper의 `Group=`이 소켓 접근을 좌우, API는 `WorkingDirectory` 고정
+      — 실 호스트 기동은 미검증
+- [x] [프론트엔드 서빙](task-host-frontend-serving.md)
+      — `FIRECRAB_STATIC_ROOT`로 `dist/` 서빙 + SPA fallback, `/api`·`/ws`는 JSON 404 유지
+      — 실제로 dev 서버 없이 대시보드 동작 확인
 - [ ] [Host 진단 — `firecrab doctor`](task-host-doctor.md)
       — KVM·ip_forward·nft·dnsmasq·UFW·소켓 권한·이미지 digest를 한 번에 점검
       — 지금까지의 실패가 대부분 코드가 아니라 host 설정이었음

--- a/firecrab-api/Cargo.toml
+++ b/firecrab-api/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["cors"] }
+tower-http = { version = "0.6", features = ["cors", "fs"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -257,6 +257,37 @@ async fn assign_request_id(mut request: Request, next: Next) -> Response {
     response
 }
 
+/// Whether `origin` names the very address this request was sent to.
+///
+/// Browsers attach `Origin` to same-origin state-changing requests as well, so
+/// once the dashboard is served by this API (`static_root`) every POST/DELETE it
+/// makes carries one. Requiring that address to be listed would be a trap: it is
+/// whatever the operator typed — `localhost`, a LAN IP, a proxy's hostname — and
+/// getting it wrong turns every action in the UI into a `403` while GETs keep
+/// working. A request whose `Origin` equals its own authority cannot have been
+/// sent by another site, which is exactly what this check is defending against.
+fn is_same_origin(origin: &HeaderValue, request: &Request) -> bool {
+    let Ok(origin) = origin.to_str() else {
+        return false;
+    };
+    // HTTP/2 carries the authority in the URI; HTTP/1.1 in the Host header.
+    let authority = request
+        .uri()
+        .authority()
+        .map(|value| value.as_str())
+        .or_else(|| {
+            request
+                .headers()
+                .get(header::HOST)
+                .and_then(|host| host.to_str().ok())
+        });
+    authority.is_some_and(|authority| {
+        origin
+            .split_once("://")
+            .is_some_and(|(_, host)| host == authority)
+    })
+}
+
 async fn enforce_origin(
     State(policy): State<HttpPolicy>,
     request: Request,
@@ -265,6 +296,7 @@ async fn enforce_origin(
     let id = request_id(&request);
     if let Some(origin) = request.headers().get(header::ORIGIN)
         && !policy.allowed_origins.contains(origin)
+        && !is_same_origin(origin, &request)
     {
         return Err(AppError::forbidden_origin(id));
     }
@@ -362,6 +394,49 @@ mod tests {
             .await
             .unwrap();
         (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn a_mutation_from_the_dashboards_own_origin_is_not_forbidden() {
+        use tower::ServiceExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        // The installed shape: dashboard served from this API, so nothing is
+        // listed as a cross-origin caller.
+        let config = HttpConfig::from_values("127.0.0.1:3000", "", false, false).unwrap();
+        let app = build_router(test_state(directory.path()).await, &config);
+
+        let post = |origin: &'static str| {
+            let app = app.clone();
+            async move {
+                let response = app
+                    .oneshot(
+                        Request::builder()
+                            .method(Method::POST)
+                            .uri("/api/vms")
+                            .header(header::HOST, "localhost:3000")
+                            .header(header::ORIGIN, origin)
+                            .header(header::CONTENT_TYPE, "application/json")
+                            .body(axum::body::Body::from("{}"))
+                            .unwrap(),
+                    )
+                    .await
+                    .unwrap();
+                response.status()
+            }
+        };
+
+        // Same origin: reaches the handler (and fails validation there, which is
+        // the point — it is not turned away at the door).
+        assert_eq!(
+            post("http://localhost:3000").await,
+            axum::http::StatusCode::BAD_REQUEST
+        );
+        // Another site posting to the same host is still refused.
+        assert_eq!(
+            post("http://evil.example").await,
+            axum::http::StatusCode::FORBIDDEN
+        );
     }
 
     #[tokio::test]

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::env;
 use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -9,11 +10,12 @@ use axum::extract::{DefaultBodyLimit, Request, State};
 use axum::http::{HeaderName, HeaderValue, Method, header};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{any, get, post};
 use axum::{Extension, Router};
 use thiserror::Error;
 use tokio::sync::Semaphore;
 use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::services::{ServeDir, ServeFile};
 use uuid::Uuid;
 
 use crate::error::AppError;
@@ -39,6 +41,12 @@ pub struct HttpConfig {
     pub allowed_origins: Vec<HeaderValue>,
     pub max_concurrent_requests: usize,
     pub request_timeout: Duration,
+    /// Directory of built dashboard assets to serve, or `None` to serve none
+    /// (`docs/task-host-frontend-serving.md`). Set when an installed deploy
+    /// should answer the browser itself instead of needing a Vite dev server
+    /// alongside it; unset during development, where `npm run dev` proxies
+    /// to this API.
+    pub static_root: Option<PathBuf>,
 }
 
 impl HttpConfig {
@@ -55,7 +63,9 @@ impl HttpConfig {
             }
         });
 
-        Self::from_values(&bind, &origins, authentication_enabled, tls_enabled)
+        let mut config = Self::from_values(&bind, &origins, authentication_enabled, tls_enabled)?;
+        config.static_root = resolve_static_root(env::var("FIRECRAB_STATIC_ROOT").ok());
+        Ok(config)
     }
 
     fn from_values(
@@ -85,8 +95,25 @@ impl HttpConfig {
             allowed_origins,
             max_concurrent_requests: 128,
             request_timeout: Duration::from_secs(10),
+            static_root: None,
         })
     }
+}
+
+/// The dashboard assets to serve, if any. A configured directory that has no
+/// `index.html` is treated as absent and logged rather than failing startup:
+/// the API is still fully usable over HTTP, and a half-built `dist/` should
+/// not stop VMs from being managed.
+fn resolve_static_root(configured: Option<String>) -> Option<PathBuf> {
+    let root = PathBuf::from(configured?);
+    if root.join("index.html").is_file() {
+        return Some(root);
+    }
+    tracing::warn!(
+        path = %root.display(),
+        "FIRECRAB_STATIC_ROOT has no index.html; serving the API only"
+    );
+    None
 }
 
 fn env_flag(name: &str) -> bool {
@@ -184,10 +211,26 @@ pub fn build_router(state: AppState, config: &HttpConfig) -> Router {
 
     let console = Router::new().route("/ws/vms/{id}/console", get(handlers::console::console_ws));
 
-    rest.merge(console)
-        .fallback(not_found)
-        .with_state(state)
-        .layer(middleware::from_fn_with_state(policy, enforce_origin))
+    let app = rest
+        .merge(console)
+        // Unknown paths under the API/WebSocket prefixes answer with the JSON
+        // error envelope even when the dashboard is served below, so a typo in
+        // a client's URL never comes back as an HTML page.
+        .route("/api/{*rest}", any(not_found))
+        .route("/ws/{*rest}", any(not_found))
+        .with_state(state);
+
+    let app = match &config.static_root {
+        // Anything else is the dashboard: a real file if it exists, otherwise
+        // index.html, because the router's routes only exist in the browser
+        // (a reload on /vms/<id> must not 404).
+        Some(root) => app.fallback_service(
+            ServeDir::new(root).fallback(ServeFile::new(root.join("index.html"))),
+        ),
+        None => app.fallback(not_found),
+    };
+
+    app.layer(middleware::from_fn_with_state(policy, enforce_origin))
         .layer(middleware::from_fn(assign_request_id))
 }
 
@@ -274,5 +317,107 @@ mod tests {
             HttpConfig::from_values("0.0.0.0:3000", "", false, false),
             Err(ConfigError::InsecureNonLoopbackBind)
         ));
+    }
+
+    #[test]
+    fn a_static_root_without_an_index_is_treated_as_absent() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().to_owned();
+        assert_eq!(resolve_static_root(None), None);
+        assert_eq!(
+            resolve_static_root(Some(root.display().to_string())),
+            None,
+            "an unbuilt dist/ must not take over the router's fallback"
+        );
+
+        std::fs::write(root.join("index.html"), "<!doctype html>").unwrap();
+        assert_eq!(
+            resolve_static_root(Some(root.display().to_string())),
+            Some(root)
+        );
+    }
+
+    async fn test_state(root: &std::path::Path) -> AppState {
+        let templates = crate::templates::TemplateRegistry::from_specs(root, std::iter::empty())
+            .expect("empty template spec list should always verify");
+        AppState::with_db_file(templates, root.join("state.db"))
+            .await
+            .expect("fresh temp db should open cleanly")
+    }
+
+    async fn get(app: &Router, path: &str) -> (axum::http::StatusCode, String) {
+        use tower::ServiceExt;
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn without_a_static_root_every_unknown_path_is_a_json_404() {
+        let directory = tempfile::tempdir().unwrap();
+        let config = HttpConfig::from_values("127.0.0.1:3000", "", false, false).unwrap();
+        let app = build_router(test_state(directory.path()).await, &config);
+
+        for path in ["/", "/api/nope", "/dashboard"] {
+            let (status, body) = get(&app, path).await;
+            assert_eq!(status, axum::http::StatusCode::NOT_FOUND, "{path}");
+            assert!(
+                body.contains("\"error\""),
+                "{path} should answer JSON: {body}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn with_a_static_root_the_dashboard_is_served_but_api_paths_still_answer_json() {
+        let directory = tempfile::tempdir().unwrap();
+        let assets = directory.path().join("dist");
+        std::fs::create_dir_all(&assets).unwrap();
+        std::fs::write(
+            assets.join("index.html"),
+            "<!doctype html><title>fc</title>",
+        )
+        .unwrap();
+        std::fs::write(assets.join("app.js"), "console.log(1)").unwrap();
+
+        let mut config = HttpConfig::from_values("127.0.0.1:3000", "", false, false).unwrap();
+        config.static_root = Some(assets);
+        let app = build_router(test_state(directory.path()).await, &config);
+
+        let (status, body) = get(&app, "/").await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert!(body.contains("<title>fc</title>"), "{body}");
+
+        let (status, body) = get(&app, "/app.js").await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(body, "console.log(1)");
+
+        // A client-side route the browser reloads on: no such file, so the
+        // SPA entry point answers instead of a 404.
+        let (status, body) = get(&app, "/vms/42").await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert!(body.contains("<title>fc</title>"), "{body}");
+
+        // ... but a mistyped API path must not come back as HTML.
+        for path in ["/api/nope", "/ws/nope"] {
+            let (status, body) = get(&app, path).await;
+            assert_eq!(status, axum::http::StatusCode::NOT_FOUND, "{path}");
+            assert!(
+                body.contains("\"error\""),
+                "{path} should answer JSON: {body}"
+            );
+        }
     }
 }

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -281,11 +281,18 @@ fn is_same_origin(origin: &HeaderValue, request: &Request) -> bool {
                 .get(header::HOST)
                 .and_then(|host| host.to_str().ok())
         });
-    authority.is_some_and(|authority| {
-        origin
-            .split_once("://")
-            .is_some_and(|(_, host)| host == authority)
-    })
+    let Some((scheme, host)) = origin.split_once("://") else {
+        // `null` (sandboxed frame, data: URL) and anything else without a
+        // scheme is not this API's own page.
+        return false;
+    };
+    // The scheme must be a web one: `chrome-extension://localhost:3000` parses
+    // to the same authority as the dashboard, and an extension's page is not
+    // it. http and https are both accepted for one authority on purpose — a
+    // TLS-terminating proxy forwards `https://name` to this plaintext port, and
+    // an attacker who could serve https on the very address the operator
+    // reached would already own the connection.
+    matches!(scheme, "http" | "https") && authority.is_some_and(|authority| host == authority)
 }
 
 async fn enforce_origin(
@@ -432,11 +439,29 @@ mod tests {
             post("http://localhost:3000").await,
             axum::http::StatusCode::BAD_REQUEST
         );
-        // Another site posting to the same host is still refused.
+        // A TLS-terminating proxy in front of this port sends the same
+        // authority with an https scheme; that is still this dashboard.
         assert_eq!(
-            post("http://evil.example").await,
-            axum::http::StatusCode::FORBIDDEN
+            post("https://localhost:3000").await,
+            axum::http::StatusCode::BAD_REQUEST
         );
+
+        for refused in [
+            // Another site posting to this host.
+            "http://evil.example",
+            // Right authority, but an extension's page is not the dashboard.
+            "chrome-extension://localhost:3000",
+            // A sandboxed frame or a data: URL.
+            "null",
+            // Another port on the same host is a different origin.
+            "http://localhost:8081",
+        ] {
+            assert_eq!(
+                post(refused).await,
+                axum::http::StatusCode::FORBIDDEN,
+                "{refused} must not pass as the dashboard's own origin"
+            );
+        }
     }
 
     #[tokio::test]

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::ffi::CString;
-use std::fs::{File, Metadata, OpenOptions};
+use std::fs::{self, File, Metadata, OpenOptions};
 use std::io::{self, Read};
 use std::os::fd::{AsRawFd, FromRawFd};
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
@@ -164,7 +164,34 @@ impl TemplateRegistry {
             .map(PathBuf::from)
             .unwrap_or(default_root);
 
-        Self::from_specs(&image_root, default_specs())
+        Self::load_from(&image_root)
+    }
+
+    /// [`load_default`](Self::load_default) against an explicit image root.
+    ///
+    /// A template whose files aren't there yet is skipped with a warning
+    /// rather than failing startup: on a fresh install the daemons come up
+    /// before any multi-gigabyte image has been built, and an API that
+    /// refuses to start would take the dashboard and every existing VM down
+    /// with it. Anything that *is* present is still verified in full by
+    /// [`from_specs`](Self::from_specs).
+    pub fn load_from(image_root: &Path) -> Result<Self, TemplateError> {
+        if !image_root.exists() {
+            fs::create_dir_all(image_root)?;
+        }
+
+        let (present, missing): (Vec<_>, Vec<_>) = default_specs()
+            .into_iter()
+            .partition(|spec| artifacts_present(image_root, spec));
+        for spec in &missing {
+            tracing::warn!(
+                template = spec.alias,
+                image_root = %image_root.display(),
+                "template artifacts are missing; skipping this template"
+            );
+        }
+
+        Self::from_specs(image_root, present)
     }
 
     /// Builds a registry from an explicit image root and template specs,
@@ -301,6 +328,16 @@ impl TemplateRegistry {
 /// alias/kernel/initrd/boot_args values are unit-testable without needing
 /// real image files on disk — `from_specs` itself always needs those to
 /// verify against, but the spec values themselves don't.
+/// Whether every file a spec needs is already on disk. A cheap existence
+/// check only — [`TemplateRegistry::from_specs`] still opens each one safely
+/// beneath the image root and hashes it.
+fn artifacts_present(image_root: &Path, spec: &TemplateSpec) -> bool {
+    std::iter::once(&spec.kernel)
+        .chain(std::iter::once(&spec.rootfs))
+        .chain(spec.initrd.as_ref())
+        .all(|relative| image_root.join(relative).is_file())
+}
+
 fn default_specs() -> [TemplateSpec; 2] {
     [
         TemplateSpec {
@@ -455,6 +492,42 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn load_from_skips_templates_whose_images_are_not_built_yet() {
+        let directory = tempdir().unwrap();
+        let root = directory.path().join("images");
+
+        // A fresh install: the image root does not even exist yet.
+        let registry = TemplateRegistry::load_from(&root).expect("startup must not fail");
+        assert!(
+            root.is_dir(),
+            "the image root is created so later builds land there"
+        );
+        assert!(
+            registry.resolve_alias("alpine-3.24").is_none(),
+            "an unbuilt template must not resolve"
+        );
+
+        // Building one template's files in makes exactly that one usable; the
+        // other stays skipped rather than failing the whole registry.
+        let alpine = default_specs()
+            .into_iter()
+            .find(|spec| spec.alias == "alpine-3.24")
+            .expect("alpine is a default template");
+        for relative in [&alpine.kernel, &alpine.rootfs]
+            .into_iter()
+            .chain(alpine.initrd.as_ref())
+        {
+            let path = root.join(relative);
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, b"image").unwrap();
+        }
+
+        let registry = TemplateRegistry::load_from(&root).expect("one built template");
+        assert!(registry.resolve_alias("alpine-3.24").is_some());
+        assert!(registry.resolve_alias("ubuntu-26.04").is_none());
+    }
 
     fn create_registry(root: &Path) -> TemplateRegistry {
         fs::write(root.join("kernel"), b"kernel").unwrap();

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+# firecrab host installer (docs/task-host-install-script.md).
+#
+# One command on a machine that only has network access: works out what is
+# missing, installs it, builds firecrab, and leaves two systemd daemons
+# running with the dashboard served on http://127.0.0.1:3000/.
+#
+# Every step checks before it changes anything, so re-running is safe and
+# doubles as a repair for a half-broken install.
+set -euo pipefail
+
+FIRECRAB_USER=${FIRECRAB_USER:-firecrab}
+FIRECRAB_GROUP=${FIRECRAB_GROUP:-firecrab}
+PREFIX=${PREFIX:-/usr/local}
+LIBDIR="$PREFIX/lib/firecrab"
+SHAREDIR="$PREFIX/share/firecrab"
+DATADIR=${DATADIR:-/var/lib/firecrab}
+CONFDIR=${CONFDIR:-/etc/firecrab}
+UNITDIR=${UNITDIR:-/etc/systemd/system}
+
+REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+UNITS=(firecrab-net-helper.service firecrab-api.service)
+
+MODE=install
+INSTALL_DEPS=1
+WITH_IMAGES=1
+WITH_UBUNTU_IMAGE=0
+WITH_FRONTEND=1
+PURGE=0
+
+PKG=''          # detected package manager
+PKG_UPDATED=0   # index refreshed at most once
+
+usage() {
+    cat <<'USAGE'
+Usage: sudo ./install.sh [OPTIONS]
+
+  (no options)        install everything that is missing, then start firecrab
+  --check             report what is missing and what would be installed
+  --no-deps           never install packages/toolchains, only report gaps
+  --no-images         do not build a guest image
+  --with-ubuntu-image also build the Ubuntu image (large, needs root chroot)
+  --no-frontend       do not build/install the dashboard
+  --uninstall         stop and remove units, binaries and dashboard
+  --purge             with --uninstall, also delete /var/lib/firecrab (VM data!)
+  -h, --help          this text
+
+Environment: FIRECRAB_USER, FIRECRAB_GROUP, PREFIX, DATADIR, CONFDIR, UNITDIR
+USAGE
+}
+
+log()  { printf '\033[1;32m==>\033[0m %s\n' "$*"; }
+step() { printf '\033[1;36m--\033[0m  %s\n' "$*"; }
+warn() { printf '\033[1;33m!!\033[0m  %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mxx\033[0m  %s\n' "$*" >&2; exit 1; }
+
+have() { command -v "$1" >/dev/null 2>&1; }
+need_root() { [ "$(id -u)" -eq 0 ] || die "run as root: sudo ./install.sh $*"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check) MODE=check ;;
+        --no-deps) INSTALL_DEPS=0 ;;
+        --no-images) WITH_IMAGES=0 ;;
+        --with-ubuntu-image) WITH_UBUNTU_IMAGE=1 ;;
+        --no-frontend) WITH_FRONTEND=0 ;;
+        --uninstall) MODE=uninstall ;;
+        --purge) PURGE=1 ;;
+        -h|--help) usage; exit 0 ;;
+        *) usage >&2; die "unknown option: $1" ;;
+    esac
+    shift
+done
+
+# --- package manager -------------------------------------------------------
+
+detect_pkg() {
+    for candidate in apt-get dnf zypper pacman apk; do
+        if have "$candidate"; then PKG=$candidate; return 0; fi
+    done
+    return 1
+}
+
+# Package name per manager, since only a few of these agree.
+pkg_name() {
+    local generic=$1
+    case "$PKG:$generic" in
+        apt-get:iproute2|dnf:iproute2)  echo "iproute2" ;;
+        zypper:iproute2|pacman:iproute2|apk:iproute2) echo "iproute2" ;;
+        *:nftables)   echo "nftables" ;;
+        *:dnsmasq)    echo "dnsmasq" ;;
+        apk:e2fsprogs) echo "e2fsprogs-extra" ;;
+        *:e2fsprogs)  echo "e2fsprogs" ;;
+        *:curl)       echo "curl" ;;
+        apt-get:node) echo "nodejs npm" ;;
+        pacman:node)  echo "nodejs npm" ;;
+        *:node)       echo "nodejs npm" ;;
+        apt-get:docker) echo "docker.io" ;;
+        *:docker)     echo "docker" ;;
+        *) echo "$generic" ;;
+    esac
+}
+
+pkg_refresh() {
+    [ "$PKG_UPDATED" -eq 1 ] && return 0
+    case "$PKG" in
+        apt-get) DEBIAN_FRONTEND=noninteractive apt-get update -qq ;;
+        apk) apk update -q ;;
+        *) : ;;  # dnf/zypper/pacman refresh as part of install
+    esac
+    PKG_UPDATED=1
+}
+
+pkg_install() {
+    pkg_refresh
+    # shellcheck disable=SC2086 # deliberate word splitting: one name can map to two packages
+    case "$PKG" in
+        apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $* ;;
+        dnf) dnf install -y -q $* ;;
+        zypper) zypper --non-interactive install -y $* ;;
+        pacman) pacman -Sy --noconfirm --needed $* ;;
+        apk) apk add --no-cache $* ;;
+        *) return 1 ;;
+    esac
+}
+
+# `ensure <command> <generic package>`: install only what is actually absent.
+ensure() {
+    local command_name=$1 generic=$2 packages
+    have "$command_name" && return 0
+
+    packages=$(pkg_name "$generic")
+    if [ "$MODE" = check ]; then
+        warn "missing: $command_name (would install: $packages)"
+        return 1
+    fi
+    [ "$INSTALL_DEPS" -eq 1 ] || { warn "missing: $command_name (--no-deps, install '$packages' yourself)"; return 1; }
+    [ -n "$PKG" ] || { warn "missing: $command_name and no known package manager — install '$packages' yourself"; return 1; }
+
+    step "installing $packages (for $command_name)"
+    pkg_install "$packages" || { warn "failed to install $packages"; return 1; }
+    have "$command_name"
+}
+
+# --- host checks -----------------------------------------------------------
+
+check_kvm() {
+    if [ -e /dev/kvm ]; then
+        log "/dev/kvm present"
+        return 0
+    fi
+    # Not installable: it is the CPU, the BIOS, or a VM without nested virt.
+    warn "/dev/kvm missing — enable virtualization in BIOS, or nested virt if this host is itself a VM"
+    return 1
+}
+
+check_systemd() {
+    if [ -d /run/systemd/system ]; then
+        log "systemd is running"
+        return 0
+    fi
+    warn "not a systemd host — the daemons can still be started by hand, but units will not work"
+    return 1
+}
+
+report_ufw() {
+    have ufw || return 0
+    local status
+    if status=$(ufw status 2>/dev/null); then
+        case "$status" in
+            *"Status: active"*)
+                warn "UFW is active — allow DHCP/DNS on each MicroNetwork bridge (docs/troubleshooting.md)" ;;
+            *) log "UFW installed but inactive" ;;
+        esac
+    else
+        warn "UFW installed; re-run as root to see whether it is active (it blocks new bridges' DHCP)"
+    fi
+}
+
+# --- dependency resolution -------------------------------------------------
+
+ensure_runtime_deps() {
+    local failed=0
+    ensure ip iproute2   || failed=1
+    ensure nft nftables  || failed=1
+    ensure dnsmasq dnsmasq || failed=1
+    ensure mkfs.ext4 e2fsprogs || failed=1
+    ensure curl curl     || failed=1
+    return $failed
+}
+
+ensure_firecracker() {
+    have firecracker && { log "firecracker present"; return 0; }
+
+    if [ "$MODE" = check ]; then
+        warn "missing: firecracker (would install via scripts/install-firecracker.sh)"
+        return 1
+    fi
+    [ "$INSTALL_DEPS" -eq 1 ] || { warn "missing: firecracker (--no-deps; run scripts/install-firecracker.sh)"; return 1; }
+
+    step "installing firecracker"
+    "$REPO_ROOT/scripts/install-firecracker.sh" || { warn "firecracker install failed"; return 1; }
+    have firecracker
+}
+
+ensure_build_tools() {
+    local failed=0
+
+    if have cargo; then
+        log "cargo present"
+    elif [ "$MODE" = check ]; then
+        warn "missing: cargo (would install via rustup)"
+        failed=1
+    elif [ "$INSTALL_DEPS" -eq 1 ]; then
+        step "installing the Rust toolchain (rustup)"
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
+            || { warn "rustup install failed"; failed=1; }
+        # rustup lands in $HOME/.cargo for whoever runs this (root under sudo).
+        export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+        have cargo || { warn "cargo still not on PATH"; failed=1; }
+    else
+        warn "missing: cargo (--no-deps; install rustup yourself)"
+        failed=1
+    fi
+
+    if [ "$WITH_FRONTEND" -eq 1 ]; then
+        ensure npm node || failed=1
+    fi
+    return $failed
+}
+
+# --- build -----------------------------------------------------------------
+
+build_all() {
+    step "building the workspace (release)"
+    ( cd "$REPO_ROOT" && cargo build --release --workspace )
+
+    if [ "$WITH_FRONTEND" -eq 1 ]; then
+        step "building the dashboard"
+        ( cd "$REPO_ROOT/firecrab-frontend" && npm ci && npm run build )
+    fi
+}
+
+# --- host layout -----------------------------------------------------------
+
+ensure_account() {
+    if getent group "$FIRECRAB_GROUP" >/dev/null; then
+        log "group $FIRECRAB_GROUP exists"
+    else
+        step "creating group $FIRECRAB_GROUP"
+        groupadd --system "$FIRECRAB_GROUP"
+    fi
+
+    if id "$FIRECRAB_USER" >/dev/null 2>&1; then
+        log "user $FIRECRAB_USER exists"
+    else
+        step "creating user $FIRECRAB_USER"
+        useradd --system --gid "$FIRECRAB_GROUP" --home-dir "$DATADIR" \
+                --shell /usr/sbin/nologin "$FIRECRAB_USER"
+    fi
+
+    # The API spawns firecracker, which opens /dev/kvm.
+    if getent group kvm >/dev/null && ! id -nG "$FIRECRAB_USER" | tr ' ' '\n' | grep -qx kvm; then
+        step "adding $FIRECRAB_USER to the kvm group"
+        usermod --append --groups kvm "$FIRECRAB_USER"
+    fi
+}
+
+ensure_directories() {
+    install -d -o root -g root -m 0755 "$LIBDIR" "$SHAREDIR"
+    install -d -o "$FIRECRAB_USER" -g "$FIRECRAB_GROUP" -m 0750 \
+            "$DATADIR" "$DATADIR/data" "$DATADIR/images"
+    install -d -o root -g "$FIRECRAB_GROUP" -m 0750 "$CONFDIR"
+    log "directories ready under $DATADIR, $CONFDIR"
+}
+
+install_binaries() {
+    local target="$REPO_ROOT/target/release"
+    for binary in firecrab-api firecrab-net-helper; do
+        [ -x "$target/$binary" ] || die "$target/$binary not found — the build did not produce it"
+        install -o root -g root -m 0755 "$target/$binary" "$LIBDIR/$binary"
+    done
+    log "binaries installed to $LIBDIR"
+
+    [ "$WITH_FRONTEND" -eq 1 ] || return 0
+    local dist="$REPO_ROOT/firecrab-frontend/dist"
+    [ -f "$dist/index.html" ] || die "$dist/index.html not found — the dashboard build did not produce it"
+    rm -rf "$SHAREDIR/dashboard"
+    install -d -o root -g root -m 0755 "$SHAREDIR/dashboard"
+    cp -r "$dist/." "$SHAREDIR/dashboard/"
+    chown -R root:root "$SHAREDIR/dashboard"
+    log "dashboard installed to $SHAREDIR/dashboard"
+}
+
+install_config() {
+    if [ -f "$CONFDIR/api.env" ]; then
+        log "keeping existing $CONFDIR/api.env"
+        return 0
+    fi
+    cat > "$CONFDIR/api.env" <<'ENVFILE'
+# firecrab API settings. The unit already sets the image root, the dashboard
+# assets and the working directory; uncomment only what you want to change.
+#
+# FIRECRAB_BIND_ADDR=127.0.0.1:3000
+# A non-loopback address requires authentication AND TLS to be enabled.
+# FIRECRAB_ALLOWED_ORIGINS=
+# Empty is correct while the dashboard is served from this same origin.
+# FIRECRAB_FIRECRACKER_BIN=firecracker
+ENVFILE
+    chown root:"$FIRECRAB_GROUP" "$CONFDIR/api.env"
+    chmod 0640 "$CONFDIR/api.env"
+    log "wrote $CONFDIR/api.env"
+}
+
+install_units() {
+    local uid
+    uid=$(id -u "$FIRECRAB_USER")
+    for unit in "${UNITS[@]}"; do
+        sed -e "s|@LIBDIR@|$LIBDIR|g" \
+            -e "s|@SHAREDIR@|$SHAREDIR|g" \
+            -e "s|@DATADIR@|$DATADIR|g" \
+            -e "s|@CONFDIR@|$CONFDIR|g" \
+            -e "s|@FIRECRAB_USER@|$FIRECRAB_USER|g" \
+            -e "s|@FIRECRAB_GROUP@|$FIRECRAB_GROUP|g" \
+            -e "s|@FIRECRAB_UID@|$uid|g" \
+            "$REPO_ROOT/packaging/systemd/$unit" > "$UNITDIR/$unit"
+        chmod 0644 "$UNITDIR/$unit"
+    done
+    systemctl daemon-reload
+    log "units installed to $UNITDIR"
+}
+
+# --- guest images ----------------------------------------------------------
+
+images_present() {
+    compgen -G "$DATADIR/images/rootfs/*.ext4" >/dev/null 2>&1
+}
+
+repo_images_present() {
+    compgen -G "$REPO_ROOT/images/rootfs/*.ext4" >/dev/null 2>&1
+}
+
+# Report-only counterpart of `ensure_images`, so --check cannot copy, chown or
+# build anything (it is run unprivileged, and a check that mutates is a trap).
+report_images() {
+    if [ "$WITH_IMAGES" -eq 0 ]; then
+        log "images: skipped (--no-images)"
+        return 0
+    fi
+    if repo_images_present; then
+        log "images: present in the repo, would be copied to $DATADIR/images"
+        return 0
+    fi
+    if images_present; then
+        log "images: already installed in $DATADIR/images"
+        return 0
+    fi
+    if have docker; then
+        warn "no guest image (would build the Alpine image with docker)"
+    else
+        warn "no guest image (would install docker, then build the Alpine image)"
+    fi
+    return 1
+}
+
+ensure_images() {
+    [ "$WITH_IMAGES" -eq 1 ] || { log "skipping images (--no-images)"; return 0; }
+
+    # Prefer images already built in the repo: copying beats rebuilding.
+    if repo_images_present; then
+        step "copying images from the repo (existing ones are kept)"
+        cp -rn "$REPO_ROOT/images/." "$DATADIR/images/" 2>/dev/null || true
+        chown -R "$FIRECRAB_USER:$FIRECRAB_GROUP" "$DATADIR/images"
+        log "images ready in $DATADIR/images"
+        return 0
+    fi
+
+    if images_present; then
+        log "images already installed in $DATADIR/images"
+        return 0
+    fi
+
+    # Nothing to copy: build one. Alpine only by default — it is ~10x smaller
+    # than Ubuntu's and builds in a container, needing no host chroot.
+    if ! ensure docker docker; then
+        warn "no docker — cannot build a guest image. Build it elsewhere and copy it into $DATADIR/images"
+        return 1
+    fi
+    if ! systemctl is-active --quiet docker 2>/dev/null; then
+        step "starting docker"
+        systemctl enable --now docker >/dev/null 2>&1 || warn "could not start docker"
+    fi
+
+    step "building the Alpine guest image (this takes a few minutes)"
+    if ! "$REPO_ROOT/scripts/firecracker-menual/install-alpine-rootfs.sh"; then
+        warn "image build failed — firecrab will start with no templates; build one later and copy it in"
+        return 1
+    fi
+
+    if [ "$WITH_UBUNTU_IMAGE" -eq 1 ]; then
+        step "building the Ubuntu guest image (large)"
+        "$REPO_ROOT/scripts/firecracker-menual/install-ubuntu-roofs.sh" \
+            || warn "Ubuntu image build failed (the Alpine one is still usable)"
+    fi
+
+    cp -rn "$REPO_ROOT/images/." "$DATADIR/images/" 2>/dev/null || true
+    chown -R "$FIRECRAB_USER:$FIRECRAB_GROUP" "$DATADIR/images"
+    log "images ready in $DATADIR/images"
+}
+
+# --- run -------------------------------------------------------------------
+
+start_units() {
+    systemctl enable --now "${UNITS[@]}"
+    sleep 1
+    local failed=0
+    for unit in "${UNITS[@]}"; do
+        if systemctl is-active --quiet "$unit"; then
+            log "$unit is running"
+        else
+            warn "$unit failed to start — journalctl -u $unit -n 30"
+            failed=1
+        fi
+    done
+    return $failed
+}
+
+do_check() {
+    log "checking host readiness (nothing will be changed)"
+    local gaps=0
+    detect_pkg && log "package manager: $PKG" || { warn "no known package manager (apt/dnf/zypper/pacman/apk)"; gaps=1; }
+    ensure_runtime_deps || gaps=1
+    ensure_firecracker || gaps=1
+    ensure_build_tools || gaps=1
+    check_kvm || gaps=1
+    check_systemd || gaps=1
+    report_images || gaps=1
+    report_ufw
+
+    if [ "$gaps" -eq 0 ]; then
+        log "host is ready — nothing missing"
+    else
+        warn "run 'sudo ./install.sh' to install the above"
+    fi
+    return 0
+}
+
+do_install() {
+    need_root
+    detect_pkg || warn "no known package manager — anything missing has to be installed by hand"
+
+    ensure_runtime_deps || die "missing runtime dependencies (see above)"
+    ensure_firecracker  || die "firecracker is required"
+    ensure_build_tools  || die "build tools are required"
+    check_kvm || warn "continuing, but VMs will not start until KVM is available"
+    check_systemd || die "this installer manages systemd units"
+
+    build_all
+    ensure_account
+    ensure_directories
+    install_binaries
+    install_config
+    install_units
+    # Deliberately non-fatal: the API now starts with no templates, and an
+    # image can be built or copied in afterwards.
+    ensure_images || warn "no guest image yet — the dashboard works, VM creation needs one"
+    start_units || die "installed, but a unit did not come up"
+    report_ufw
+
+    local bind=127.0.0.1:3000
+    log "done — dashboard at http://$bind/"
+    if ! images_present; then
+        warn "no template image installed; build one with scripts/firecracker-menual/install-alpine-rootfs.sh and copy it to $DATADIR/images"
+    fi
+}
+
+do_uninstall() {
+    need_root --uninstall
+    for unit in "${UNITS[@]}"; do
+        systemctl disable --now "$unit" 2>/dev/null || true
+        rm -f "$UNITDIR/$unit"
+    done
+    systemctl daemon-reload
+    log "units removed"
+
+    rm -f "$LIBDIR/firecrab-api" "$LIBDIR/firecrab-net-helper"
+    rm -rf "$SHAREDIR/dashboard"
+    rmdir --ignore-fail-on-non-empty "$LIBDIR" "$SHAREDIR" 2>/dev/null || true
+    log "binaries and dashboard removed"
+
+    # Left alone on purpose: the account, the config and the data directory.
+    # Bridges and nftables tables belong to the helper, which is now stopped;
+    # they disappear on the next reboot.
+    if [ "$PURGE" -eq 1 ]; then
+        warn "purging $DATADIR and $CONFDIR (all VM disks and the database)"
+        rm -rf "$DATADIR" "$CONFDIR"
+    else
+        log "kept $DATADIR and $CONFDIR — pass --purge to delete them too"
+    fi
+}
+
+case "$MODE" in
+    check) do_check ;;
+    install) do_install ;;
+    uninstall) do_uninstall ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,10 @@ pkg_name() {
         apk:e2fsprogs) echo "e2fsprogs-extra" ;;
         *:e2fsprogs)  echo "e2fsprogs" ;;
         *:curl)       echo "curl" ;;
+        # scripts/install-firecracker.sh needs find and tar; a minimal
+        # openSUSE or Debian install has neither.
+        *:findutils)  echo "findutils" ;;
+        *:tar)        echo "tar" ;;
         # cargo needs a linker; rustup only warns that one is missing and the
         # build then fails at link time with a much less obvious error.
         apt-get:cc)   echo "build-essential" ;;
@@ -198,7 +202,8 @@ report_ufw() {
 
 # --- dependency resolution -------------------------------------------------
 
-# The commands the two daemons shell out to while running.
+# The commands the two daemons shell out to while running, plus the handful the
+# installer's own helper scripts need.
 ensure_runtime_deps() {
     local failed=0
     ensure ip iproute2   || failed=1
@@ -206,6 +211,8 @@ ensure_runtime_deps() {
     ensure dnsmasq dnsmasq || failed=1
     ensure mkfs.ext4 e2fsprogs || failed=1
     ensure curl curl     || failed=1
+    ensure find findutils || failed=1
+    ensure tar tar       || failed=1
     return $failed
 }
 

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ Usage: sudo ./install.sh [OPTIONS]
 
   (no options)        install everything that is missing, then start firecrab
   --check             report what is missing and what would be installed
+  --deps-only         install the dependencies, then stop (no host changes)
   --no-deps           never install packages/toolchains, only report gaps
   --no-images         do not build a guest image
   --with-ubuntu-image also build the Ubuntu image (large, needs root chroot)
@@ -61,6 +62,7 @@ need_root() { [ "$(id -u)" -eq 0 ] || die "run as root: sudo ./install.sh $*"; }
 while [ $# -gt 0 ]; do
     case "$1" in
         --check) MODE=check ;;
+        --deps-only) MODE=deps ;;
         --no-deps) INSTALL_DEPS=0 ;;
         --no-images) WITH_IMAGES=0 ;;
         --with-ubuntu-image) WITH_UBUNTU_IMAGE=1 ;;
@@ -87,15 +89,24 @@ detect_pkg() {
 pkg_name() {
     local generic=$1
     case "$PKG:$generic" in
-        apt-get:iproute2|dnf:iproute2)  echo "iproute2" ;;
-        zypper:iproute2|pacman:iproute2|apk:iproute2) echo "iproute2" ;;
+        # Fedora/RHEL call it iproute; everyone else iproute2.
+        dnf:iproute2) echo "iproute" ;;
+        *:iproute2)   echo "iproute2" ;;
         *:nftables)   echo "nftables" ;;
         *:dnsmasq)    echo "dnsmasq" ;;
         apk:e2fsprogs) echo "e2fsprogs-extra" ;;
         *:e2fsprogs)  echo "e2fsprogs" ;;
         *:curl)       echo "curl" ;;
-        apt-get:node) echo "nodejs npm" ;;
-        pacman:node)  echo "nodejs npm" ;;
+        # cargo needs a linker; rustup only warns that one is missing and the
+        # build then fails at link time with a much less obvious error.
+        apt-get:cc)   echo "build-essential" ;;
+        apk:cc)       echo "build-base" ;;
+        *:cc)         echo "gcc" ;;
+        # Node is the one dependency nobody names the same way. openSUSE has
+        # meta packages; Fedora ships only versioned streams (nodejs22-npm-bin
+        # and friends), so the unversioned guess below simply fails there and
+        # `ensure_build_tools` carries on without the dashboard.
+        zypper:node)  echo "nodejs-default npm-default" ;;
         *:node)       echo "nodejs npm" ;;
         apt-get:docker) echo "docker.io" ;;
         *:docker)     echo "docker" ;;
@@ -244,8 +255,14 @@ ensure_build_tools() {
         failed=1
     fi
 
-    if [ "$WITH_FRONTEND" -eq 1 ]; then
-        ensure npm node || failed=1
+    ensure cc cc || failed=1
+
+    if [ "$WITH_FRONTEND" -eq 1 ] && ! ensure npm node; then
+        # Degraded, not fatal: the API and MicroNetworks work without the
+        # dashboard, and node package names vary too much between distributions
+        # to fail an install over. Build it later and re-run.
+        warn "no npm — installing without the dashboard (re-run after installing Node)"
+        WITH_FRONTEND=0
     fi
     return $failed
 }
@@ -482,16 +499,33 @@ do_check() {
     return 0
 }
 
+# Installs what firecrab needs and stops there — no account, directories, units
+# or services. This is the part that differs per distribution, so it is what a
+# container without systemd (and CI's distro matrix) can usefully exercise.
+do_deps() {
+    need_root --deps-only
+    detect_pkg || die "no known package manager (apt/dnf/zypper/pacman/apk)"
+
+    ensure_runtime_deps || die "missing runtime dependencies (see above)"
+    ensure_firecracker  || die "firecracker is required"
+    ensure_build_tools  || die "build tools are required"
+    check_kvm || warn "no KVM here; that only matters where VMs actually run"
+    report_ufw
+    log "dependencies ready — run without --deps-only to install firecrab"
+}
+
 # The default path: fill the gaps, build, lay out, start.
 do_install() {
     need_root
+    # Checked before anything is installed: refusing after pulling in five
+    # packages would be a waste of the operator's time.
+    check_systemd || die "this installer manages systemd units"
     detect_pkg || warn "no known package manager — anything missing has to be installed by hand"
 
     ensure_runtime_deps || die "missing runtime dependencies (see above)"
     ensure_firecracker  || die "firecracker is required"
     ensure_build_tools  || die "build tools are required"
     check_kvm || warn "continuing, but VMs will not start until KVM is available"
-    check_systemd || die "this installer manages systemd units"
 
     build_all
     ensure_account
@@ -540,6 +574,7 @@ do_uninstall() {
 
 case "$MODE" in
     check) do_check ;;
+    deps) do_deps ;;
     install) do_install ;;
     uninstall) do_uninstall ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ PURGE=0
 PKG=''          # detected package manager
 PKG_UPDATED=0   # index refreshed at most once
 
+# Help text, also printed before failing on an unknown option.
 usage() {
     cat <<'USAGE'
 Usage: sudo ./install.sh [OPTIONS]
@@ -74,6 +75,7 @@ done
 
 # --- package manager -------------------------------------------------------
 
+# Sets PKG to the first package manager found; returns 1 if none is.
 detect_pkg() {
     for candidate in apt-get dnf zypper pacman apk; do
         if have "$candidate"; then PKG=$candidate; return 0; fi
@@ -101,6 +103,7 @@ pkg_name() {
     esac
 }
 
+# Refreshes the package index at most once per run.
 pkg_refresh() {
     [ "$PKG_UPDATED" -eq 1 ] && return 0
     case "$PKG" in
@@ -111,15 +114,15 @@ pkg_refresh() {
     PKG_UPDATED=1
 }
 
+# Installs the named packages with whichever manager was detected.
 pkg_install() {
     pkg_refresh
-    # shellcheck disable=SC2086 # deliberate word splitting: one name can map to two packages
     case "$PKG" in
-        apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $* ;;
-        dnf) dnf install -y -q $* ;;
-        zypper) zypper --non-interactive install -y $* ;;
-        pacman) pacman -Sy --noconfirm --needed $* ;;
-        apk) apk add --no-cache $* ;;
+        apt-get) DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$@" ;;
+        dnf) dnf install -y -q "$@" ;;
+        zypper) zypper --non-interactive install -y "$@" ;;
+        pacman) pacman -Sy --noconfirm --needed "$@" ;;
+        apk) apk add --no-cache "$@" ;;
         *) return 1 ;;
     esac
 }
@@ -129,21 +132,24 @@ ensure() {
     local command_name=$1 generic=$2 packages
     have "$command_name" && return 0
 
-    packages=$(pkg_name "$generic")
+    # One generic name can map to two packages (nodejs + npm), so the words are
+    # split here, deliberately, into an array rather than left to the shell.
+    read -ra packages <<<"$(pkg_name "$generic")"
     if [ "$MODE" = check ]; then
-        warn "missing: $command_name (would install: $packages)"
+        warn "missing: $command_name (would install: ${packages[*]})"
         return 1
     fi
-    [ "$INSTALL_DEPS" -eq 1 ] || { warn "missing: $command_name (--no-deps, install '$packages' yourself)"; return 1; }
-    [ -n "$PKG" ] || { warn "missing: $command_name and no known package manager — install '$packages' yourself"; return 1; }
+    [ "$INSTALL_DEPS" -eq 1 ] || { warn "missing: $command_name (--no-deps, install '${packages[*]}' yourself)"; return 1; }
+    [ -n "$PKG" ] || { warn "missing: $command_name and no known package manager — install '${packages[*]}' yourself"; return 1; }
 
-    step "installing $packages (for $command_name)"
-    pkg_install "$packages" || { warn "failed to install $packages"; return 1; }
+    step "installing ${packages[*]} (for $command_name)"
+    pkg_install "${packages[@]}" || { warn "failed to install ${packages[*]}"; return 1; }
     have "$command_name"
 }
 
 # --- host checks -----------------------------------------------------------
 
+# A VM cannot start without /dev/kvm, and this script cannot supply it.
 check_kvm() {
     if [ -e /dev/kvm ]; then
         log "/dev/kvm present"
@@ -154,6 +160,7 @@ check_kvm() {
     return 1
 }
 
+# The units need a running systemd, not merely the binary.
 check_systemd() {
     if [ -d /run/systemd/system ]; then
         log "systemd is running"
@@ -163,6 +170,7 @@ check_systemd() {
     return 1
 }
 
+# UFW is not ours to change, so its DHCP block is reported, not fixed.
 report_ufw() {
     have ufw || return 0
     local status
@@ -179,6 +187,7 @@ report_ufw() {
 
 # --- dependency resolution -------------------------------------------------
 
+# The commands the two daemons shell out to while running.
 ensure_runtime_deps() {
     local failed=0
     ensure ip iproute2   || failed=1
@@ -189,6 +198,7 @@ ensure_runtime_deps() {
     return $failed
 }
 
+# Comes from its own upstream script rather than a distro package.
 ensure_firecracker() {
     have firecracker && { log "firecracker present"; return 0; }
 
@@ -203,6 +213,7 @@ ensure_firecracker() {
     have firecracker
 }
 
+# cargo, plus npm when the dashboard is being built.
 ensure_build_tools() {
     local failed=0
 
@@ -213,8 +224,18 @@ ensure_build_tools() {
         failed=1
     elif [ "$INSTALL_DEPS" -eq 1 ]; then
         step "installing the Rust toolchain (rustup)"
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path \
-            || { warn "rustup install failed"; failed=1; }
+        # Downloaded whole, then run - piping curl into sh executes whatever
+        # arrived if the transfer is cut off partway.
+        local installer
+        installer=$(mktemp)
+        # shellcheck disable=SC2064 # expand the path now, not at trap time
+        trap "rm -f '$installer'" RETURN
+        if curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$installer"; then
+            sh "$installer" -y --no-modify-path || { warn "rustup install failed"; failed=1; }
+        else
+            warn "could not download the rustup installer"
+            failed=1
+        fi
         # rustup lands in $HOME/.cargo for whoever runs this (root under sudo).
         export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
         have cargo || { warn "cargo still not on PATH"; failed=1; }
@@ -231,6 +252,7 @@ ensure_build_tools() {
 
 # --- build -----------------------------------------------------------------
 
+# Release binaries, and the dashboard bundle unless it was skipped.
 build_all() {
     step "building the workspace (release)"
     ( cd "$REPO_ROOT" && cargo build --release --workspace )
@@ -243,6 +265,7 @@ build_all() {
 
 # --- host layout -----------------------------------------------------------
 
+# The account the API runs as, in the kvm group for firecracker.
 ensure_account() {
     if getent group "$FIRECRAB_GROUP" >/dev/null; then
         log "group $FIRECRAB_GROUP exists"
@@ -266,6 +289,7 @@ ensure_account() {
     fi
 }
 
+# Data, config and install directories with their intended owners.
 ensure_directories() {
     install -d -o root -g root -m 0755 "$LIBDIR" "$SHAREDIR"
     install -d -o "$FIRECRAB_USER" -g "$FIRECRAB_GROUP" -m 0750 \
@@ -274,6 +298,7 @@ ensure_directories() {
     log "directories ready under $DATADIR, $CONFDIR"
 }
 
+# Puts the built binaries, and the dashboard, where the units expect them.
 install_binaries() {
     local target="$REPO_ROOT/target/release"
     for binary in firecrab-api firecrab-net-helper; do
@@ -292,6 +317,7 @@ install_binaries() {
     log "dashboard installed to $SHAREDIR/dashboard"
 }
 
+# Seeds api.env once so an operator's edits survive a re-run.
 install_config() {
     if [ -f "$CONFDIR/api.env" ]; then
         log "keeping existing $CONFDIR/api.env"
@@ -312,6 +338,7 @@ ENVFILE
     log "wrote $CONFDIR/api.env"
 }
 
+# Renders the unit templates with this host's paths and account.
 install_units() {
     local uid
     uid=$(id -u "$FIRECRAB_USER")
@@ -332,10 +359,12 @@ install_units() {
 
 # --- guest images ----------------------------------------------------------
 
+# Whether a guest rootfs is already installed.
 images_present() {
     compgen -G "$DATADIR/images/rootfs/*.ext4" >/dev/null 2>&1
 }
 
+# Whether the repo has images that can be copied instead of built.
 repo_images_present() {
     compgen -G "$REPO_ROOT/images/rootfs/*.ext4" >/dev/null 2>&1
 }
@@ -363,6 +392,7 @@ report_images() {
     return 1
 }
 
+# Gets a guest image into place: copy from the repo, otherwise build one.
 ensure_images() {
     [ "$WITH_IMAGES" -eq 1 ] || { log "skipping images (--no-images)"; return 0; }
 
@@ -410,6 +440,7 @@ ensure_images() {
 
 # --- run -------------------------------------------------------------------
 
+# Enables and starts both units, then confirms they really came up.
 start_units() {
     systemctl enable --now "${UNITS[@]}"
     sleep 1
@@ -425,10 +456,16 @@ start_units() {
     return $failed
 }
 
+# Report-only path: every gap, no changes, no root required.
 do_check() {
     log "checking host readiness (nothing will be changed)"
     local gaps=0
-    detect_pkg && log "package manager: $PKG" || { warn "no known package manager (apt/dnf/zypper/pacman/apk)"; gaps=1; }
+    if detect_pkg; then
+        log "package manager: $PKG"
+    else
+        warn "no known package manager (apt/dnf/zypper/pacman/apk)"
+        gaps=1
+    fi
     ensure_runtime_deps || gaps=1
     ensure_firecracker || gaps=1
     ensure_build_tools || gaps=1
@@ -445,6 +482,7 @@ do_check() {
     return 0
 }
 
+# The default path: fill the gaps, build, lay out, start.
 do_install() {
     need_root
     detect_pkg || warn "no known package manager — anything missing has to be installed by hand"
@@ -474,6 +512,7 @@ do_install() {
     fi
 }
 
+# Removes what this script installed; data only with --purge.
 do_uninstall() {
     need_root --uninstall
     for unit in "${UNITS[@]}"; do

--- a/packaging/systemd/firecrab-api.service
+++ b/packaging/systemd/firecrab-api.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=firecrab API and dashboard
+Documentation=https://github.com/pista/firecrab
+After=firecrab-net-helper.service network-online.target
+Wants=firecrab-net-helper.service
+
+[Service]
+Type=simple
+User=@FIRECRAB_USER@
+Group=@FIRECRAB_GROUP@
+# Not cosmetic: the DB (data/firecrab.db) and VM artifacts (data/vms/<id>/) are
+# resolved relative to the working directory. Start this anywhere else and it
+# silently opens a different, empty database.
+WorkingDirectory=@DATADIR@
+Environment=FIRECRAB_IMAGE_ROOT=@DATADIR@/images
+Environment=FIRECRAB_STATIC_ROOT=@SHAREDIR@/dashboard
+EnvironmentFile=-@CONFDIR@/api.env
+ExecStart=@LIBDIR@/firecrab-api
+Restart=on-failure
+RestartSec=2
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectSystem=full
+ReadWritePaths=@DATADIR@ /run/firecrab
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/firecrab-net-helper.service
+++ b/packaging/systemd/firecrab-net-helper.service
@@ -34,7 +34,11 @@ RestartSec=2
 #                     A uid-0 process with CAP_KILL removed cannot signal a
 #                     process of another uid — the kernel checks the capability,
 #                     not the uid.
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_KILL
+#   CHOWN             dnsmasq hands its pid file to the user it drops to. CI
+#                     caught this one: without it the journal carries "chown of
+#                     PID file /run/firecrab/dnsmasq.pid failed: Operation not
+#                     permitted" on every start.
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_KILL CAP_CHOWN
 NoNewPrivileges=yes
 
 # Deliberately mild: this process shells out to nft/ip and supervises dnsmasq,

--- a/packaging/systemd/firecrab-net-helper.service
+++ b/packaging/systemd/firecrab-net-helper.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=firecrab privileged network helper
+Documentation=https://github.com/pista/firecrab
+# Owns the bridges, TAPs, nftables tables and dnsmasq that the API asks for.
+# Must be listening before the API's startup reconcile runs, or the API only
+# logs a warning and the host side stays unprovisioned until the next VM start.
+After=network-pre.target
+Wants=network-pre.target
+Before=firecrab-api.service
+
+[Service]
+Type=simple
+# root for CAP_NET_ADMIN; the group is what makes the socket reachable — the
+# helper chmods it 0660 and takes its group from this process, so the API's
+# account must be in @FIRECRAB_GROUP@.
+User=root
+Group=@FIRECRAB_GROUP@
+RuntimeDirectory=firecrab
+RuntimeDirectoryMode=0750
+Environment=FIRECRAB_NET_HELPER_ALLOWED_UID=@FIRECRAB_UID@
+ExecStart=@LIBDIR@/firecrab-net-helper
+Restart=on-failure
+RestartSec=2
+
+# Deliberately mild: this process shells out to nft/ip and supervises dnsmasq,
+# which inherit the namespace. ProtectSystem=strict would take /var with it and
+# break dnsmasq's lease file.
+ProtectHome=yes
+ProtectSystem=full
+ReadWritePaths=/run/firecrab
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/firecrab-net-helper.service
+++ b/packaging/systemd/firecrab-net-helper.service
@@ -22,6 +22,21 @@ ExecStart=@LIBDIR@/firecrab-net-helper
 Restart=on-failure
 RestartSec=2
 
+# Still uid 0, but with everything it does not use taken away. Each of these is
+# load-bearing; dropping one breaks a specific operation at runtime rather than
+# at startup:
+#   NET_ADMIN         bridges and TAPs over rtnetlink, and the nftables tables
+#   NET_RAW           dnsmasq's raw DHCP sockets
+#   NET_BIND_SERVICE  dnsmasq binds 67 (DHCP) and 53 (DNS)
+#   SETUID, SETGID    dnsmasq drops to an unprivileged user after startup
+#   KILL              signalling dnsmasq once it has dropped to that user:
+#                     SIGHUP to reload, SIGTERM to stop, signal 0 to probe it.
+#                     A uid-0 process with CAP_KILL removed cannot signal a
+#                     process of another uid — the kernel checks the capability,
+#                     not the uid.
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID CAP_KILL
+NoNewPrivileges=yes
+
 # Deliberately mild: this process shells out to nft/ip and supervises dnsmasq,
 # which inherit the namespace. ProtectSystem=strict would take /var with it and
 # break dnsmasq's lease file.


### PR DESCRIPTION
Running firecrab meant three terminals by hand - the net-helper, the API, and a Vite dev server whose proxy is the only thing that let the browser reach the API. Nothing came back after a reboot, and bringing it up on a fresh machine meant following docs step by step.

- install.sh: works out what is missing and installs it, with no separate bootstrap flag. Packages come from whichever manager the host has (apt/dnf/zypper/pacman/apk), firecracker from the existing script, Rust from rustup, and the guest image is copied from the repo or built with docker. KVM is the one thing it cannot install, so it says exactly what to fix. Then it creates the firecrab account (with kvm group), lays out /var/lib/firecrab and /etc/firecrab, installs binaries and dashboard, renders the units and starts them
- --check reports the same findings unprivileged and changes nothing; --uninstall keeps data unless --purge. Re-running is safe, so it doubles as a repair
- systemd units: the helper runs as root but with Group=firecrab, which is what makes its 0660 socket reachable at all - getting that wrong is exactly how the API failed to connect earlier this week. The API gets WorkingDirectory pinned, because its DB and VM artifacts are resolved relative to it
- the API serves the built dashboard when FIRECRAB_STATIC_ROOT points at a dist/ with an index.html, with SPA fallback. /api and /ws keep answering JSON 404 so a mistyped path never comes back as HTML
- a template whose image files are not built yet is now skipped with a warning instead of failing startup. Otherwise an install that has not built a multi-gigabyte rootfs yet cannot even bring the API up, and one missing file takes the dashboard and every existing VM with it. Files that are present are still hashed and verified as before
- the READMEs (all four languages) lead with the installer and keep the three-terminal flow as the development path, where it also now mentions the net-helper it had been silently omitting

Verified: cargo fmt/clippy/test --workspace green (158/20/16/56), cargo doc clean, server.rs 18% -> 80% and templates.rs 93% coverage. Live: the dashboard, its assets, a client-side route, the API and the console WebSocket all answer correctly with no dev server running; --check runs as a normal user and provably leaves the filesystem untouched. The full install is not verified end to end - it creates a system account and units, which would collide with the current manual setup on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a one-command host installer with `--check` and uninstall/purge semantics; the API can serve a built dashboard directly (SPA fallback included).
  * Same-origin requests from dashboard pages are now allowed for API actions.
  * Optional guest image artifacts are skipped when missing instead of blocking startup.
  * Added hardened systemd units for the API and network helper.

* **Documentation**
  * Updated multilingual install/development docs, including new install/validation guidance and static-dashboard behavior.

* **Tests**
  * Added CI coverage and tests for installer idempotency, routing/dashboard behavior, and service setup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->