### PR TITLE
fix(frontend): constrain shell checkbox list height

### DIFF
--- a/firecrab-frontend/src/components/ShellCheckboxList.tsx
+++ b/firecrab-frontend/src/components/ShellCheckboxList.tsx
@@ -47,41 +47,49 @@ export default function ShellCheckboxList({
     onChange(selectedIds.filter((id) => id !== shellId));
   };
 
+  const shellList = (
+    <ul className="shell-check-ul">
+      {shells.map((shell) => {
+        const checked = selectedIds.includes(shell.id);
+        const inputId = `${idPrefix}-${shell.id}`;
+        const blockNew = atCap && !checked;
+        return (
+          <li key={shell.id}>
+            <label
+              htmlFor={inputId}
+              className={
+                blockNew ? "shell-check-label is-capped" : "shell-check-label"
+              }
+            >
+              <input
+                id={inputId}
+                type="checkbox"
+                checked={checked}
+                disabled={disabled || blockNew}
+                onChange={(event) => toggle(shell.id, event.target.checked)}
+              />
+              <span className="shell-check-name" title={shell.description ?? shell.name}>
+                {shell.name}
+              </span>
+              <span className="shell-check-meta mono">v{shell.latestVersion}</span>
+            </label>
+          </li>
+        );
+      })}
+    </ul>
+  );
+
   return (
     <fieldset
       className="shell-check-list"
       disabled={disabled}
       aria-label={t("Shells", "Shell")}
     >
-      <ul className="shell-check-ul">
-        {shells.map((shell) => {
-          const checked = selectedIds.includes(shell.id);
-          const inputId = `${idPrefix}-${shell.id}`;
-          const blockNew = atCap && !checked;
-          return (
-            <li key={shell.id}>
-              <label
-                htmlFor={inputId}
-                className={
-                  blockNew ? "shell-check-label is-capped" : "shell-check-label"
-                }
-              >
-                <input
-                  id={inputId}
-                  type="checkbox"
-                  checked={checked}
-                  disabled={disabled || blockNew}
-                  onChange={(event) => toggle(shell.id, event.target.checked)}
-                />
-                <span className="shell-check-name" title={shell.description ?? shell.name}>
-                  {shell.name}
-                </span>
-                <span className="shell-check-meta mono">v{shell.latestVersion}</span>
-              </label>
-            </li>
-          );
-        })}
-      </ul>
+      {shells.length >= 3 ? (
+        <div className="shell-check-scroll">{shellList}</div>
+      ) : (
+        shellList
+      )}
       {atCap ? (
         <p className="poll-note shell-check-hint">
           {t(`Max ${MAX_SHELLS_PER_VM} shells`, `최대 ${MAX_SHELLS_PER_VM}개`)}
@@ -90,4 +98,3 @@ export default function ShellCheckboxList({
     </fieldset>
   );
 }
-

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -210,18 +210,28 @@ form.shell-create-grid .field-span-2 {
 .shell-check-list:disabled {
   opacity: 0.65;
 }
+.shell-check-scroll {
+  max-height: 7rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--bg);
+}
 .shell-check-ul {
   list-style: none;
   margin: 0;
   padding: 0.35rem 0.5rem;
-  max-height: 9.5rem;
-  overflow: auto;
   border: 1px solid var(--line);
   border-radius: 4px;
   background: var(--bg);
   display: flex;
   flex-direction: column;
   gap: 0.15rem;
+}
+.shell-check-scroll .shell-check-ul {
+  border: 0;
+  border-radius: 0;
 }
 .shell-check-label {
   display: flex;


### PR DESCRIPTION
## Summary

- wrap the shell checkbox list in a bounded scroll container when the catalog has three or more entries
- keep one- and two-shell lists on their existing unwrapped layout
- keep the border fixed around the scrolling area and contain scroll chaining

## Why

Large shell catalogs currently make the Create VM form and VM detail editor grow vertically, pushing later controls out of reach. Showing about three rows at a time keeps both forms compact without changing checkbox state or selection behavior.

Fixes #68

## Verification

- `npm ci --prefix firecrab-frontend`
- `npm run lint --prefix firecrab-frontend` (passes with the existing `react/only-export-components` warning in `src/i18n.tsx`)
- `npm run build --prefix firecrab-frontend`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Shell checkbox lists with three or more items now appear in a compact, scrollable container.
  * Added visual styling to distinguish the scroll area and improve list readability.
  * Shorter lists continue to display directly without scrolling.
  * Existing checkbox behavior and selection limits remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->