### PR TITLE
Fix/network readiness timeout

### DIFF
--- a/firecrab-api/src/firecracker.rs
+++ b/firecrab-api/src/firecracker.rs
@@ -492,10 +492,8 @@ pub async fn spawn_vm(
         .stdout(Stdio::piped())
         .stderr(Stdio::from(stderr))
         .kill_on_drop(true);
-    // Firecracker defaults to virtio-mmio. Rocky Linux 9's stock kernel has
-    // that transport disabled but ships virtio-pci, so only its template
-    // opts into the VMM's PCI device model. Other templates retain the
-    // smaller/default MMIO layout.
+    // Firecracker defaults to virtio-mmio. Templates whose distro kernels
+    // need the PCI device model opt in through `requires_pci_transport`.
     if enable_pci {
         command.arg("--enable-pci");
     }

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -745,10 +745,12 @@ async fn finish_run_start(
     template: std::sync::Arc<crate::templates::TemplateVersion>,
     network: &VmNetwork,
 ) -> Result<FirecrackerProcess, String> {
-    // Rocky Linux 9's stock kernel supports virtio-pci but not Firecracker's
-    // default virtio-mmio transport. Capture this before the template Arc is
-    // moved into the blocking disk/configuration task below.
+    // Capture transport-derived values before the template Arc is moved into
+    // the blocking disk/configuration task below. `runtime_boot_args` also
+    // repairs legacy registrations (Ubuntu's `pci=off`, Rocky's missing
+    // virtio_net preload) without requiring users to recreate their VMs.
     let enable_pci = template.requires_pci_transport();
+    let runtime_boot_args = template.runtime_boot_args();
     // Same reasoning as `enable_pci` above: `template` is moved into the
     // spawn_blocking closure below, so anything this function still needs
     // afterward — like gating the network-ready wait on MicroBoot below —
@@ -804,7 +806,7 @@ async fn finish_run_start(
             &record,
             &kernel,
             initrd.as_deref(),
-            &template.boot_args,
+            &runtime_boot_args,
             Some(&network),
         )
         .map_err(|error| format!("config generation failed: {error}"))?;
@@ -2366,6 +2368,69 @@ while True:
         assert_eq!(db_state(&state, vm.id), Some(VmState::Stopped));
         assert!(!process_alive(pid));
         assert!(state.processes.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_repairs_a_legacy_ubuntu_mmio_registration() {
+        let directory = short_tempdir();
+        let root = directory.path();
+        let binary = fake_firecracker(
+            root,
+            &format!(
+                "if '--enable-pci' not in sys.argv:\n    raise SystemExit('missing --enable-pci')\nsignal.signal(signal.SIGTERM, lambda *_: sys.exit(0)){SERVE_LOOP}"
+            ),
+        );
+        let state = test_state_with_binary(root, binary).await;
+        state
+            .templates
+            .register_spec(TemplateSpec {
+                alias: "ubuntu-26.04".to_owned(),
+                version: "ubuntu-26.04-v2".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: "console=ttyS0 pci=off root=/dev/vda rw".to_owned(),
+            })
+            .unwrap();
+
+        let mut vm = record("legacy-ubuntu", Uuid::new_v4());
+        vm.template = "ubuntu-26.04".to_owned();
+        vm.template_version = "ubuntu-26.04-v2".to_owned();
+        seed_vm(&state, &vm);
+
+        let Json(started) = start_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(started.state, VmState::Running);
+        let runtime_id = state
+            .vms
+            .lock()
+            .unwrap()
+            .get(&vm.id)
+            .and_then(|live| live.last_runtime_id)
+            .expect("start must retain its runtime id");
+        let config_path = crate::artifacts::VmArtifactPaths::for_vm(&state.runtime.vms_dir, vm.id)
+            .runtime(runtime_id)
+            .config;
+        let config: serde_json::Value =
+            serde_json::from_slice(&fs::read(config_path).unwrap()).unwrap();
+        let boot_args = config["boot-source"]["boot_args"].as_str().unwrap();
+        assert!(!boot_args.split_whitespace().any(|arg| arg == "pci=off"));
+        assert!(boot_args.contains("root=/dev/vda"));
+
+        let Json(stopped) = stop_vm(
+            State(state),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(stopped.state, VmState::Stopped);
     }
 
     async fn stop_tolerates_a_failed_teardown_step(fail_operation: &'static str) {

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -2422,6 +2422,11 @@ while True:
         let boot_args = config["boot-source"]["boot_args"].as_str().unwrap();
         assert!(!boot_args.split_whitespace().any(|arg| arg == "pci=off"));
         assert!(boot_args.contains("root=/dev/vda"));
+        assert!(
+            boot_args
+                .split_whitespace()
+                .any(|arg| arg == "net.ifnames=0")
+        );
 
         let Json(stopped) = stop_vm(
             State(state),

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -169,6 +169,13 @@ impl TemplateVersion {
             args.push("rd.driver.pre=virtio_net");
         }
 
+        // Both distro images configure their network manager for `eth0`.
+        // PCI's predictable naming would otherwise expose the NIC as an
+        // ens*/enp* device and leave that configuration unmatched.
+        if enable_pci && !args.contains(&"net.ifnames=0") {
+            args.push("net.ifnames=0");
+        }
+
         args.join(" ")
     }
 }
@@ -1252,6 +1259,7 @@ mod tests {
         assert!(ubuntu.requires_pci_transport());
         assert!(!ubuntu.runtime_boot_args().contains("pci=off"));
         assert!(ubuntu.runtime_boot_args().contains("root=/dev/vda"));
+        assert!(ubuntu.runtime_boot_args().contains("net.ifnames=0"));
 
         let rocky = registry
             .resolve_alias("rocky-9")

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -142,14 +142,34 @@ impl TemplateVersion {
     }
 
     /// Whether this image must be started with Firecracker's PCI transport
-    /// enabled. Firecracker normally presents virtio devices over MMIO, but
-    /// Rocky Linux 9's stock EL9 kernel deliberately has
-    /// `CONFIG_VIRTIO_MMIO` disabled while keeping `CONFIG_VIRTIO_PCI`
-    /// built in. Its rootfs and dracut initramfs are otherwise valid, so
-    /// choose PCI for this one built-in template rather than replacing the
-    /// distro kernel with an unrelated one.
+    /// enabled. Rocky Linux 9 needs PCI because its stock kernel disables
+    /// `CONFIG_VIRTIO_MMIO`. Ubuntu 26.04 also uses PCI because its stock
+    /// kernel rejects Firecracker 1.16's command-line MMIO regions as busy,
+    /// while its virtio-pci transport is built in.
     pub fn requires_pci_transport(&self) -> bool {
-        self.name == "rocky-9"
+        matches!(self.name.as_str(), "rocky-9" | "ubuntu-26.04")
+    }
+
+    /// Returns the kernel command line adjusted for the transport selected
+    /// by [`Self::requires_pci_transport`]. This intentionally happens at
+    /// start time so VMs pinned to registrations made before the transport
+    /// fix also recover on their next start.
+    pub fn runtime_boot_args(&self) -> String {
+        let enable_pci = self.requires_pci_transport();
+        let mut args: Vec<&str> = self
+            .boot_args
+            .split_whitespace()
+            .filter(|arg| !(enable_pci && *arg == "pci=off"))
+            .collect();
+
+        // The EL9 initramfs contains virtio_net, but does not load it merely
+        // because the PCI device exists. Force it before switching to the
+        // rootfs so NetworkManager sees the interface immediately.
+        if self.name == "rocky-9" && !args.contains(&"rd.driver.pre=virtio_net") {
+            args.push("rd.driver.pre=virtio_net");
+        }
+
+        args.join(" ")
     }
 }
 
@@ -1214,21 +1234,42 @@ mod tests {
         assert!(rocky.boot_args.contains("net.ifnames=0"));
 
         let directory = tempdir().unwrap();
-        for relative in [&rocky.kernel, &rocky.rootfs]
-            .into_iter()
-            .chain(rocky.initrd.as_ref())
-        {
-            let path = directory.path().join(relative);
-            fs::create_dir_all(path.parent().unwrap()).unwrap();
-            fs::write(path, b"image").unwrap();
+        for spec in &specs {
+            for relative in [&spec.kernel, &spec.rootfs]
+                .into_iter()
+                .chain(spec.initrd.as_ref())
+            {
+                let path = directory.path().join(relative);
+                fs::create_dir_all(path.parent().unwrap()).unwrap();
+                fs::write(path, b"image").unwrap();
+            }
         }
-        let registry = TemplateRegistry::from_specs(directory.path(), [rocky.clone()]).unwrap();
-        assert!(
-            registry
-                .resolve_alias("rocky-9")
-                .expect("Rocky template resolves")
-                .requires_pci_transport()
+        let registry = TemplateRegistry::from_specs(directory.path(), specs).unwrap();
+
+        let ubuntu = registry
+            .resolve_alias("ubuntu-26.04")
+            .expect("Ubuntu template resolves");
+        assert!(ubuntu.requires_pci_transport());
+        assert!(!ubuntu.runtime_boot_args().contains("pci=off"));
+        assert!(ubuntu.runtime_boot_args().contains("root=/dev/vda"));
+
+        let rocky = registry
+            .resolve_alias("rocky-9")
+            .expect("Rocky template resolves");
+        assert!(rocky.requires_pci_transport());
+        assert_eq!(
+            rocky
+                .runtime_boot_args()
+                .matches("rd.driver.pre=virtio_net")
+                .count(),
+            1
         );
+
+        let alpine = registry
+            .resolve_alias("alpine-3.24")
+            .expect("Alpine template resolves");
+        assert!(!alpine.requires_pci_transport());
+        assert!(alpine.runtime_boot_args().contains("pci=off"));
     }
 
     #[test]

--- a/firecrab-net-helper/src/dhcp.rs
+++ b/firecrab-net-helper/src/dhcp.rs
@@ -68,6 +68,9 @@ pub enum DhcpError {
     /// Couldn't signal the running dnsmasq process to reload.
     #[error("failed to reload the running dnsmasq process")]
     Reload(#[source] io::Error),
+    /// Couldn't inspect the supervised dnsmasq process.
+    #[error("failed to inspect the running dnsmasq process")]
+    Inspect(#[source] io::Error),
 }
 
 /// Single-writer actor: every reservation-file rewrite goes through one
@@ -271,7 +274,14 @@ pub async fn sync_dhcp_leases(
 ) -> Result<(), DhcpError> {
     let mut state = actor.state.lock().await;
     let networks_changed = state.served_networks.as_deref() != Some(micro_networks);
-    if is_stale_snapshot(state.applied_revision, revision, networks_changed) {
+    let dnsmasq_running = owned_child_running(&mut state)?
+        || (state.child.is_none() && running_orphan_pid().await.is_some());
+    if can_skip_snapshot(
+        state.applied_revision,
+        revision,
+        networks_changed,
+        dnsmasq_running,
+    ) {
         return Ok(());
     }
 
@@ -324,6 +334,35 @@ fn is_stale_snapshot(applied_revision: Option<u64>, revision: u64, networks_chan
     !networks_changed && applied_revision.is_some_and(|applied| applied >= revision)
 }
 
+/// A duplicate lease snapshot is safe to skip only while the process serving
+/// it is still alive. VM starts resend the same revision, so this health gate
+/// is also how a crashed dnsmasq is recovered without operator intervention.
+fn can_skip_snapshot(
+    applied_revision: Option<u64>,
+    revision: u64,
+    networks_changed: bool,
+    dnsmasq_running: bool,
+) -> bool {
+    dnsmasq_running && is_stale_snapshot(applied_revision, revision, networks_changed)
+}
+
+/// Reaps an exited supervised child and reports whether it is still running.
+/// Merely retaining a [`Child`] handle is not a liveness check: an exited,
+/// unreaped child still has a PID and accepts `kill(pid, 0)` as a zombie.
+fn owned_child_running(state: &mut DhcpState) -> Result<bool, DhcpError> {
+    let Some(child) = state.child.as_mut() else {
+        return Ok(false);
+    };
+    match child.try_wait().map_err(DhcpError::Inspect)? {
+        None => Ok(true),
+        Some(status) => {
+            eprintln!("[WARN] dnsmasq exited with {status}; restarting it on this DHCP sync");
+            state.child = None;
+            Ok(false)
+        }
+    }
+}
+
 /// Terminates whatever dnsmasq is currently running — this process's own
 /// child if it has one, otherwise an orphan left by a previous net-helper
 /// lifetime (found via its pid file). Best-effort: if nothing is running, or
@@ -342,14 +381,28 @@ async fn stop_running_dnsmasq(state: &mut DhcpState) {
 }
 
 /// Reads dnsmasq's own pid file and returns its pid if that process is
-/// still alive — a `kill(pid, 0)` existence probe, not a real signal.
+/// still alive and is not a zombie. `kill(pid, 0)` alone is insufficient:
+/// Linux reports success for an unreaped zombie, which cannot serve DHCP or
+/// react to SIGHUP.
 async fn running_orphan_pid() -> Option<u32> {
     let text = tokio::fs::read_to_string(PID_FILE).await.ok()?;
     let pid: u32 = text.trim().parse().ok()?;
     // SAFETY: signal 0 sends nothing; it only probes whether `pid` exists
     // and is signalable, per kill(2).
-    let alive = unsafe { libc::kill(pid as i32, 0) } == 0;
-    alive.then_some(pid)
+    if unsafe { libc::kill(pid as i32, 0) } != 0 {
+        return None;
+    }
+    let stat = tokio::fs::read_to_string(format!("/proc/{pid}/stat"))
+        .await
+        .ok()?;
+    (proc_state(&stat) != Some('Z')).then_some(pid)
+}
+
+/// Extracts the one-character process state after `/proc/<pid>/stat`'s
+/// parenthesized command name. Use the last delimiter because a command name
+/// itself may contain `)` characters.
+fn proc_state(stat: &str) -> Option<char> {
+    stat.rsplit_once(") ")?.1.chars().next()
 }
 
 /// Tells `pid` (not necessarily a process this instance spawned) to
@@ -485,11 +538,10 @@ async fn spawn_dnsmasq(
 /// Tells a running dnsmasq to re-read its hosts file.
 fn reload(child: &mut Child) -> Result<(), DhcpError> {
     let Some(pid) = child.id() else {
-        // Already exited; nothing to signal. The next sync_dhcp_leases call
-        // will find `state.child` still `Some` but this reload a no-op —
-        // acceptable since a crashed dnsmasq needs an operator/supervisor
-        // restart regardless, same as any other unexpectedly-dead daemon.
-        return Ok(());
+        return Err(DhcpError::Reload(io::Error::new(
+            io::ErrorKind::NotFound,
+            "dnsmasq has already exited",
+        )));
     };
     // SAFETY: sending a signal is memory-safe; a stale/reused pid only
     // risks misdelivering the signal, not memory unsafety.
@@ -749,12 +801,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_ignores_a_stale_or_duplicate_revision() {
+    async fn sync_ignores_a_stale_or_duplicate_revision_while_dnsmasq_is_alive() {
         let actor = DhcpActor::new();
         {
             let mut state = actor.state.lock().await;
             state.applied_revision = Some(5);
             state.served_networks = Some(Vec::new());
+            state.child = Some(
+                Command::new("sleep")
+                    .arg("60")
+                    .spawn()
+                    .expect("spawn stand-in dnsmasq"),
+            );
         }
 
         // Would fail trying to actually spawn/bind dnsmasq for real if it
@@ -780,6 +838,15 @@ mod tests {
             .await
             .is_ok()
         );
+
+        let mut child = actor
+            .state
+            .lock()
+            .await
+            .child
+            .take()
+            .expect("stand-in child remains tracked");
+        child.kill().await.expect("stop stand-in dnsmasq");
     }
 
     #[test]
@@ -795,5 +862,18 @@ mod tests {
         assert!(!is_stale_snapshot(Some(5), 3, true));
         // Nothing applied yet is never stale.
         assert!(!is_stale_snapshot(None, 0, false));
+    }
+
+    #[test]
+    fn a_stale_snapshot_is_reapplied_when_dnsmasq_is_dead() {
+        assert!(can_skip_snapshot(Some(5), 5, false, true));
+        assert!(!can_skip_snapshot(Some(5), 5, false, false));
+    }
+
+    #[test]
+    fn proc_state_distinguishes_a_zombie_even_with_parentheses_in_comm() {
+        assert_eq!(proc_state("42 (dnsmasq) S 1 2 3"), Some('S'));
+        assert_eq!(proc_state("42 (dns)masq) Z 1 2 3"), Some('Z'));
+        assert_eq!(proc_state("malformed"), None);
     }
 }

--- a/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
@@ -175,6 +175,10 @@ cat >"$staging/etc/fstab" <<'EOF'
 /dev/vda / ext4 defaults 0 1
 EOF
 : >"$staging/etc/machine-id"
+install -d -m 0755 "$staging/etc/modules-load.d"
+cat >"$staging/etc/modules-load.d/firecrab-network.conf" <<'EOF'
+virtio_net
+EOF
 rm -f "$staging/etc/resolv.conf"
 cat >"$staging/etc/resolv.conf" <<'EOF'
 nameserver 172.30.0.1

--- a/scripts/firecracker-menual/install-rocky-rootfs.sh
+++ b/scripts/firecracker-menual/install-rocky-rootfs.sh
@@ -9,6 +9,8 @@
 # EL9 configures virtio-pci but deliberately leaves CONFIG_VIRTIO_MMIO off.
 # The Rocky template therefore asks the VMM for PCI transport at runtime;
 # its initramfs still carries virtio_blk/net and ext4 for the guest rootfs.
+# virtio_net is explicitly loaded because EL9 does not request it early
+# enough from Firecracker's minimal PCI topology on every boot.
 
 set -euo pipefail
 
@@ -168,6 +170,10 @@ nameserver 172.30.0.1
 EOF_RESOLV
 
 : >"$staging/etc/machine-id"
+install -d -m 0755 "$staging/etc/modules-load.d"
+cat >"$staging/etc/modules-load.d/firecrab-network.conf" <<'EOF_MODULES'
+virtio_net
+EOF_MODULES
 install -d -m 0755 "$staging/etc/NetworkManager/system-connections"
 cat >"$staging/etc/NetworkManager/system-connections/firecrab-ethernet.nmconnection" <<'EOF_NETWORK'
 [connection]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM startup compatibility across Rocky Linux 9 and Ubuntu 26.04 templates.
  * Automatically repairs legacy boot arguments and applies required PCI networking settings.
  * Improved DHCP recovery when managed or orphaned DNS services stop unexpectedly.
  * Prevented stale process states from being treated as active.

* **Improvements**
  * Rocky Linux images now automatically load the required virtual network driver at boot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->