### PR TITLE
feat(network): allow VM communication within MicroNetwork

### DIFF
--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -684,7 +684,8 @@ pub struct MicroNetworkNat {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MicroNetworkFirewall {
-    /// VMs inside this network cannot reach each other.
+    /// Whether VMs inside this network are prevented from reaching each
+    /// other. Firecrab permits this traffic, so this is currently false.
     pub east_west_blocked: bool,
     /// Traffic routed to any other Firecrab network is dropped.
     pub cross_network_blocked: bool,

--- a/firecrab-api/src/handlers/micro_networks.rs
+++ b/firecrab-api/src/handlers/micro_networks.rs
@@ -132,7 +132,7 @@ pub async fn get_micro_network(
             source_cidr: network.subnet_cidr,
         },
         firewall: MicroNetworkFirewall {
-            east_west_blocked: true,
+            east_west_blocked: false,
             cross_network_blocked: true,
             anti_spoofing: true,
             default_egress: EgressPolicy::default(),
@@ -646,7 +646,7 @@ mod tests {
         assert!(detail.nat.enabled);
         assert_eq!(detail.nat.source_cidr, "172.31.0.0/24");
         // Firewall posture is what the rendered ruleset enforces.
-        assert!(detail.firewall.east_west_blocked);
+        assert!(!detail.firewall.east_west_blocked);
         assert!(detail.firewall.cross_network_blocked);
         assert!(detail.firewall.anti_spoofing);
         assert!(detail.vms.is_empty());

--- a/firecrab-frontend/src/components/MicroNetworks.tsx
+++ b/firecrab-frontend/src/components/MicroNetworks.tsx
@@ -279,7 +279,9 @@ function MicroNetworkDetail({
         <dt>{t("Firewall", "방화벽")}</dt>
         <dd>
           {[
-            firewall.eastWestBlocked && t("VM-to-VM blocked", "VM 간 차단"),
+            firewall.eastWestBlocked
+              ? t("VM-to-VM blocked", "VM 간 차단")
+              : t("VM-to-VM allowed", "VM 간 통신 허용"),
             firewall.crossNetworkBlocked && t("Cross-network blocked", "다른 네트워크 차단"),
             firewall.antiSpoofing && t("IP/MAC spoofing blocked", "IP/MAC 위조 차단"),
           ]

--- a/firecrab-helper-protocol/src/network.rs
+++ b/firecrab-helper-protocol/src/network.rs
@@ -11,9 +11,8 @@ use crate::PROTOCOL_VERSION;
 
 /// Prefix for every Firecrab-owned TAP interface name. TAP interface names
 /// are bounded by IFNAMSIZ (16 bytes incl. NUL): `fct` + 12 hex of
-/// sha256(vm_id) = 15 chars. The prefix is distinct from the bridge name
-/// (`fcbr0`) so an east-west wildcard (`fct*`) never matches the bridge
-/// itself.
+/// sha256(vm_id) = 15 chars. The prefix is distinct from MicroNetwork bridge
+/// names so rules and diagnostics can identify VM-facing interfaces.
 pub const TAP_PREFIX: &str = "fct";
 
 /// The deterministic TAP interface name for a VM. Both `firecrab-api` (to

--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -5,7 +5,7 @@
 use std::net::Ipv4Addr;
 use std::process::Stdio;
 
-use firecrab_helper_protocol::network::{MacAddr, MicroNetworkSpec, TAP_PREFIX, tap_name};
+use firecrab_helper_protocol::network::{MacAddr, MicroNetworkSpec, tap_name};
 use rtnetlink::new_connection;
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
@@ -325,8 +325,8 @@ fn render_apply_ruleset(
     // Routed traffic aimed at any Firecrab subnet is denied before the
     // per-VM egress map is consulted: that is what keeps two MicroNetworks
     // from reaching each other now that the host routes all of them. Traffic
-    // within one subnet is switched, not routed, and is denied separately by
-    // the bridge table's tap-to-tap rule.
+    // within one subnet is switched, not routed, and is intentionally allowed
+    // so VMs in the same MicroNetwork can communicate with each other.
     // Empty MicroNetwork set: still block link-local/loopback as destinations
     // for any future per-VM policy; no trailing comma that would break nft.
     let internal_destinations = if subnets.is_empty() {
@@ -388,10 +388,6 @@ fn render_apply_ruleset(
          \tchain prerouting {{\n\
          \t\ttype filter hook prerouting priority -300; policy accept;\n\
          \t\tiifname vmap @l2_ingress\n\
-         \t}}\n\
-         \tchain forward {{\n\
-         \t\ttype filter hook forward priority -200; policy accept;\n\
-         \t\tiifname \"{TAP_PREFIX}*\" oifname \"{TAP_PREFIX}*\" drop\n\
          \t}}\n\
          }}\n"
     ))
@@ -797,11 +793,14 @@ mod tests {
     }
 
     #[test]
-    fn global_ruleset_denies_east_west_between_firecrab_taps() {
+    fn global_ruleset_allows_east_west_within_a_micro_network() {
         let ruleset = render_apply_ruleset("eth0", &[]).unwrap();
-        assert!(ruleset.contains("iifname \"fct*\" oifname \"fct*\" drop"));
-        // The wildcard must not be able to match the bridge itself.
-        assert!(!"fcbr0".starts_with("fct"));
+        // TAPs in the same MicroNetwork share one Linux bridge, so leaving
+        // bridge forwarding at its accept default permits their L2 traffic.
+        // Different MicroNetworks use different bridges and their routed
+        // traffic is denied by firecrab_egress above.
+        assert!(!ruleset.contains("iifname \"fct*\" oifname \"fct*\" drop"));
+        assert!(!ruleset.contains("type filter hook forward priority -200"));
     }
 
     #[test]

--- a/public-docs/networking.md
+++ b/public-docs/networking.md
@@ -58,6 +58,10 @@ sudo nft list table inet firecrab
 The helper runs dnsmasq for DHCP.
 It uses nftables for NAT, isolation, and anti-spoofing.
 
+VMs attached to the same MicroNetwork can communicate directly over their
+leased IPv4 addresses. This traffic stays on that network's Linux bridge and
+does not require internet access or an `internet` VM egress policy.
+
 Traffic between different MicroNetworks is blocked.
 
 ## Inspect


### PR DESCRIPTION
Closes #72

## Summary

- Allow direct L2 communication between VMs attached to the same MicroNetwork.
- Preserve cross-MicroNetwork isolation and per-VM IP/MAC anti-spoofing.
- Reflect the allowed VM-to-VM posture in the API, dashboard, and networking documentation.

## Verification

- Net-helper, API networking, API types, and helper protocol tests pass.
- Frontend production build and lint pass.
- Live VM-to-VM ping verified with 3/3 replies and 0% packet loss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VMs on the same MicroNetwork can communicate directly using their leased IPv4 addresses.
  * Same-network traffic no longer requires internet access or an internet egress policy.

* **Bug Fixes**
  * Firewall details now clearly show whether VM-to-VM traffic is allowed or blocked.
  * Traffic between different MicroNetworks remains controlled by existing firewall rules.

* **Documentation**
  * Clarified MicroNetwork communication behavior and network interface identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->