### PR TITLE
Fix/arm64 image magic number

### DIFF
--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -946,7 +946,7 @@ pub struct BootstrapStepRun {
 #[serde(rename_all = "camelCase")]
 pub struct BootstrapResponse {
     pub bootstrap_id: Uuid,
-    /// The target being bootstrapped (`alpine-3.24`, `ubuntu-26.04`, or `rocky-9.8`).
+    /// The target being bootstrapped (`alpine-3.24.1`, `ubuntu-26.04`, or `rocky-9.8`).
     pub alias: String,
     /// Which template the disposable builder VM booted from — always the
     /// internal MicroBoot alias since `firecrab_api::microboot` replaced
@@ -1346,7 +1346,7 @@ mod tests {
     fn bootstrap_response_carries_an_empty_timeline_by_default() {
         let json = serde_json::json!({
             "bootstrapId": "00000000-0000-0000-0000-000000000000",
-            "alias": "alpine-3.24",
+            "alias": "alpine-3.24.1",
             "sourceAlias": "__microboot",
             "vmId": "00000000-0000-0000-0000-000000000000",
             "status": "booting",

--- a/firecrab-api/src/bootstrap.rs
+++ b/firecrab-api/src/bootstrap.rs
@@ -46,6 +46,29 @@ impl BootstrapTracker {
             .cloned()
     }
 
+    /// The session that is still running, if there is one.
+    ///
+    /// Exists so a dashboard that has lost its in-memory handle on a
+    /// bootstrap can find it again: the session id is minted server-side by
+    /// [`try_begin`](Self::try_begin) and handed to whoever issued the
+    /// `POST`, so a browser reload or a walk to another page used to leave a
+    /// build running with no way left to address it — no session panel, no
+    /// console, until it finished. Only one bootstrap runs at a time (the
+    /// invariant `try_begin` enforces), so "the active one" is unambiguous
+    /// and needs no id to ask for.
+    ///
+    /// Terminal sessions are deliberately not returned: a finished build is
+    /// history, and resurrecting it on every page load would show a stale
+    /// result as if it were live.
+    pub fn active(&self) -> Option<BootstrapResponse> {
+        self.sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .find(|session| is_active(session))
+            .cloned()
+    }
+
     /// Whether any tracked session hasn't reached a terminal status — a
     /// cheap pre-check for `handlers::bootstrap::start_bootstrap`, which
     /// still has to go through [`try_begin`](Self::try_begin) for the
@@ -330,6 +353,34 @@ mod tests {
 
         tracker.finish_ok(id);
         assert!(!tracker.any_active());
+    }
+
+    /// What lets a reloaded dashboard find the build it already started:
+    /// the id lives only in the browser's memory, so without this the
+    /// session becomes unaddressable the moment that page goes away.
+    #[test]
+    fn active_returns_the_running_session_and_forgets_it_once_finished() {
+        let tracker = BootstrapTracker::default();
+        assert!(tracker.active().is_none());
+
+        let vm_id = Uuid::new_v4();
+        let id = tracker
+            .try_begin("ubuntu-26.04", "alpine-3.24", vm_id)
+            .expect("no other session is active");
+
+        let found = tracker.active().expect("the running session");
+        assert_eq!(found.bootstrap_id, id);
+        assert_eq!(found.alias, "ubuntu-26.04");
+        // The console the caller reconnects to hangs off this id.
+        assert_eq!(found.vm_id, vm_id);
+
+        tracker.finish_ok(id);
+        assert!(
+            tracker.active().is_none(),
+            "a finished build is history, not something to resurrect on the next page load"
+        );
+        // Still reachable by id, for whoever is already watching it.
+        assert!(tracker.get(id).is_some());
     }
 
     /// The single-session gate the dashboard's double-click can otherwise

--- a/firecrab-api/src/bootstrap.rs
+++ b/firecrab-api/src/bootstrap.rs
@@ -326,13 +326,13 @@ mod tests {
     fn begin_then_snapshot_returns_a_booting_session() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
 
         let snapshot = tracker.get(id).unwrap();
         assert_eq!(snapshot.status, BootstrapStatus::Booting);
         assert_eq!(snapshot.alias, "ubuntu-26.04");
-        assert_eq!(snapshot.source_alias, "alpine-3.24");
+        assert_eq!(snapshot.source_alias, "alpine-3.24.1");
     }
 
     #[test]
@@ -347,7 +347,7 @@ mod tests {
         assert!(!tracker.any_active());
 
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
         assert!(tracker.any_active());
 
@@ -365,7 +365,7 @@ mod tests {
 
         let vm_id = Uuid::new_v4();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", vm_id)
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", vm_id)
             .expect("no other session is active");
 
         let found = tracker.active().expect("the running session");
@@ -392,12 +392,12 @@ mod tests {
     fn try_begin_refuses_a_second_session_while_one_is_still_active() {
         let tracker = BootstrapTracker::default();
         let first = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("the first session claims the slot");
 
         assert!(
             tracker
-                .try_begin("rocky-9.8", "alpine-3.24", Uuid::new_v4())
+                .try_begin("rocky-9.8", "alpine-3.24.1", Uuid::new_v4())
                 .is_none()
         );
 
@@ -406,7 +406,7 @@ mod tests {
         tracker.finish_ok(first);
         assert!(
             tracker
-                .try_begin("rocky-9.8", "alpine-3.24", Uuid::new_v4())
+                .try_begin("rocky-9.8", "alpine-3.24.1", Uuid::new_v4())
                 .is_some()
         );
     }
@@ -415,7 +415,7 @@ mod tests {
     fn set_status_from_only_applies_while_the_session_is_in_the_expected_status() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
 
         assert!(tracker.set_status_from(id, BootstrapStatus::Booting, BootstrapStatus::Running));
@@ -427,7 +427,7 @@ mod tests {
     fn finish_ok_records_succeeded_status_and_end_time() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
 
         tracker.finish_ok(id);
@@ -441,7 +441,7 @@ mod tests {
     fn finish_err_records_failed_status_and_reason_in_the_log() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
 
         tracker.finish_err(id, "download failed: connection reset");
@@ -455,7 +455,7 @@ mod tests {
     fn finish_err_from_only_fails_a_session_still_in_the_expected_status() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
 
         tracker.set_status_from(id, BootstrapStatus::Booting, BootstrapStatus::Running);
@@ -470,7 +470,7 @@ mod tests {
     fn remove_evicts_a_tracked_session() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other session is active");
         tracker.remove(id);
         assert!(tracker.get(id).is_none());
@@ -480,7 +480,7 @@ mod tests {
     fn a_new_session_opens_on_the_builder_vm_step() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("alpine-3.24", "__microboot", Uuid::new_v4())
+            .try_begin("alpine-3.24.1", "__microboot", Uuid::new_v4())
             .expect("first session");
         let session = tracker.get(id).expect("session");
 
@@ -497,7 +497,7 @@ mod tests {
     fn set_step_closes_the_previous_step_as_succeeded() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("alpine-3.24", "__microboot", Uuid::new_v4())
+            .try_begin("alpine-3.24.1", "__microboot", Uuid::new_v4())
             .expect("first session");
 
         tracker.set_step(id, BootstrapStep::InstallingSystem);
@@ -520,7 +520,7 @@ mod tests {
     fn finishing_ok_closes_the_last_step_and_clears_the_current_one() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("alpine-3.24", "__microboot", Uuid::new_v4())
+            .try_begin("alpine-3.24.1", "__microboot", Uuid::new_v4())
             .expect("first session");
         tracker.set_step(id, BootstrapStep::Finalizing);
 
@@ -571,7 +571,7 @@ mod tests {
     fn a_compare_and_set_failure_that_does_not_apply_leaves_the_timeline_alone() {
         let tracker = BootstrapTracker::default();
         let id = tracker
-            .try_begin("alpine-3.24", "__microboot", Uuid::new_v4())
+            .try_begin("alpine-3.24.1", "__microboot", Uuid::new_v4())
             .expect("first session");
 
         // Session is in `Booting`; this expects `Packaging`, so it must no-op.

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -54,9 +54,20 @@ const BOOTSTRAP_DONE_SENTINEL: &str = "FIRECRAB_BOOTSTRAP_DONE";
 
 /// How long the guest-side bootstrap script may run before this module
 /// gives up waiting — real network downloads (hundreds of MB) plus a real
-/// package install, so far more generous than
-/// a long guest-side install.
-const BOOTSTRAP_SCRIPT_TIMEOUT: Duration = Duration::from_secs(1800);
+/// package install, so far more generous than a long guest-side install.
+///
+/// Measured end-to-end on an aarch64 host, one builder at a time, on the
+/// single vCPU this module used to give the builder: alpine-3.24 in 2m55s,
+/// rocky-9.8 in 9m44s, and ubuntu-26.04 was still going when the old
+/// 30-minute bound killed it — with the guest's vCPU pegged at ~98% for the
+/// entire run, so it was building, not hung. Ubuntu is the outlier by
+/// construction: ~1.2 GiB of packaged rootfs against rocky's ~430 MiB, an
+/// `apt-get install` that includes `linux-image-generic`, and then two full
+/// single-threaded `mkfs.ext4 -d` passes (the 2 GiB image, then the output
+/// directory onto `/dev/vda`). 90 minutes covers that with room for a
+/// loaded host; the session log's heartbeat is what distinguishes a slow
+/// run from a stuck one in the meantime, and a stuck one can be cancelled.
+const BOOTSTRAP_SCRIPT_TIMEOUT: Duration = Duration::from_secs(5400);
 
 /// Marker the console-readiness probe asks the guest's shell to echo back,
 /// kept distinct from [`BOOTSTRAP_DONE_SENTINEL`] so a probe reply can never
@@ -68,9 +79,25 @@ const CONSOLE_PROBE_SENTINEL: &str = "FIRECRAB_BOOTSTRAP_SHELL_READY";
 /// cheaply while agetty is still coming up.
 const CONSOLE_PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 
-/// Bounded so an unbootable console fails in ~30s with a clear message
-/// instead of hanging until [`BOOTSTRAP_SCRIPT_TIMEOUT`].
-const CONSOLE_PROBE_ATTEMPTS: usize = 10;
+/// Bounded so an unbootable console fails with a clear message instead of
+/// hanging until [`BOOTSTRAP_SCRIPT_TIMEOUT`] — but bounded as a "something
+/// is genuinely wrong" limit, the same way [`BUILDER_BOOT_TIMEOUT`] is, not
+/// as a latency budget.
+///
+/// It used to be 10 (~30s), which is *below* what a healthy builder needs.
+/// The probes start the moment the VM is `Running`, and for a MicroBoot
+/// builder that is immediate — `handlers::vms` skips the network-readiness
+/// wait for this alias, because Alpine's netboot initramfs has no init
+/// service to fire the sentinel. So this budget has to cover the guest's
+/// entire boot, and the builder's `ram: 8192` makes that boot slow: timed on
+/// an aarch64 host, the recovery shell answers at ~10s with 1024 MiB but
+/// ~15s with 8192 MiB, purely from setting up the larger memory map. Under
+/// host CPU load (a parallel `cargo build` was enough) the same guest took
+/// 25.3s, and a busier host pushes it past 30s — at which point the session
+/// fails with "console shell never became responsive" even though nothing is
+/// wrong with the VM at all. 40 leaves several times that headroom while
+/// still failing ~15x faster than the script timeout.
+const CONSOLE_PROBE_ATTEMPTS: usize = 40;
 
 /// How often the session log gets a "still running" line while the script
 /// executes. Frequent enough that the dashboard never looks frozen for long,
@@ -198,7 +225,21 @@ pub async fn start_bootstrap(
         // given distro actually touches. Rocky additionally sizes its tmpfs
         // work area off this number — see bootstrap-rocky-in-guest.sh.
         ram: 8192,
-        cpu: 1,
+        // The build is CPU-bound end to end: a bootstrap that ran to the
+        // old 30-minute limit had burned 29.8 minutes of CPU, so its single
+        // vCPU sat at ~98% for the entire run. Most of the work is serial
+        // by nature (dpkg/apk unpack one package at a time, `mkfs.ext4 -d`
+        // walks the tree once), so the second vCPU is not a second worker so
+        // much as somewhere for the guest kernel's own I/O completion and
+        // page-cache work to go instead of preempting the installer.
+        //
+        // 2 rather than the host's core count because the workload cannot
+        // use more: measured over a full 25-minute Ubuntu build at this
+        // setting, the builder averaged 148% CPU — it did not saturate even
+        // the two vCPUs it had. Unlike the packaging step above, which is
+        // genuinely parallel and now takes every core, this ceiling is a
+        // property of dpkg, not of what we allow it.
+        cpu: 2,
         // The target's own build headroom, but never below the floor the
         // source template itself needs to boot at all — a source rootfs
         // bigger than the target's build budget would otherwise fail

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -925,9 +925,27 @@ mod tests {
         0x2f, 0x00, 0x2e, 0x00,
     ];
 
+    /// A minimal raw Linux/arm64 `Image` boot header: "MZ" for the EFI stub
+    /// and `ARM64_IMAGE_MAGIC` ("ARMd") at offset 0x38, which is what
+    /// `extract-arm64-image` reads to recognize an already-unwrapped Image
+    /// and pass it straight through. A bare "MZ" prefix won't do — the real
+    /// script would then look for the EFI zboot payload or the UKI `.linux`
+    /// section that a distro vmlinuz carries and reject the fixture for
+    /// having neither, which is a different failure than the one these tests
+    /// are about.
     #[cfg(target_arch = "aarch64")]
     fn fake_kernel_header() -> &'static [u8] {
-        b"MZ\0\0fake ARM64 PE Image"
+        const HEADER: &[u8] = &{
+            let mut header = [0_u8; 64];
+            header[0] = b'M';
+            header[1] = b'Z';
+            header[0x38] = b'A';
+            header[0x39] = b'R';
+            header[0x3a] = b'M';
+            header[0x3b] = b'd';
+            header
+        };
+        HEADER
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -1161,11 +1179,11 @@ mod tests {
     /// there's no explicit terminal `exit 1`). Without also checking for
     /// non-empty stdout, `build_package_blocking` would silently package a
     /// 0-byte kernel as a "successful" bootstrap. This seeds a raw kernel
-    /// `extract-vmlinux` genuinely cannot recognize (plain text, not an ELF
-    /// or any known compressed kernel format) and asserts packaging fails
-    /// loudly instead.
+    /// neither helper can recognize (plain text: not an ELF, not a known
+    /// compressed kernel format, not an ARM64 Image in any wrapper) and
+    /// asserts packaging fails loudly instead.
     #[tokio::test]
-    async fn package_bootstrap_fails_when_extract_vmlinux_cannot_recognize_the_raw_kernel() {
+    async fn package_bootstrap_fails_when_the_raw_kernel_cannot_be_prepared() {
         let directory = tempdir().unwrap();
         let state = test_state(directory.path()).await;
         let vm = seed_builder_vm(&state, VmState::Running);
@@ -1193,8 +1211,16 @@ mod tests {
 
         let snapshot = state.bootstraps.get(bootstrap_id).unwrap();
         assert_eq!(snapshot.status, BootstrapStatus::Failed);
+        // Which helper reports the failure is architecture-specific: x86_64
+        // extracts an ELF vmlinux, aarch64 unwraps a raw Image out of the
+        // distro's EFI zboot/UKI wrapper.
+        let expected_failure = if cfg!(target_arch = "aarch64") {
+            "extract-arm64-image failed"
+        } else {
+            "extract-vmlinux failed"
+        };
         assert!(
-            snapshot.log.contains("extract-vmlinux failed"),
+            snapshot.log.contains(expected_failure),
             "log: {}",
             snapshot.log
         );

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -44,7 +44,7 @@ const BUILDER_BOOT_TIMEOUT: Duration = Duration::from_secs(600);
 /// `TemplateRegistry::known_specs()` directly, so a future built-in
 /// addition doesn't silently become bootstrap-eligible without its own
 /// guest script (Task 6 covers exactly these 3, no more).
-const BOOTSTRAPPABLE_ALIASES: [&str; 3] = ["alpine-3.24", "ubuntu-26.04", "rocky-9.8"];
+const BOOTSTRAPPABLE_ALIASES: [&str; 3] = ["alpine-3.24.1", "ubuntu-26.04", "rocky-9.8"];
 
 /// Sentinel the pushed script prints once it's done, followed by `:` and
 /// its exit code — same shape as other console sentinels, kept as its
@@ -57,7 +57,7 @@ const BOOTSTRAP_DONE_SENTINEL: &str = "FIRECRAB_BOOTSTRAP_DONE";
 /// package install, so far more generous than a long guest-side install.
 ///
 /// Measured end-to-end on an aarch64 host, one builder at a time, on the
-/// single vCPU this module used to give the builder: alpine-3.24 in 2m55s,
+/// single vCPU this module used to give the builder: alpine-3.24.1 in 2m55s,
 /// rocky-9.8 in 9m44s, and ubuntu-26.04 was still going when the old
 /// 30-minute bound killed it — with the guest's vCPU pegged at ~98% for the
 /// entire run, so it was building, not hung. Ubuntu is the outlier by
@@ -142,7 +142,7 @@ const ROCKY_SCRIPT: &str =
 
 fn script_for(alias: &str) -> String {
     let script = match alias {
-        "alpine-3.24" => ALPINE_SCRIPT,
+        "alpine-3.24.1" => ALPINE_SCRIPT,
         "ubuntu-26.04" => UBUNTU_SCRIPT,
         "rocky-9.8" => ROCKY_SCRIPT,
         other => unreachable!("start_bootstrap already rejected unknown alias {other}"),
@@ -306,7 +306,7 @@ pub async fn start_bootstrap(
 /// target ends up.
 fn bootstrap_disk_gb(target_alias: &str) -> u16 {
     match target_alias {
-        "alpine-3.24" => 4,
+        "alpine-3.24.1" => 4,
         _ => 8, // ubuntu-26.04, rocky-9.8 — 2G rootfs_size each, per default_specs()
     }
 }
@@ -772,7 +772,7 @@ fn build_package_blocking(
     std::fs::create_dir_all(rootfs_dest.parent().unwrap()).ok();
     std::fs::rename(&raw_rootfs, &rootfs_dest).map_err(|e| format!("place rootfs: {e}"))?;
 
-    let raw_kernel_name = if alias == "alpine-3.24" {
+    let raw_kernel_name = if alias == "alpine-3.24.1" {
         "vmlinuz-virt-raw"
     } else {
         "vmlinuz-raw"
@@ -946,7 +946,7 @@ mod tests {
             );
             assert!(!script.contains("@ROCKY_"), "unresolved marker in {alias}");
         }
-        assert!(script_for("alpine-3.24").contains("alpine_version='3.24.1'"));
+        assert!(script_for("alpine-3.24.1").contains("alpine_version='3.24.1'"));
         assert!(script_for("ubuntu-26.04").contains("series='26.04'"));
         assert!(script_for("rocky-9.8").contains("rocky_release='9.8'"));
         assert!(script_for("rocky-9.8").contains("rocky_container_build='20260525.0'"));
@@ -1132,7 +1132,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Packaging,
         );
@@ -1228,7 +1228,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Packaging,
         );
@@ -1282,7 +1282,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Packaging,
         );
@@ -1322,7 +1322,7 @@ mod tests {
 
     /// Covers the `if let Some(initrd_relative) = &spec.initrd` branch in
     /// `build_package_blocking` that the `ubuntu-26.04` test above never
-    /// exercises (Ubuntu's spec has `initrd: None`) — `alpine-3.24` does
+    /// exercises (Ubuntu's spec has `initrd: None`) — `alpine-3.24.1` does
     /// carry an initrd, and its raw-kernel dump filename
     /// (`vmlinuz-virt-raw`, per `bootstrap-alpine-in-guest.sh`) differs
     /// from every other alias's `vmlinuz-raw`, which `build_package_blocking`
@@ -1344,7 +1344,7 @@ mod tests {
 
         let bootstrap_id = seeded_session(
             &state,
-            "alpine-3.24",
+            "alpine-3.24.1",
             "ubuntu-26.04",
             vm.id,
             BootstrapStatus::Packaging,
@@ -1361,7 +1361,7 @@ mod tests {
         );
         let staged = crate::image_install::staged_package_path(
             state.templates.image_root_path(),
-            "alpine-3.24",
+            "alpine-3.24.1",
         );
         let listing = std::process::Command::new("tar")
             .arg("--use-compress-program=zstd")
@@ -1425,13 +1425,13 @@ mod tests {
         let (status, Json(session)) = start_bootstrap(
             State(state.clone()),
             Extension(RequestId(Uuid::new_v4())),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
         )
         .await
         .unwrap();
 
         assert_eq!(status, StatusCode::ACCEPTED);
-        assert_eq!(session.alias, "alpine-3.24");
+        assert_eq!(session.alias, "alpine-3.24.1");
         assert_eq!(session.source_alias, crate::microboot::MICROBOOT_ALIAS);
 
         // The builder VM's own spec, not just the session's status. The RAM
@@ -1460,7 +1460,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1524,7 +1524,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1573,7 +1573,7 @@ mod tests {
         let state = test_state(directory.path()).await;
         let id = state
             .bootstraps
-            .try_begin("ubuntu-26.04", "alpine-3.24", Uuid::new_v4())
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", Uuid::new_v4())
             .expect("no other bootstrap session is active");
 
         let Json(found) = get_bootstrap(
@@ -1614,7 +1614,7 @@ mod tests {
         let vm = seed_builder_vm(&state, VmState::Running);
         let id = state
             .bootstraps
-            .try_begin("ubuntu-26.04", "alpine-3.24", vm.id)
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", vm.id)
             .expect("no other bootstrap session is active");
 
         let status = cancel_bootstrap(
@@ -1643,7 +1643,7 @@ mod tests {
         let vm = seed_builder_vm(&state, VmState::Error);
         let bootstrap_id = state
             .bootstraps
-            .try_begin("ubuntu-26.04", "alpine-3.24", vm.id)
+            .try_begin("ubuntu-26.04", "alpine-3.24.1", vm.id)
             .expect("no other bootstrap session is active");
 
         watch_bootstrap_boot(&state, bootstrap_id, vm.id).await;
@@ -1690,7 +1690,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1723,7 +1723,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1751,7 +1751,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1776,7 +1776,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "ubuntu-26.04",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Running,
         );
@@ -1801,7 +1801,7 @@ mod tests {
         let bootstrap_id = seeded_session(
             &state,
             "not-a-template",
-            "alpine-3.24",
+            "alpine-3.24.1",
             vm.id,
             BootstrapStatus::Packaging,
         );

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -865,7 +865,9 @@ fn build_package_blocking(
 /// session it already started. `null` rather than `404` because "nothing is
 /// building" is the ordinary answer on almost every page load, not a
 /// failure to look something up.
-pub async fn get_active_bootstrap(State(state): State<AppState>) -> Json<Option<BootstrapResponse>> {
+pub async fn get_active_bootstrap(
+    State(state): State<AppState>,
+) -> Json<Option<BootstrapResponse>> {
     Json(state.bootstraps.active())
 }
 

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -77,9 +77,34 @@ const CONSOLE_PROBE_ATTEMPTS: usize = 10;
 /// rare enough not to bury the real output the script emits at the end.
 const BOOTSTRAP_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
-/// Packaging runs beside customer VMs, so using zstd's `-T0` all-core mode
-/// can starve a booting guest long enough to trigger its network timeout.
-const PACKAGE_ZSTD_THREADS: &str = "-T2";
+/// Compression settings for the package this module produces. Deliberately
+/// *not* the ones `scripts/package-m2images.sh` publishes with (`-19 -T2`),
+/// because the two archives have opposite economics: a published package is
+/// compressed once and downloaded by everyone, so paying for the last few
+/// percent is right; a MicroBoot package never leaves the host that built it
+/// (`image_install::staged_package_path` — it is staged for that machine to
+/// install and nothing fetches it), so those percent buy nothing at all.
+///
+/// Measured on 512 MiB of a real Ubuntu rootfs on an aarch64 host:
+///
+/// ```text
+///   -19 -T2   46.4s   276.7 MiB   (what this used to be)
+///   -19 -T0   26.1s   276.7 MiB
+///   -12 -T0    1.6s   285.1 MiB
+/// ```
+///
+/// So the level, not the thread count, was the cost: `-19` bought 3.0% of
+/// size for 29x the time, and its block-level parallelism is poor enough
+/// that all six cores only made it 1.8x faster. On the 2.07 GiB Ubuntu
+/// package that is ~3m19s of every build spent shrinking a local file by
+/// 27 MiB.
+///
+/// `-T0` is safe here now in a way it was not before: it used to risk
+/// starving a *booting* guest long enough to trip its network-readiness
+/// wait, but that wait is no longer a 30-second budget (see
+/// `state::RuntimeConfig::network_ready_timeout`).
+const PACKAGE_ZSTD_THREADS: &str = "-T0";
+const PACKAGE_ZSTD_LEVEL: &str = "-12";
 
 const ALPINE_SCRIPT: &str =
     include_str!("../../../scripts/firecracker-menual/bootstrap-alpine-in-guest.sh");
@@ -757,7 +782,7 @@ fn build_package_blocking(
         .map_err(|e| format!("spawn tar: {e}"))?;
     let tar_stdout = tar.stdout.take().ok_or("tar stdout missing")?;
     let zstd = std::process::Command::new("zstd")
-        .args([PACKAGE_ZSTD_THREADS, "-19", "-f", "-o"])
+        .args([PACKAGE_ZSTD_THREADS, PACKAGE_ZSTD_LEVEL, "-f", "-o"])
         .arg(&staging_temp)
         .stdin(tar_stdout)
         .status()

--- a/firecrab-api/src/handlers/bootstrap.rs
+++ b/firecrab-api/src/handlers/bootstrap.rs
@@ -855,6 +855,20 @@ fn build_package_blocking(
     Ok(())
 }
 
+/// `GET /api/images/bootstrap` — the bootstrap that is still running, or
+/// `null` when none is.
+///
+/// The id-addressed sibling below can only be used by whoever holds the id
+/// the `POST` returned, which the dashboard keeps in component state; a
+/// reload or a walk to another page drops it, and the build then runs to
+/// completion invisibly. This is how that page finds its way back to a
+/// session it already started. `null` rather than `404` because "nothing is
+/// building" is the ordinary answer on almost every page load, not a
+/// failure to look something up.
+pub async fn get_active_bootstrap(State(state): State<AppState>) -> Json<Option<BootstrapResponse>> {
+    Json(state.bootstraps.active())
+}
+
 /// `GET /api/images/bootstrap/{bootstrapId}`.
 pub async fn get_bootstrap(
     State(state): State<AppState>,

--- a/firecrab-api/src/handlers/builder_vm.rs
+++ b/firecrab-api/src/handlers/builder_vm.rs
@@ -93,10 +93,10 @@ mod tests {
 
     #[test]
     fn builder_vm_name_is_recognizable_and_unique_per_call() {
-        let first = builder_vm_name("alpine-3.24");
-        let second = builder_vm_name("alpine-3.24");
+        let first = builder_vm_name("alpine-3.24.1");
+        let second = builder_vm_name("alpine-3.24.1");
 
-        assert!(first.starts_with("builder-alpine-3.24-"));
+        assert!(first.starts_with("builder-alpine-3.24.1-"));
         assert_ne!(first, second, "two builders must not collide on a name");
     }
 

--- a/firecrab-api/src/handlers/images.rs
+++ b/firecrab-api/src/handlers/images.rs
@@ -481,7 +481,7 @@ mod tests {
         assert!(
             images
                 .iter()
-                .any(|image| image.alias == "alpine-3.24" && !image.installed)
+                .any(|image| image.alias == "alpine-3.24.1" && !image.installed)
         );
         assert!(
             images
@@ -526,7 +526,7 @@ mod tests {
         state.image_packages = ImageInstallTracker::disabled();
         let result = start_image_package(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await;
@@ -630,7 +630,7 @@ mod tests {
     async fn package_then_image_install_registers_and_marks_installed() {
         let source = tempdir().unwrap();
         let dest = tempdir().unwrap();
-        let alpine = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let alpine = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         write_file(&source.path().join(&alpine.kernel), b"fake-alpine-kernel");
         write_file(
             &source.path().join(alpine.initrd.as_ref().unwrap()),
@@ -665,7 +665,7 @@ mod tests {
 
         let accepted = start_image_package(
             State(state.clone()),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
@@ -678,7 +678,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let Json(snap) = get_image_package(
                 State(state.clone()),
-                Path("alpine-3.24".to_owned()),
+                Path("alpine-3.24.1".to_owned()),
                 Extension(RequestId(uuid::Uuid::nil())),
             )
             .await
@@ -698,16 +698,16 @@ mod tests {
         assert!(ok, "package install did not succeed in time");
         assert!(crate::image_install::staged_package_exists(
             state.templates.image_root_path(),
-            "alpine-3.24"
+            "alpine-3.24.1"
         ));
         assert!(
-            state.templates.resolve_alias("alpine-3.24").is_none(),
+            state.templates.resolve_alias("alpine-3.24.1").is_none(),
             "package acquisition must not register an image"
         );
 
         let accepted = start_image_install(
             State(state.clone()),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
@@ -719,7 +719,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let Json(snap) = get_image_install(
                 State(state.clone()),
-                Path("alpine-3.24".to_owned()),
+                Path("alpine-3.24.1".to_owned()),
                 Extension(RequestId(uuid::Uuid::nil())),
             )
             .await
@@ -734,18 +734,18 @@ mod tests {
             }
         }
         assert!(installed, "image install did not succeed in time");
-        assert!(state.templates.resolve_alias("alpine-3.24").is_some());
+        assert!(state.templates.resolve_alias("alpine-3.24.1").is_some());
 
         let Json(images) = list_images(State(state.clone())).await;
         let alpine_row = images
             .iter()
-            .find(|image| image.alias == "alpine-3.24")
+            .find(|image| image.alias == "alpine-3.24.1")
             .unwrap();
         assert!(alpine_row.installed);
 
         let deleted = delete_image(
             State(state.clone()),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
@@ -754,14 +754,14 @@ mod tests {
         assert!(
             crate::image_install::staged_package_exists(
                 state.templates.image_root_path(),
-                "alpine-3.24"
+                "alpine-3.24.1"
             ),
             "image deletion must preserve the prepared package"
         );
 
         let accepted = start_image_install(
             State(state.clone()),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
@@ -772,7 +772,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let Json(snap) = get_image_install(
                 State(state.clone()),
-                Path("alpine-3.24".to_owned()),
+                Path("alpine-3.24.1".to_owned()),
                 Extension(RequestId(uuid::Uuid::nil())),
             )
             .await
@@ -841,7 +841,7 @@ mod tests {
         let state = empty_state(directory.path()).await;
         let result = delete_image(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await;
@@ -871,12 +871,12 @@ mod tests {
         let state = empty_state(directory.path()).await;
         let Json(snap) = get_image_install(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
         .unwrap();
-        assert_eq!(snap.alias, "alpine-3.24");
+        assert_eq!(snap.alias, "alpine-3.24.1");
         assert_eq!(snap.status, ImageInstallStatus::Idle);
     }
 
@@ -886,7 +886,7 @@ mod tests {
         let state = empty_state(directory.path()).await;
         let result = start_image_install(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await;
@@ -939,7 +939,7 @@ mod tests {
     async fn start_image_install_refuses_already_installed() {
         let directory = tempdir().unwrap();
         let root = directory.path();
-        let alpine = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let alpine = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         write_file(&root.join(&alpine.kernel), b"k");
         write_file(&root.join(alpine.initrd.as_ref().unwrap()), b"i");
         write_file(&root.join(&alpine.rootfs), b"r");
@@ -950,7 +950,7 @@ mod tests {
         state.image_installs = ImageInstallTracker::with_base_url("http://127.0.0.1:9");
         let result = start_image_install(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await;
@@ -965,15 +965,15 @@ mod tests {
         write_file(
             &crate::image_install::staged_package_path(
                 state.templates.image_root_path(),
-                "alpine-3.24",
+                "alpine-3.24.1",
             ),
             b"already-prepared",
         );
         state.image_installs = ImageInstallTracker::with_base_url("http://127.0.0.1:9");
-        state.image_installs.begin("alpine-3.24").unwrap();
+        state.image_installs.begin("alpine-3.24.1").unwrap();
         let result = start_image_install(
             State(state),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await;
@@ -1095,7 +1095,7 @@ mod tests {
 
         let _ = start_image_package(
             State(state.clone()),
-            Path("alpine-3.24".to_owned()),
+            Path("alpine-3.24.1".to_owned()),
             Extension(RequestId(uuid::Uuid::nil())),
         )
         .await
@@ -1106,7 +1106,7 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             let Json(snap) = get_image_package(
                 State(state.clone()),
-                Path("alpine-3.24".to_owned()),
+                Path("alpine-3.24.1".to_owned()),
                 Extension(RequestId(uuid::Uuid::nil())),
             )
             .await
@@ -1121,11 +1121,11 @@ mod tests {
             failed,
             "package install should fail when artifacts are missing"
         );
-        assert!(state.templates.resolve_alias("alpine-3.24").is_none());
+        assert!(state.templates.resolve_alias("alpine-3.24.1").is_none());
         assert!(
             !crate::image_install::staged_package_exists(
                 state.templates.image_root_path(),
-                "alpine-3.24"
+                "alpine-3.24.1"
             ),
             "a failed download must not publish a ready package"
         );

--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -2394,6 +2394,21 @@ mod tests {
         state.store.load_all().unwrap().get(&id).map(|vm| vm.state)
     }
 
+    /// The exit monitor flips the in-memory record first and persists a
+    /// moment later, so waiting on [`wait_for_state`] and then reading the
+    /// store in the same breath can still see the pre-transition row —
+    /// observed failing once in a fully parallel suite run, passing on every
+    /// rerun. Poll the store for its own sake instead.
+    async fn wait_for_db_state(state: &AppState, id: Uuid, want: VmState) {
+        for _ in 0..100 {
+            if db_state(state, id) == Some(want) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(30)).await;
+        }
+        panic!("vm {id} never persisted {want:?}");
+    }
+
     async fn wait_for_state(state: &AppState, id: Uuid, want: VmState) {
         for _ in 0..100 {
             if memory_state(state, id) == Some(want) {
@@ -2833,6 +2848,12 @@ while True:
         assert!(state.processes.lock().unwrap().is_empty());
     }
 
+    /// x86_64 only: `requires_pci_transport_for_arch` returns false on
+    /// aarch64, whose kernels keep Firecracker's virtio-mmio transport (and
+    /// therefore `pci=off`), so there is no legacy mmio registration to
+    /// repair there and the fixture's `--enable-pci` requirement could never
+    /// be met.
+    #[cfg(target_arch = "x86_64")]
     #[tokio::test]
     async fn start_repairs_a_legacy_ubuntu_mmio_registration() {
         let directory = short_tempdir();
@@ -3498,7 +3519,7 @@ while True:
         .unwrap();
 
         wait_for_state(&state, vm.id, VmState::Stopped).await;
-        assert_eq!(db_state(&state, vm.id), Some(VmState::Stopped));
+        wait_for_db_state(&state, vm.id, VmState::Stopped).await;
         assert!(state.processes.lock().unwrap().is_empty());
     }
 

--- a/firecrab-api/src/image_install.rs
+++ b/firecrab-api/src/image_install.rs
@@ -874,9 +874,9 @@ mod tests {
             )
         );
         assert_eq!(
-            package_url("http://mirror.example/m2", "alpine-3.24"),
+            package_url("http://mirror.example/m2", "alpine-3.24.1"),
             format!(
-                "http://mirror.example/m2/alpine/3.24.1{architecture_segment}/alpine-3.24.tar.zst"
+                "http://mirror.example/m2/alpine/3.24.1{architecture_segment}/alpine-3.24.1.tar.zst"
             )
         );
         assert_eq!(
@@ -901,8 +901,8 @@ mod tests {
     #[test]
     fn packages_use_architecture_specific_registry_paths() {
         assert_eq!(
-            package_path_for_arch("alpine-3.24", "aarch64"),
-            "alpine/3.24.1/aarch64/alpine-3.24.tar.zst"
+            package_path_for_arch("alpine-3.24.1", "aarch64"),
+            "alpine/3.24.1/aarch64/alpine-3.24.1.tar.zst"
         );
         assert_eq!(
             package_path_for_arch("ubuntu-26.04", "aarch64"),
@@ -938,7 +938,7 @@ mod tests {
 
     #[test]
     fn package_name_uses_alias_tar_zst() {
-        assert_eq!(package_name("alpine-3.24"), "alpine-3.24.tar.zst");
+        assert_eq!(package_name("alpine-3.24.1"), "alpine-3.24.1.tar.zst");
         assert_eq!(package_name("ubuntu-26.04"), "ubuntu-26.04.tar.zst");
         assert_eq!(package_name("rocky-9.8"), "rocky-9.8.tar.zst");
     }
@@ -948,16 +948,16 @@ mod tests {
         let directory = tempdir().unwrap();
         write_staged_package_origin(
             directory.path(),
-            "alpine-3.24",
+            "alpine-3.24.1",
             PackageOrigin::MicroRegistry,
         )
         .unwrap();
         assert_eq!(
-            staged_package_origin(directory.path(), "alpine-3.24"),
+            staged_package_origin(directory.path(), "alpine-3.24.1"),
             Some(PackageOrigin::MicroRegistry)
         );
-        clear_staged_package_origin(directory.path(), "alpine-3.24").unwrap();
-        assert_eq!(staged_package_origin(directory.path(), "alpine-3.24"), None);
+        clear_staged_package_origin(directory.path(), "alpine-3.24.1").unwrap();
+        assert_eq!(staged_package_origin(directory.path(), "alpine-3.24.1"), None);
     }
 
     #[test]
@@ -994,7 +994,7 @@ mod tests {
 
     #[test]
     fn validation_accepts_a_complete_spec_and_rejects_an_empty_archive() {
-        let alpine = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let alpine = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         let members = vec![
             "kernel/".to_owned(),
             alpine.kernel.to_string_lossy().into_owned(),
@@ -1017,7 +1017,7 @@ mod tests {
 
     #[test]
     fn ensure_spec_requires_all_artifacts() {
-        let alpine = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let alpine = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         let members = vec![
             alpine.kernel.to_string_lossy().into_owned(),
             alpine.rootfs.to_string_lossy().into_owned(),
@@ -1123,7 +1123,7 @@ mod tests {
     async fn image_install_reports_failure_when_no_package_has_been_staged() {
         let directory = tempdir().unwrap();
         let templates = TemplateRegistry::from_specs(directory.path(), std::iter::empty()).unwrap();
-        let spec = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let spec = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         let tracker = ImageInstallTracker::disabled();
         tracker.begin(&spec.alias).unwrap();
 
@@ -1149,7 +1149,7 @@ mod tests {
         });
 
         let templates = TemplateRegistry::from_specs(directory.path(), std::iter::empty()).unwrap();
-        let spec = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let spec = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         let tracker = ImageInstallTracker::with_base_url(format!("http://{addr}"));
         tracker.begin(&spec.alias).unwrap();
 
@@ -1171,7 +1171,7 @@ mod tests {
     async fn install_once_from_local_http_registers() {
         let source = tempdir().unwrap();
         let dest = tempdir().unwrap();
-        let alpine = TemplateRegistry::known_spec("alpine-3.24").unwrap();
+        let alpine = TemplateRegistry::known_spec("alpine-3.24.1").unwrap();
         write_file(&source.path().join(&alpine.kernel), b"fake-alpine-kernel");
         write_file(
             &source.path().join(alpine.initrd.as_ref().unwrap()),
@@ -1218,6 +1218,6 @@ mod tests {
             staged_package_origin(dest.path(), &alpine.alias),
             Some(PackageOrigin::MicroRegistry)
         );
-        assert!(templates.resolve_alias("alpine-3.24").is_some());
+        assert!(templates.resolve_alias("alpine-3.24.1").is_some());
     }
 }

--- a/firecrab-api/src/image_install.rs
+++ b/firecrab-api/src/image_install.rs
@@ -957,7 +957,10 @@ mod tests {
             Some(PackageOrigin::MicroRegistry)
         );
         clear_staged_package_origin(directory.path(), "alpine-3.24.1").unwrap();
-        assert_eq!(staged_package_origin(directory.path(), "alpine-3.24.1"), None);
+        assert_eq!(
+            staged_package_origin(directory.path(), "alpine-3.24.1"),
+            None
+        );
     }
 
     #[test]

--- a/firecrab-api/src/m2image_manifest.rs
+++ b/firecrab-api/src/m2image_manifest.rs
@@ -79,7 +79,7 @@ mod tests {
                 .iter()
                 .map(|image| image.alias.as_str())
                 .collect::<Vec<_>>(),
-            ["alpine-3.24", "ubuntu-26.04", "rocky-9.8"]
+            ["alpine-3.24.1", "ubuntu-26.04", "rocky-9.8"]
         );
         assert!(manifest.images.iter().all(|image| {
             image.artifacts.contains_key("x86_64") && image.artifacts.contains_key("aarch64")

--- a/firecrab-api/src/microboot.rs
+++ b/firecrab-api/src/microboot.rs
@@ -427,7 +427,10 @@ fn is_arm64_image(path: &Path) -> bool {
     let Ok(mut file) = std::fs::File::open(path) else {
         return false;
     };
-    if file.seek(SeekFrom::Start(ARM64_IMAGE_MAGIC_OFFSET)).is_err() {
+    if file
+        .seek(SeekFrom::Start(ARM64_IMAGE_MAGIC_OFFSET))
+        .is_err()
+    {
         return false;
     }
     let mut magic = [0_u8; 4];

--- a/firecrab-api/src/microboot.rs
+++ b/firecrab-api/src/microboot.rs
@@ -7,7 +7,7 @@
 //! artifact-verification machinery works unchanged. See
 //! `public-docs/images.md`.
 
-use std::io::Read;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use crate::state::AppState;
@@ -355,14 +355,40 @@ fn prepare_kernel_image_for_arch(
             .map_err(|error| format!("mkdir {}: {error}", parent.display()))?;
     }
     std::fs::copy(raw_kernel, dest)
-        .map(|_| ())
         .map_err(|error| {
             format!(
                 "copy {} to {}: {error}",
                 raw_kernel.display(),
                 dest.display()
             )
-        })
+        })?;
+    restore_arm64_image_magic(dest)
+}
+
+/// Offset of the Linux/arm64 "Image" boot header's `magic` field, per
+/// `Documentation/arch/arm64/booting.rst`.
+const ARM64_IMAGE_MAGIC_OFFSET: u64 = 0x38;
+/// `ARM64_IMAGE_MAGIC` (`0x644d5241`), little-endian.
+const ARM64_IMAGE_MAGIC: [u8; 4] = *b"ARMd";
+
+/// Alpine's official netboot `vmlinuz-virt` for aarch64 (what `ensure_registered`
+/// downloads this builder kernel from) ships with this field zeroed out, even
+/// though the PE/EFI wrapper checked above is intact and would pass a plain
+/// `file`-style PE/ARM64 sniff. Firecracker's aarch64 kernel loader (rust-vmm
+/// linux-loader) validates this field independently of the PE header and
+/// refuses to boot with "invalid Image magic number" if it doesn't match —
+/// confirmed live against a production build (see the M2Images magic-number
+/// fix in `scripts/firecracker-menual/install-*-rootfs.sh`, same defect, same
+/// upstream cause), so repair it here too.
+fn restore_arm64_image_magic(dest: &Path) -> Result<(), String> {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(dest)
+        .map_err(|error| format!("open {} for magic repair: {error}", dest.display()))?;
+    file.seek(SeekFrom::Start(ARM64_IMAGE_MAGIC_OFFSET))
+        .map_err(|error| format!("seek {} for magic repair: {error}", dest.display()))?;
+    file.write_all(&ARM64_IMAGE_MAGIC)
+        .map_err(|error| format!("write ARM64 Image magic into {}: {error}", dest.display()))
 }
 
 #[cfg(test)]
@@ -392,12 +418,39 @@ mod tests {
     fn arm64_kernel_keeps_the_pe_image_instead_of_extracting_elf() {
         let dir = temp_image_root();
         let raw = dir.path().join("Image.raw");
-        std::fs::write(&raw, b"MZ\0\0firecracker-arm64-image").unwrap();
+        let mut raw_bytes = vec![0_u8; 64];
+        raw_bytes[0] = b'M';
+        raw_bytes[1] = b'Z';
+        raw_bytes.extend_from_slice(b"firecracker-arm64-image");
+        std::fs::write(&raw, &raw_bytes).unwrap();
         let dest = dir.path().join("Image-virt");
 
         prepare_kernel_image_for_arch(&raw, &dest, "aarch64").unwrap();
 
-        assert_eq!(std::fs::read(dest).unwrap(), std::fs::read(raw).unwrap());
+        let mut expected = raw_bytes;
+        expected[0x38..0x3c].copy_from_slice(&ARM64_IMAGE_MAGIC);
+        assert_eq!(std::fs::read(dest).unwrap(), expected);
+    }
+
+    #[test]
+    fn arm64_kernel_gets_its_boot_magic_repaired() {
+        // Reproduces the exact production defect: Alpine's official
+        // netboot vmlinuz-virt for aarch64 has this field zeroed, which
+        // Firecracker's kernel loader rejects with "invalid Image magic
+        // number" even though the PE/EFI wrapper around it is intact.
+        let dir = temp_image_root();
+        let raw = dir.path().join("Image.raw");
+        let mut raw_bytes = vec![0_u8; 64];
+        raw_bytes[0] = b'M';
+        raw_bytes[1] = b'Z';
+        raw_bytes.extend_from_slice(b"payload");
+        std::fs::write(&raw, &raw_bytes).unwrap();
+        let dest = dir.path().join("Image-virt");
+
+        prepare_kernel_image_for_arch(&raw, &dest, "aarch64").unwrap();
+
+        let dest_bytes = std::fs::read(dest).unwrap();
+        assert_eq!(&dest_bytes[0x38..0x3c], &ARM64_IMAGE_MAGIC);
     }
 
     #[test]
@@ -422,7 +475,16 @@ mod tests {
         // Firecracker supports, so extract-vmlinux takes its pass-through
         // path without scanning the much larger test executable.
         if crate::image_install::host_architecture() == "aarch64" {
-            std::fs::write(&raw_kernel, b"MZ\0\0fake ARM64 PE Image").unwrap();
+            // Magic already correct at 0x38 so the repair step is a no-op
+            // and the byte-equality assertion below stays meaningful for
+            // what this test actually covers (registration, not repair —
+            // see `arm64_kernel_gets_its_boot_magic_repaired` for that).
+            let mut fake = vec![0_u8; 64];
+            fake[0] = b'M';
+            fake[1] = b'Z';
+            fake[0x38..0x3c].copy_from_slice(&ARM64_IMAGE_MAGIC);
+            fake.extend_from_slice(b"fake ARM64 PE Image");
+            std::fs::write(&raw_kernel, &fake).unwrap();
         } else {
             std::fs::copy("/usr/bin/true", &raw_kernel).unwrap();
         }

--- a/firecrab-api/src/microboot.rs
+++ b/firecrab-api/src/microboot.rs
@@ -7,7 +7,7 @@
 //! artifact-verification machinery works unchanged. See
 //! `public-docs/images.md`.
 
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::state::AppState;
@@ -26,7 +26,7 @@ pub(crate) const MICROBOOT_ALIAS: &str = "__microboot";
 /// `images/.templates.json` is re-derived rather than silently reused: that
 /// file is replayed at every startup, and without this check a host that
 /// bootstrapped once would keep booting builders off the stale spec forever.
-const MICROBOOT_VERSION: &str = "v5";
+const MICROBOOT_VERSION: &str = "v6";
 
 fn netboot_url(filename: &str) -> String {
     netboot_url_for_arch(crate::image_install::host_architecture(), filename)
@@ -116,28 +116,86 @@ pub(crate) async fn ensure_registered(state: &AppState) -> Result<String, String
 
     let raw_kernel = cache_dir.join("vmlinuz-virt.raw");
     let initrd_dest = image_root.join(initrd_relative());
-    // Fetched as a pair, never individually. Alpine republishes both files
-    // at these same two URLs on every 3.24.x point release, so a cache left
-    // half-populated by an earlier failure would otherwise pair a stale
-    // kernel with a fresh initrd — whose `/lib/modules/$(uname -r)` then
-    // doesn't match, so virtio never loads and the guest script fails at
-    // `ip link set eth0 up` or on `/dev/vda` with a symptom that points
-    // nowhere near the real cause.
-    let kernel_cached = tokio::fs::try_exists(&raw_kernel).await.unwrap_or(false);
-    let initrd_cached = tokio::fs::try_exists(&initrd_dest).await.unwrap_or(false);
-    if !kernel_cached || !initrd_cached {
-        crate::image_install::download_to(&client, &netboot_url("vmlinuz-virt"), &raw_kernel)
-            .await?;
-        crate::image_install::download_to(&client, &netboot_url("initramfs-virt"), &initrd_dest)
-            .await?;
+    let cached = tokio::fs::try_exists(&raw_kernel).await.unwrap_or(false)
+        && tokio::fs::try_exists(&initrd_dest).await.unwrap_or(false);
+    if !cached {
+        download_netboot_pair(&client, &raw_kernel, &initrd_dest).await?;
     }
 
-    let templates = state.templates.clone();
+    let templates = &state.templates;
+    match register(templates, &image_root, &raw_kernel).await {
+        Ok(()) => Ok(MICROBOOT_ALIAS.to_owned()),
+        // A cache hit is only ever a guess that the files on disk are the
+        // ones these URLs serve *now*, for *this* host — and both halves of
+        // that have already been wrong in production. This module downloaded
+        // hardcoded x86_64 netboot URLs until arm64 support landed, so every
+        // aarch64 host that ran a build from before then still has an x86_64
+        // bzImage sitting at `vmlinuz-virt.raw`; nothing above ever looked
+        // inside it, so the wrong-architecture pair was reused forever and
+        // every bootstrap failed at `pick_builder_source`. A download that
+        // died midway leaves the same kind of unusable-but-present file.
+        // Preparing the kernel is what actually reads the bytes, so treat a
+        // failure on cached input as a poisoned cache: discard the pair and
+        // fetch it once more before giving up.
+        Err(error) if cached => {
+            tracing::warn!(
+                %error,
+                "cached microboot builder artifacts are unusable; re-downloading them"
+            );
+            discard_cached_pair(&raw_kernel, &initrd_dest).await;
+            download_netboot_pair(&client, &raw_kernel, &initrd_dest).await?;
+            register(templates, &image_root, &raw_kernel).await?;
+            Ok(MICROBOOT_ALIAS.to_owned())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Fetches the netboot kernel and initrd as a pair, never individually.
+/// Alpine republishes both files at these same two URLs on every 3.24.x
+/// point release, so a cache left half-populated by an earlier failure
+/// would otherwise pair a stale kernel with a fresh initrd — whose
+/// `/lib/modules/$(uname -r)` then doesn't match, so virtio never loads and
+/// the guest script fails at `ip link set eth0 up` or on `/dev/vda` with a
+/// symptom that points nowhere near the real cause.
+async fn download_netboot_pair(
+    client: &reqwest::Client,
+    raw_kernel: &Path,
+    initrd_dest: &Path,
+) -> Result<(), String> {
+    crate::image_install::download_to(client, &netboot_url("vmlinuz-virt"), raw_kernel).await?;
+    crate::image_install::download_to(client, &netboot_url("initramfs-virt"), initrd_dest).await
+}
+
+/// Drops a cached pair that turned out to be unusable. Best-effort: the
+/// re-download overwrites both paths anyway, so a removal that fails is
+/// worth a line in the log and nothing more.
+async fn discard_cached_pair(raw_kernel: &Path, initrd_dest: &Path) {
+    for path in [raw_kernel, initrd_dest] {
+        if let Err(error) = tokio::fs::remove_file(path).await
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                %error,
+                path = %path.display(),
+                "could not remove the unusable microboot artifact"
+            );
+        }
+    }
+}
+
+/// `register_blocking` off the async runtime's worker threads.
+async fn register(
+    templates: &std::sync::Arc<crate::templates::TemplateRegistry>,
+    image_root: &Path,
+    raw_kernel: &Path,
+) -> Result<(), String> {
+    let templates = templates.clone();
+    let image_root = image_root.to_path_buf();
+    let raw_kernel = raw_kernel.to_path_buf();
     tokio::task::spawn_blocking(move || register_blocking(&templates, &image_root, &raw_kernel))
         .await
-        .map_err(|error| format!("microboot registration task panicked: {error}"))??;
-
-    Ok(MICROBOOT_ALIAS.to_owned())
+        .map_err(|error| format!("microboot registration task panicked: {error}"))?
 }
 
 /// Serializes the download-and-register path — see `ensure_registered`.
@@ -187,7 +245,7 @@ pub(crate) fn spawn_warmup(state: AppState) {
 }
 
 /// The blocking half: prepare the downloaded `vmlinuz-virt` as an x86_64
-/// ELF vmlinux or ARM64 PE Image, create a small
+/// ELF vmlinux or a raw ARM64 Image, create a small
 /// placeholder rootfs artifact (its content is irrelevant — the guest
 /// overwrites the real disk it grows into via `mkfs.ext4 -F`, see the
 /// design doc's "스크래치 디스크" section), and register the spec.
@@ -339,30 +397,15 @@ fn prepare_kernel_image_for_arch(
         return extract_vmlinux(raw_kernel, dest);
     }
 
-    let mut file = std::fs::File::open(raw_kernel)
-        .map_err(|error| format!("open {}: {error}", raw_kernel.display()))?;
-    let mut magic = [0_u8; 2];
-    file.read_exact(&mut magic)
-        .map_err(|error| format!("read ARM64 kernel {}: {error}", raw_kernel.display()))?;
-    if magic != *b"MZ" {
+    extract_arm64_image(raw_kernel, dest)?;
+    if !is_arm64_image(dest) {
+        let _ = std::fs::remove_file(dest);
         return Err(format!(
-            "ARM64 kernel is not a PE Image: {}",
+            "extracted kernel is not a raw ARM64 Image: {}",
             raw_kernel.display()
         ));
     }
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)
-            .map_err(|error| format!("mkdir {}: {error}", parent.display()))?;
-    }
-    std::fs::copy(raw_kernel, dest)
-        .map_err(|error| {
-            format!(
-                "copy {} to {}: {error}",
-                raw_kernel.display(),
-                dest.display()
-            )
-        })?;
-    restore_arm64_image_magic(dest)
+    Ok(())
 }
 
 /// Offset of the Linux/arm64 "Image" boot header's `magic` field, per
@@ -371,24 +414,65 @@ const ARM64_IMAGE_MAGIC_OFFSET: u64 = 0x38;
 /// `ARM64_IMAGE_MAGIC` (`0x644d5241`), little-endian.
 const ARM64_IMAGE_MAGIC: [u8; 4] = *b"ARMd";
 
-/// Alpine's official netboot `vmlinuz-virt` for aarch64 (what `ensure_registered`
-/// downloads this builder kernel from) ships with this field zeroed out, even
-/// though the PE/EFI wrapper checked above is intact and would pass a plain
-/// `file`-style PE/ARM64 sniff. Firecracker's aarch64 kernel loader (rust-vmm
-/// linux-loader) validates this field independently of the PE header and
-/// refuses to boot with "invalid Image magic number" if it doesn't match —
-/// confirmed live against a production build (see the M2Images magic-number
-/// fix in `scripts/firecracker-menual/install-*-rootfs.sh`, same defect, same
-/// upstream cause), so repair it here too.
-fn restore_arm64_image_magic(dest: &Path) -> Result<(), String> {
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .open(dest)
-        .map_err(|error| format!("open {} for magic repair: {error}", dest.display()))?;
-    file.seek(SeekFrom::Start(ARM64_IMAGE_MAGIC_OFFSET))
-        .map_err(|error| format!("seek {} for magic repair: {error}", dest.display()))?;
-    file.write_all(&ARM64_IMAGE_MAGIC)
-        .map_err(|error| format!("write ARM64 Image magic into {}: {error}", dest.display()))
+/// Whether the file is a raw Linux/arm64 `Image` — the only kernel format
+/// Firecracker boots on aarch64. This field is only ever *read*: Alpine's
+/// netboot `vmlinuz-virt` (what `ensure_registered` downloads this builder
+/// kernel from) is an EFI zboot image, a PE wrapper around a compressed
+/// `Image`, which carries `LINUX_PE_MAGIC` here instead. Writing `ARMd` over
+/// that gets the file past the loader and then jumps the guest CPU into an
+/// EFI stub running without EFI boot services, which dies before it can emit
+/// a console byte — so the wrapper is unwrapped by `extract-arm64-image` and
+/// the magic is verified rather than stamped.
+fn is_arm64_image(path: &Path) -> bool {
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return false;
+    };
+    if file.seek(SeekFrom::Start(ARM64_IMAGE_MAGIC_OFFSET)).is_err() {
+        return false;
+    }
+    let mut magic = [0_u8; 4];
+    file.read_exact(&mut magic).is_ok() && magic == ARM64_IMAGE_MAGIC
+}
+
+/// Resolves the `extract-arm64-image` script path, the same installed-layout
+/// first, repo-relative fallback order `resolve_extract_vmlinux` uses.
+pub(crate) fn resolve_extract_arm64_image() -> PathBuf {
+    if let Ok(exe) = std::env::current_exe() {
+        let candidate = exe
+            .parent()
+            .unwrap_or(Path::new(""))
+            .join("extract-arm64-image");
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../scripts/firecracker-menual/extract-arm64-image")
+}
+
+fn extract_arm64_image(raw_kernel: &Path, dest: &Path) -> Result<(), String> {
+    let extract_arm64_image = resolve_extract_arm64_image();
+    let output = std::process::Command::new(&extract_arm64_image)
+        .arg(raw_kernel)
+        .output()
+        .map_err(|error| {
+            format!(
+                "run extract-arm64-image ({}): {error}",
+                extract_arm64_image.display()
+            )
+        })?;
+    if !output.status.success() || output.stdout.is_empty() {
+        return Err(format!(
+            "extract-arm64-image failed on {}: {}",
+            raw_kernel.display(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("mkdir {}: {error}", parent.display()))?;
+    }
+    std::fs::write(dest, &output.stdout)
+        .map_err(|error| format!("write {}: {error}", dest.display()))
 }
 
 #[cfg(test)]
@@ -414,43 +498,155 @@ mod tests {
         assert!(!dest.exists());
     }
 
-    #[test]
-    fn arm64_kernel_keeps_the_pe_image_instead_of_extracting_elf() {
-        let dir = temp_image_root();
-        let raw = dir.path().join("Image.raw");
-        let mut raw_bytes = vec![0_u8; 64];
-        raw_bytes[0] = b'M';
-        raw_bytes[1] = b'Z';
-        raw_bytes.extend_from_slice(b"firecracker-arm64-image");
-        std::fs::write(&raw, &raw_bytes).unwrap();
-        let dest = dir.path().join("Image-virt");
+    /// A minimal raw Linux/arm64 `Image`: the boot header is all this code
+    /// (and Firecracker's loader) ever inspects, so only `ARM64_IMAGE_MAGIC`
+    /// at 0x38 has to be real.
+    fn fake_raw_arm64_image(tail: &[u8]) -> Vec<u8> {
+        let mut image = vec![0_u8; 64];
+        image[0] = b'M';
+        image[1] = b'Z';
+        image[0x38..0x3c].copy_from_slice(&ARM64_IMAGE_MAGIC);
+        image.extend_from_slice(tail);
+        image
+    }
 
-        prepare_kernel_image_for_arch(&raw, &dest, "aarch64").unwrap();
+    /// Wraps `image` the way `CONFIG_EFI_ZBOOT` does: a PE/MZ header with the
+    /// `zimg` tag, the payload's offset and size, and its compression name,
+    /// per `drivers/firmware/efi/libstub/zboot-header.S`.
+    fn fake_efi_zboot_image(image: &[u8], dir: &Path) -> Vec<u8> {
+        let plain = dir.join("payload.bin");
+        std::fs::write(&plain, image).unwrap();
+        let gzipped = std::process::Command::new("gzip")
+            .arg("-c")
+            .arg(&plain)
+            .output()
+            .expect("gzip the zboot payload");
+        assert!(gzipped.status.success(), "gzip failed");
 
-        let mut expected = raw_bytes;
-        expected[0x38..0x3c].copy_from_slice(&ARM64_IMAGE_MAGIC);
-        assert_eq!(std::fs::read(dest).unwrap(), expected);
+        const PAYLOAD_OFFSET: usize = 0x40;
+        let mut wrapper = vec![0_u8; PAYLOAD_OFFSET];
+        wrapper[0..4].copy_from_slice(b"MZ\0\0");
+        wrapper[4..8].copy_from_slice(b"zimg");
+        wrapper[8..12].copy_from_slice(&(PAYLOAD_OFFSET as u32).to_le_bytes());
+        wrapper[12..16].copy_from_slice(&(gzipped.stdout.len() as u32).to_le_bytes());
+        wrapper[0x18..0x1c].copy_from_slice(b"gzip");
+        // LINUX_PE_MAGIC, which is what really sits at 0x38 in a zboot image
+        // — the byte range the old magic-stamping repair used to overwrite.
+        wrapper[0x38..0x3c].copy_from_slice(&0x8182_23cd_u32.to_le_bytes());
+        wrapper.extend_from_slice(&gzipped.stdout);
+        wrapper
     }
 
     #[test]
-    fn arm64_kernel_gets_its_boot_magic_repaired() {
-        // Reproduces the exact production defect: Alpine's official
-        // netboot vmlinuz-virt for aarch64 has this field zeroed, which
-        // Firecracker's kernel loader rejects with "invalid Image magic
-        // number" even though the PE/EFI wrapper around it is intact.
+    fn arm64_raw_image_is_passed_through_untouched() {
         let dir = temp_image_root();
         let raw = dir.path().join("Image.raw");
-        let mut raw_bytes = vec![0_u8; 64];
-        raw_bytes[0] = b'M';
-        raw_bytes[1] = b'Z';
-        raw_bytes.extend_from_slice(b"payload");
-        std::fs::write(&raw, &raw_bytes).unwrap();
+        let image = fake_raw_arm64_image(b"firecracker-arm64-image");
+        std::fs::write(&raw, &image).unwrap();
         let dest = dir.path().join("Image-virt");
 
         prepare_kernel_image_for_arch(&raw, &dest, "aarch64").unwrap();
 
-        let dest_bytes = std::fs::read(dest).unwrap();
-        assert_eq!(&dest_bytes[0x38..0x3c], &ARM64_IMAGE_MAGIC);
+        assert_eq!(std::fs::read(dest).unwrap(), image);
+    }
+
+    #[test]
+    fn arm64_efi_zboot_kernel_is_unwrapped_to_the_raw_image() {
+        // Reproduces the production defect: Alpine's official netboot
+        // vmlinuz-virt for aarch64 is an EFI zboot image, a PE wrapper around
+        // a compressed Image. Firecracker can only boot what is inside it, so
+        // the wrapper has to come off here.
+        let dir = temp_image_root();
+        let image = fake_raw_arm64_image(b"the real kernel");
+        let raw = dir.path().join("vmlinuz-virt");
+        std::fs::write(&raw, fake_efi_zboot_image(&image, dir.path())).unwrap();
+        let dest = dir.path().join("Image-virt");
+
+        prepare_kernel_image_for_arch(&raw, &dest, "aarch64").unwrap();
+
+        assert_eq!(std::fs::read(dest).unwrap(), image);
+    }
+
+    #[test]
+    fn arm64_kernel_that_cannot_be_unwrapped_is_rejected() {
+        // The boot magic is verified, never written. Stamping it onto a
+        // wrapper Firecracker cannot boot only moves the failure into the
+        // guest, where it looks like a VM that boots to silence.
+        let dir = temp_image_root();
+        let raw = dir.path().join("vmlinuz-virt");
+        let mut wrapper = vec![0_u8; 64];
+        wrapper[0] = b'M';
+        wrapper[1] = b'Z';
+        wrapper.extend_from_slice(b"neither zboot nor a UKI");
+        std::fs::write(&raw, &wrapper).unwrap();
+        let dest = dir.path().join("Image-virt");
+
+        let result = prepare_kernel_image_for_arch(&raw, &dest, "aarch64");
+
+        assert!(result.is_err(), "expected an unbootable wrapper to fail");
+        assert!(!dest.exists());
+    }
+
+    /// A minimal PE/COFF file carrying one section under `name` and nothing
+    /// else — enough for `extract-arm64-image` to walk the section table and
+    /// decide there is no kernel in here.
+    fn fake_pe_with_one_section(name: &[u8; 8]) -> Vec<u8> {
+        const PE_OFFSET: usize = 0x40;
+        let mut pe = vec![0_u8; PE_OFFSET];
+        pe[0..2].copy_from_slice(b"MZ");
+        pe[0x3c..0x40].copy_from_slice(&(PE_OFFSET as u32).to_le_bytes());
+
+        let mut header = vec![0_u8; 24];
+        header[0..4].copy_from_slice(b"PE\0\0");
+        header[4..6].copy_from_slice(&0xaa64_u16.to_le_bytes()); // IMAGE_FILE_MACHINE_ARM64
+        header[6..8].copy_from_slice(&1_u16.to_le_bytes()); // NumberOfSections
+        // SizeOfOptionalHeader stays 0, so the section table follows here.
+        pe.extend_from_slice(&header);
+
+        let mut section = vec![0_u8; 40];
+        section[0..8].copy_from_slice(name);
+        pe.extend_from_slice(&section);
+        pe
+    }
+
+    #[test]
+    fn an_x86_kernel_left_behind_by_an_older_build_is_rejected_on_aarch64() {
+        // Reproduces what every aarch64 host upgraded across the arm64 work
+        // still had cached: this module downloaded hardcoded x86_64 netboot
+        // URLs before `netboot_url_for_arch` existed, so `vmlinuz-virt.raw`
+        // held an x86 bzImage — a PE with `MZ` at 0x00, no `zimg` tag, no
+        // `.linux` section, and zeros where a raw Image carries its boot
+        // magic. Stamping `ARM64_IMAGE_MAGIC` onto those zeros (what this
+        // module used to do) handed Firecracker an x86 kernel it happily
+        // loaded and the guest could never run.
+        let dir = temp_image_root();
+        let raw = dir.path().join("vmlinuz-virt.raw");
+        std::fs::write(&raw, fake_pe_with_one_section(b".text\0\0\0")).unwrap();
+        let dest = dir.path().join("Image-virt");
+
+        let result = prepare_kernel_image_for_arch(&raw, &dest, "aarch64");
+
+        assert!(
+            result.is_err(),
+            "expected an x86 PE kernel to be rejected on aarch64"
+        );
+        assert!(!dest.exists());
+    }
+
+    #[tokio::test]
+    async fn discarding_a_poisoned_cache_removes_both_halves_and_tolerates_a_missing_one() {
+        // `ensure_registered` re-downloads the pair right after this, so the
+        // only thing that must hold is that neither stale file survives and
+        // that a half-populated cache doesn't turn into an error path.
+        let dir = temp_image_root();
+        let raw_kernel = dir.path().join("vmlinuz-virt.raw");
+        let initrd = dir.path().join("initramfs-virt");
+        std::fs::write(&raw_kernel, b"an x86 bzImage on an aarch64 host").unwrap();
+
+        discard_cached_pair(&raw_kernel, &initrd).await;
+
+        assert!(!raw_kernel.exists());
+        assert!(!initrd.exists());
     }
 
     #[test]
@@ -475,16 +671,11 @@ mod tests {
         // Firecracker supports, so extract-vmlinux takes its pass-through
         // path without scanning the much larger test executable.
         if crate::image_install::host_architecture() == "aarch64" {
-            // Magic already correct at 0x38 so the repair step is a no-op
-            // and the byte-equality assertion below stays meaningful for
-            // what this test actually covers (registration, not repair —
-            // see `arm64_kernel_gets_its_boot_magic_repaired` for that).
-            let mut fake = vec![0_u8; 64];
-            fake[0] = b'M';
-            fake[1] = b'Z';
-            fake[0x38..0x3c].copy_from_slice(&ARM64_IMAGE_MAGIC);
-            fake.extend_from_slice(b"fake ARM64 PE Image");
-            std::fs::write(&raw_kernel, &fake).unwrap();
+            // Already a raw Image, so the extraction step passes it straight
+            // through and this test keeps covering what it is about
+            // (registration, not unwrapping — see
+            // `arm64_efi_zboot_kernel_is_unwrapped_to_the_raw_image`).
+            std::fs::write(&raw_kernel, fake_raw_arm64_image(b"fake ARM64 Image")).unwrap();
         } else {
             std::fs::copy("/usr/bin/true", &raw_kernel).unwrap();
         }

--- a/firecrab-api/src/microboot.rs
+++ b/firecrab-api/src/microboot.rs
@@ -26,7 +26,7 @@ pub(crate) const MICROBOOT_ALIAS: &str = "__microboot";
 /// `images/.templates.json` is re-derived rather than silently reused: that
 /// file is replayed at every startup, and without this check a host that
 /// bootstrapped once would keep booting builders off the stale spec forever.
-const MICROBOOT_VERSION: &str = "v4";
+const MICROBOOT_VERSION: &str = "v5";
 
 fn netboot_url(filename: &str) -> String {
     netboot_url_for_arch(crate::image_install::host_architecture(), filename)

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -213,6 +213,15 @@ pub fn build_router(state: AppState, config: &HttpConfig) -> Router {
             "/api/images/{alias}/bootstrap",
             post(handlers::bootstrap::start_bootstrap),
         )
+        // Before the id-addressed route below only so the two read in the
+        // order a reader meets them; axum matches the literal `bootstrap`
+        // segment ahead of `{alias}` regardless of registration order, so
+        // `GET /api/images/bootstrap` can never be taken for an alias named
+        // "bootstrap".
+        .route(
+            "/api/images/bootstrap",
+            get(handlers::bootstrap::get_active_bootstrap),
+        )
         .route(
             "/api/images/bootstrap/{bootstrapId}",
             get(handlers::bootstrap::get_bootstrap).delete(handlers::bootstrap::cancel_bootstrap),

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -32,6 +32,14 @@ pub struct RuntimeConfig {
     /// How long to wait for the guest's network-readiness sentinel on its
     /// serial console before failing the start (see
     /// `handlers::vms::wait_for_network_ready`).
+    ///
+    /// This is a hang detector, not a latency budget, so it is sized for the
+    /// slowest guest rather than the typical one. Every supported template's
+    /// readiness script reports *both* outcomes — `FIRECRAB_NETWORK_READY`
+    /// or `FIRECRAB_NETWORK_FAILED <reason>` — so a guest that boots and
+    /// simply has no working network still fails in its own good time and
+    /// never reaches this bound. Only a guest that never gets far enough to
+    /// run the script at all does.
     pub network_ready_timeout: Duration,
 }
 
@@ -43,7 +51,17 @@ impl RuntimeConfig {
             firecracker_binary: firecracker::default_firecracker_binary(),
             ready_timeout: Duration::from_secs(10),
             stop_grace: Duration::from_secs(5),
-            network_ready_timeout: Duration::from_secs(30),
+            // 30s used to live here, which no Rocky VM could ever meet:
+            // timed on an aarch64 host at 1 vCPU / 2048 MiB, its dracut
+            // initramfs alone runs past 21s, and the readiness verdict lands
+            // at 67.5s (52s of that before the script's own 15s
+            // wait-for-IPv4 loop). Every rocky-9.8 start failed with "timed
+            // out waiting for network readiness" while the guest was still
+            // booting perfectly normally. Alpine reaches its verdict in ~4s
+            // and Ubuntu in between, so this bound is set by the slowest
+            // template plus room for a loaded host — see the field's doc for
+            // why overshooting costs nothing in the ordinary failure case.
+            network_ready_timeout: Duration::from_secs(180),
         }
     }
 }

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -1241,7 +1241,7 @@ mod tests {
             .iter()
             .find(|spec| spec.alias == "rocky-9.8")
             .expect("rocky-9.8 is one of the default specs");
-        assert_eq!(rocky.version, "rocky-9.8-v2");
+        assert_eq!(rocky.version, "rocky-9.8-v4");
         if alpine_arch == "aarch64" {
             assert_eq!(
                 rocky.kernel,
@@ -1369,7 +1369,7 @@ mod tests {
         );
 
         let rocky = specs.iter().find(|spec| spec.alias == "rocky-9.8").unwrap();
-        assert_eq!(rocky.version, "rocky-9.8-v2");
+        assert_eq!(rocky.version, "rocky-9.8-v4");
         assert_eq!(
             rocky.kernel,
             PathBuf::from("kernel/Image-rocky-9.8-aarch64")

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -865,7 +865,7 @@ mod tests {
             "the image root is created so later builds land there"
         );
         assert!(
-            registry.resolve_alias("alpine-3.24").is_none(),
+            registry.resolve_alias("alpine-3.24.1").is_none(),
             "an unbuilt template must not resolve"
         );
 
@@ -873,7 +873,7 @@ mod tests {
         // other stays skipped rather than failing the whole registry.
         let alpine = default_specs()
             .into_iter()
-            .find(|spec| spec.alias == "alpine-3.24")
+            .find(|spec| spec.alias == "alpine-3.24.1")
             .expect("alpine is a default template");
         for relative in [&alpine.kernel, &alpine.rootfs]
             .into_iter()
@@ -885,7 +885,7 @@ mod tests {
         }
 
         let registry = TemplateRegistry::load_from(&root).expect("one built template");
-        assert!(registry.resolve_alias("alpine-3.24").is_some());
+        assert!(registry.resolve_alias("alpine-3.24.1").is_some());
         assert!(registry.resolve_alias("ubuntu-26.04").is_none());
         assert!(registry.resolve_alias("rocky-9.8").is_none());
     }
@@ -1213,8 +1213,8 @@ mod tests {
 
         let alpine = specs
             .iter()
-            .find(|spec| spec.alias == "alpine-3.24")
-            .expect("alpine-3.24 is one of the default specs");
+            .find(|spec| spec.alias == "alpine-3.24.1")
+            .expect("alpine-3.24.1 is one of the default specs");
         let expected_alpine_kernel = if alpine_arch == "aarch64" {
             "kernel/Image-alpine-virt-aarch64"
         } else {
@@ -1319,7 +1319,7 @@ mod tests {
         );
 
         let alpine = registry
-            .resolve_alias("alpine-3.24")
+            .resolve_alias("alpine-3.24.1")
             .expect("Alpine template resolves");
         assert!(!alpine.requires_pci_transport());
         assert!(alpine.runtime_boot_args().contains("pci=off"));
@@ -1333,7 +1333,7 @@ mod tests {
                 .iter()
                 .map(|spec| spec.alias.as_str())
                 .collect::<Vec<_>>(),
-            vec!["alpine-3.24", "ubuntu-26.04", "rocky-9.8"]
+            vec!["alpine-3.24.1", "ubuntu-26.04", "rocky-9.8"]
         );
 
         let ubuntu = specs
@@ -1353,7 +1353,7 @@ mod tests {
 
         let alpine = specs
             .iter()
-            .find(|spec| spec.alias == "alpine-3.24")
+            .find(|spec| spec.alias == "alpine-3.24.1")
             .unwrap();
         assert_eq!(
             alpine.kernel,

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -1241,7 +1241,7 @@ mod tests {
             .iter()
             .find(|spec| spec.alias == "rocky-9.8")
             .expect("rocky-9.8 is one of the default specs");
-        assert_eq!(rocky.version, "rocky-9.8-v1");
+        assert_eq!(rocky.version, "rocky-9.8-v2");
         if alpine_arch == "aarch64" {
             assert_eq!(
                 rocky.kernel,
@@ -1369,7 +1369,7 @@ mod tests {
         );
 
         let rocky = specs.iter().find(|spec| spec.alias == "rocky-9.8").unwrap();
-        assert_eq!(rocky.version, "rocky-9.8-v1");
+        assert_eq!(rocky.version, "rocky-9.8-v2");
         assert_eq!(
             rocky.kernel,
             PathBuf::from("kernel/Image-rocky-9.8-aarch64")

--- a/firecrab-frontend/src/api/client.ts
+++ b/firecrab-frontend/src/api/client.ts
@@ -366,6 +366,20 @@ export function getBootstrap(bootstrapId: string): Promise<BootstrapResponse> {
   return fetchJson(`/api/images/bootstrap/${encodeURIComponent(bootstrapId)}`);
 }
 
+/**
+ * The bootstrap still running on this host, if any
+ * (`GET /api/images/bootstrap`).
+ *
+ * `startBootstrap` returns the session id, but only to the page that issued
+ * it — reload that page, or leave and come back, and the id is gone while
+ * the build keeps going. This asks the server for it instead, which is what
+ * lets the session panel and its console reappear. Resolves to `null` when
+ * nothing is building.
+ */
+export function getActiveBootstrap(): Promise<BootstrapResponse | null> {
+  return fetchJson(`/api/images/bootstrap`);
+}
+
 /** Cancel a bootstrap and delete its builder VM (`DELETE /api/images/bootstrap/{bootstrapId}`). */
 export async function cancelBootstrap(bootstrapId: string): Promise<void> {
   let response: Response;

--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -14,6 +14,7 @@ import {
   deleteImage,
   deleteStagedPackage,
   deleteVm,
+  getActiveBootstrap,
   getBootstrap,
   getImageInstall,
   getImagePackage,
@@ -592,6 +593,8 @@ export default function Images() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [packageJobs, setPackageJobs] = useState<Record<string, ImageInstallResponse>>({});
   const packagePollingRef = useRef(new Set<string>());
+  /** Session id currently being polled, so only ever one loop runs. */
+  const bootstrapPollingRef = useRef<string | null>(null);
   const [install, setInstall] = useState<ImageInstallResponse | null>(null);
   const [installOrigin, setInstallOrigin] = useState<"microRegistry" | "microBoot" | null>(null);
   const [selectedAlias, setSelectedAlias] = useState<string | null>(null);
@@ -757,28 +760,67 @@ export default function Images() {
   // 404는 취소로 삭제된 세션이라는 확정 신호(그만 폴링), 그 외 에러는
   // 일시적일 수 있으니 계속 폴링한다.
   const pollBootstrap = (bootstrapId: string) => {
+    // One loop per session: the resume effect below and an explicit start
+    // can both ask for the same id, and StrictMode runs that effect twice in
+    // development, so without this guard the timers stack up.
+    if (bootstrapPollingRef.current === bootstrapId) return;
+    bootstrapPollingRef.current = bootstrapId;
+    const stop = () => {
+      if (bootstrapPollingRef.current === bootstrapId) bootstrapPollingRef.current = null;
+    };
     const tick = async () => {
-      if (!mountedRef.current) return;
+      if (!mountedRef.current) return stop();
       try {
         const snapshot = await getBootstrap(bootstrapId);
-        if (!mountedRef.current) return;
+        if (!mountedRef.current) return stop();
         setBootstrapSession(snapshot);
         if (snapshot.status === "succeeded") {
+          stop();
           await Promise.all([refreshList(), refreshRegistry()]);
         } else if (snapshot.status !== "failed") {
           setTimeout(() => void tick(), 1000);
+        } else {
+          // "failed" is a confirmed terminal state too — stop without retrying.
+          stop();
         }
-        // "failed" is a confirmed terminal state too — stop without retrying.
       } catch (err) {
         if (err instanceof ApiClientError && err.status === 404) {
+          stop();
           if (mountedRef.current) setBootstrapSession(null);
           return;
         }
         if (mountedRef.current) setTimeout(() => void tick(), 1000);
+        else stop();
       }
     };
     void tick();
   };
+
+  // Makes good on what the `mountedRef` comment above already promises —
+  // that a bootstrap "keeps running on the backend and this panel resumes
+  // polling it next time Images mounts". It could not, until now: the
+  // session id arrives only in the `startBootstrap` response and lives only
+  // in this component's state, so a reload or a walk to another tab left the
+  // build running with no panel and no console until it finished. Ask the
+  // server which bootstrap is live and pick that id back up.
+  useEffect(() => {
+    let cancelled = false;
+    getActiveBootstrap()
+      .then((session) => {
+        if (cancelled || !mountedRef.current || !session) return;
+        setBootstrapSession(session);
+        pollBootstrap(session.bootstrapId);
+      })
+      // Having nothing to resume is the ordinary case, and a failure here
+      // must not stop the image list itself from rendering.
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+    // Once, on mount. `pollBootstrap` is rebuilt every render, but the ref
+    // guard inside it is what keeps duplicate loops out.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleStartBootstrap = async (alias: string) => {
     if (bootstrapStartingAlias !== null) return;

--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -32,7 +32,7 @@ import InlineConsole from "./InlineConsole";
 import { useI18n } from "../i18n";
 
 const KNOWN_TEMPLATES = [
-  { alias: "alpine-3.24", label: "Alpine Linux", logoSrc: "https://www.alpinelinux.org/alpinelinux-logo.svg" },
+  { alias: "alpine-3.24.1", label: "Alpine Linux", logoSrc: "https://www.alpinelinux.org/alpinelinux-logo.svg" },
   { alias: "ubuntu-26.04", label: "Ubuntu", logoSrc: "https://assets.ubuntu.com/v1/ff6a9a38-ubuntu-logo-2022.svg" },
   { alias: "rocky-9.8", label: "Rocky Linux 9.8", logoSrc: "https://raw.githubusercontent.com/rocky-linux/branding/main/logo/src/icon-primary.svg" },
 ] as const;

--- a/install.sh
+++ b/install.sh
@@ -384,12 +384,15 @@ install_binaries() {
         [ -x "$target/$binary" ] || die "$target/$binary not found — the build did not produce it"
         $SUDO install -o root -g root -m 0755 "$target/$binary" "$LIBDIR/$binary"
     done
-    # extract-vmlinux is a shell script used at runtime by the API.
-    # Installing it next to the binary lets the API find it without needing
-    # access to the repo checkout (which may be in a user home the service
-    # account cannot reach).
-    $SUDO install -o root -g root -m 0755 \
-        "$REPO_ROOT/scripts/firecracker-menual/extract-vmlinux" "$LIBDIR/extract-vmlinux"
+    # extract-vmlinux and extract-arm64-image are shell scripts used at
+    # runtime by the API to turn a distro vmlinuz into the kernel format
+    # Firecracker boots on each architecture. Installing them next to the
+    # binary lets the API find them without needing access to the repo
+    # checkout (which may be in a user home the service account cannot reach).
+    for helper in extract-vmlinux extract-arm64-image; do
+        $SUDO install -o root -g root -m 0755 \
+            "$REPO_ROOT/scripts/firecracker-menual/$helper" "$LIBDIR/$helper"
+    done
     # Host doctor is a shell script — no build step. On PATH as firecrab-doctor.
     $SUDO install -d -o root -g root -m 0755 "$PREFIX/bin"
     $SUDO install -o root -g root -m 0755 "$REPO_ROOT/scripts/firecrab-doctor.sh" \

--- a/install.sh
+++ b/install.sh
@@ -346,6 +346,26 @@ ensure_account() {
         step "adding $FIRECRAB_USER to the kvm group"
         $SUDO usermod --append --groups kvm "$FIRECRAB_USER"
     fi
+
+    # Group membership above is necessary but not always sufficient: some
+    # hosts' /dev/kvm doesn't actually land in the kvm group the standard
+    # udev rule (KERNEL=="kvm", GROUP="kvm") asks for — seen live on a
+    # Parallels ARM host where it came up group "sgx" instead, which made
+    # every VM start fail with "Kvm error: Permission denied (os error 13)"
+    # even though $FIRECRAB_USER was correctly in the kvm group. An ACL
+    # entry is a narrow, idempotent belt-and-suspenders fix: it grants the
+    # kvm group access without touching whatever else owns the device node,
+    # and re-running this is a no-op once the entry is already there.
+    if [ -e /dev/kvm ]; then
+        if have setfacl; then
+            if ! getfacl -p /dev/kvm 2>/dev/null | grep -qx 'group:kvm:rw-'; then
+                step "granting the kvm group ACL access to /dev/kvm"
+                $SUDO setfacl -m g:kvm:rw /dev/kvm
+            fi
+        else
+            warn "setfacl not found — skipping the /dev/kvm ACL fixup (install the 'acl' package if VMs fail with a KVM permission error)"
+        fi
+    fi
 }
 
 # Data, config and install directories with their intended owners.

--- a/packaging/m2images.json
+++ b/packaging/m2images.json
@@ -14,8 +14,8 @@
       "distribution": "alpine",
       "series": "3.24",
       "version": "3.24.1",
-      "revision": 4,
-      "templateVersion": "alpine-3.24.1-v4",
+      "revision": 5,
+      "templateVersion": "alpine-3.24.1-v5",
       "minDiskGb": 1,
       "builder": {
         "script": "scripts/firecracker-menual/install-alpine-rootfs.sh",
@@ -47,8 +47,8 @@
       "distribution": "ubuntu",
       "series": "26.04",
       "version": "26.04",
-      "revision": 3,
-      "templateVersion": "ubuntu-26.04-v3",
+      "revision": 5,
+      "templateVersion": "ubuntu-26.04-v5",
       "minDiskGb": 2,
       "builder": {
         "script": "scripts/firecracker-menual/install-ubuntu-roofs.sh",
@@ -80,8 +80,8 @@
       "distribution": "rocky",
       "series": "9.8",
       "version": "9.8",
-      "revision": 2,
-      "templateVersion": "rocky-9.8-v2",
+      "revision": 4,
+      "templateVersion": "rocky-9.8-v4",
       "minDiskGb": 2,
       "builder": {
         "script": "scripts/firecracker-menual/install-rocky-rootfs.sh",

--- a/packaging/m2images.json
+++ b/packaging/m2images.json
@@ -14,8 +14,8 @@
       "distribution": "alpine",
       "series": "3.24",
       "version": "3.24.1",
-      "revision": 3,
-      "templateVersion": "alpine-3.24.1-v3",
+      "revision": 4,
+      "templateVersion": "alpine-3.24.1-v4",
       "minDiskGb": 1,
       "builder": {
         "script": "scripts/firecracker-menual/install-alpine-rootfs.sh",
@@ -47,8 +47,8 @@
       "distribution": "ubuntu",
       "series": "26.04",
       "version": "26.04",
-      "revision": 2,
-      "templateVersion": "ubuntu-26.04-v2",
+      "revision": 3,
+      "templateVersion": "ubuntu-26.04-v3",
       "minDiskGb": 2,
       "builder": {
         "script": "scripts/firecracker-menual/install-ubuntu-roofs.sh",
@@ -80,8 +80,8 @@
       "distribution": "rocky",
       "series": "9.8",
       "version": "9.8",
-      "revision": 1,
-      "templateVersion": "rocky-9.8-v1",
+      "revision": 2,
+      "templateVersion": "rocky-9.8-v2",
       "minDiskGb": 2,
       "builder": {
         "script": "scripts/firecracker-menual/install-rocky-rootfs.sh",

--- a/packaging/m2images.json
+++ b/packaging/m2images.json
@@ -10,7 +10,7 @@
   ],
   "images": [
     {
-      "alias": "alpine-3.24",
+      "alias": "alpine-3.24.1",
       "distribution": "alpine",
       "series": "3.24",
       "version": "3.24.1",
@@ -31,14 +31,14 @@
           "initrd": "kernel/initramfs-alpine-virt-x86_64",
           "rootfs": "rootfs/alpine-rootfs-3.24.1-x86_64.ext4",
           "bootArgs": "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rootfstype=ext4 rw",
-          "registryKey": "alpine/3.24.1/x86_64/alpine-3.24.tar.zst"
+          "registryKey": "alpine/3.24.1/x86_64/alpine-3.24.1.tar.zst"
         },
         "aarch64": {
           "kernel": "kernel/Image-alpine-virt-aarch64",
           "initrd": "kernel/initramfs-alpine-virt-aarch64",
           "rootfs": "rootfs/alpine-rootfs-3.24.1-aarch64.ext4",
           "bootArgs": "keep_bootcon console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rootfstype=ext4 rw",
-          "registryKey": "alpine/3.24.1/aarch64/alpine-3.24.tar.zst"
+          "registryKey": "alpine/3.24.1/aarch64/alpine-3.24.1.tar.zst"
         }
       }
     },

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -51,7 +51,7 @@ curl -s -X POST http://127.0.0.1:3000/api/vms \
   -H 'Content-Type: application/json' \
   -d "{
     \"name\": \"demo\",
-    \"template\": \"alpine-3.24\",
+    \"template\": \"alpine-3.24.1\",
     \"cpu\": 1,
     \"ram\": 512,
     \"diskGb\": 2,

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -3,7 +3,7 @@
 An M2Image contains a kernel and root filesystem.
 It is the source template for new VM disks.
 
-Supported aliases are `alpine-3.24`, `ubuntu-26.04`, and `rocky-9.8`.
+Supported aliases are `alpine-3.24.1`, `ubuntu-26.04`, and `rocky-9.8`.
 All three support x86_64 and ARM64. Rocky is exposed only through the
 versioned `rocky-9.8` alias.
 ARM64 packages keep the distro PE32+ `Image`; x86_64 packages use an ELF
@@ -20,7 +20,7 @@ Build all images supported by the current Linux host architecture.
 Build one alias when needed.
 
 ```sh
-./scripts/build-m2images.sh --alias alpine-3.24
+./scripts/build-m2images.sh --alias alpine-3.24.1
 ./scripts/build-m2images.sh --alias rocky-9.8
 ```
 
@@ -48,12 +48,12 @@ chroots are rejected with an explicit error.
 dist/m2images/
   catalog.json
   x86_64/
-    alpine-3.24.tar.zst
+    alpine-3.24.1.tar.zst
     ubuntu-26.04.tar.zst
     rocky-9.8.tar.zst
     SHA256SUMS
   aarch64/
-    alpine-3.24.tar.zst
+    alpine-3.24.1.tar.zst
     ubuntu-26.04.tar.zst
     rocky-9.8.tar.zst
     SHA256SUMS
@@ -64,7 +64,7 @@ Verify packages after building them.
 ```sh
 cd dist/m2images/x86_64
 sha256sum -c SHA256SUMS
-tar --list --zstd --file alpine-3.24.tar.zst
+tar --list --zstd --file alpine-3.24.1.tar.zst
 ```
 
 ## Release manifest

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -83,7 +83,7 @@ It creates a network, starts a VM, checks connectivity, and removes the VM.
 Run one image check locally after installation.
 
 ```sh
-scripts/ci-m2-guest-boot.sh alpine-3.24
+scripts/ci-m2-guest-boot.sh alpine-3.24.1
 ```
 
 ## Related

--- a/scripts/ci-m2-guest-boot.sh
+++ b/scripts/ci-m2-guest-boot.sh
@@ -3,13 +3,13 @@
 # (guest MicroVM) for the given template, ping it, then stop+delete.
 #
 # Usage: scripts/ci-m2-guest-boot.sh <template-alias>
-#   e.g. scripts/ci-m2-guest-boot.sh alpine-3.24
+#   e.g. scripts/ci-m2-guest-boot.sh alpine-3.24.1
 #
 # Prerequisites: firecrab-api listening on :3000, a registered template,
 # KVM available, micro_network create works (explicit networks only).
 set -euo pipefail
 
-TEMPLATE=${1:?template alias required (e.g. alpine-3.24)}
+TEMPLATE=${1:?template alias required (e.g. alpine-3.24.1)}
 API=${FIRECRAB_API:-http://127.0.0.1:3000}
 # Unique /24 per template hash so parallel matrix jobs on one host would not
 # collide if ever co-located (each CI job is its own runner today).

--- a/scripts/firecracker-menual/bootstrap-alpine-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-alpine-in-guest.sh
@@ -93,11 +93,24 @@ REPOS
 # share /etc/resolv.conf the way the /proc,/sys,/dev bind mounts do, so
 # without this the extracted minirootfs's own (unusable) resolv.conf makes
 # every package lookup fail DNS resolution (found live: "DNS: transient
-# error", every package "no such package"). The final production value is
-# the same either way; only the timing moved.
-cat >"${staging}/etc/resolv.conf" <<'EOF'
-nameserver 172.30.0.1
-EOF
+# error", every package "no such package").
+#
+# Taken from the outer shell rather than written as a literal. This used to
+# pin "nameserver 172.30.0.1" — the gateway of the *default* MicroNetwork —
+# so a builder VM placed on any other MicroNetwork (172.33.0.0/24, say) sent
+# every lookup to an address nothing answers on and failed with exactly the
+# symptom above, while the outer shell, whose resolver udhcpc had just set
+# from the lease, was fetching from the same mirror successfully two steps
+# earlier. What the *finished image* ships is a separate concern, written
+# further down, the way bootstrap-rocky-in-guest.sh already separates them.
+if [ -s /etc/resolv.conf ]; then
+  cp /etc/resolv.conf "${staging}/etc/resolv.conf"
+else
+  build_resolver=$(ip route show default 2>/dev/null | awk '{ print $3; exit }')
+  [ -n "$build_resolver" ] \
+    || fail 'no resolver in the outer shell and no default gateway to derive one from'
+  printf 'nameserver %s\n' "$build_resolver" >"${staging}/etc/resolv.conf"
+fi
 
 mount -t proc proc "$staging/proc"
 mount --rbind /sys "$staging/sys"
@@ -115,6 +128,16 @@ EOF
 cat >"${staging}/etc/hosts" <<EOF
 127.0.0.1 localhost
 127.0.1.1 ${rootfs_hostname}
+EOF
+
+# The resolver the finished image ships with, replacing the builder VM's own
+# (whose MicroNetwork the image will usually not be on). Only ever read
+# before the first DHCP lease lands: dnsmasq hands the bridge out as the
+# guest's DNS server and dhcpcd rewrites this file from the lease on boot.
+# Same value and same reason as bootstrap-rocky-in-guest.sh's.
+rm -f "${staging}/etc/resolv.conf"
+cat >"${staging}/etc/resolv.conf" <<'EOF'
+nameserver 172.30.0.1
 EOF
 cat >"${staging}/etc/fstab" <<'EOF'
 /dev/vda / ext4 defaults 0 1

--- a/scripts/firecracker-menual/bootstrap-alpine-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-alpine-in-guest.sh
@@ -21,7 +21,11 @@ rootfs_hostname='firecrab'
 # bash: Shell repository scripts often use #!/bin/bash (same as Ubuntu).
 rootfs_packages='alpine-baselayout busybox bash openrc agetty iproute2-minimal iputils-ping dhcpcd openssh-server ca-certificates curl procps linux-virt'
 
-info() { printf '[INFO] %s\n' "$*"; }
+# Seconds since the script started, on every line — see the same helper in
+# bootstrap-ubuntu-in-guest.sh for why the session log is useless for finding
+# where a slow build spent its time without it.
+script_started=$(date +%s)
+info() { printf '[INFO +%ss] %s\n' "$(( $(date +%s) - script_started ))" "$*"; }
 fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
 
 cleanup_mounts() {

--- a/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
@@ -369,6 +369,16 @@ test -e "$staging/etc/systemd/system/firecrab-network-ready.service" || fail 'mi
 cp "$vmlinuz_path" "$out/vmlinuz-raw"
 cp "$initrd_path" "$out/initramfs"
 
+# Now that it is safely in $out, drop it from the tree that becomes the
+# rootfs. Firecracker loads the initrd the host hands it (the copy just
+# made), never one from inside the guest's own filesystem, so the in-rootfs
+# copy is 27.9 MB — 7.5% of this image, measured with debugfs on a built
+# one — that is written twice by the two mkfs.ext4 passes below, shipped in
+# every package, and never read. EL9 owns this path as %ghost precisely
+# because it is regenerated rather than shipped, so dracut inside a running
+# guest recreates it on the next kernel update exactly as it would have.
+rm -f "$initrd_path"
+
 info 'building rootfs.ext4'
 truncate -s "$rootfs_size" "$out/rootfs.ext4.tmp"
 # -O ^orphan_file: see the identical flag in the alpine/ubuntu scripts —

--- a/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
@@ -142,11 +142,15 @@ tar -xJf "$container_archive" -C "$oci_dir"
 info "extracting Rocky ${rocky_release} ${rocky_arch} Container-Base"
 if [ -f "$oci_dir/index.json" ]; then
   manifest_digest=$(jq -r '.manifests[0].digest | sub("^sha256:"; "")' "$oci_dir/index.json")
-  [ -n "$manifest_digest" ] && [ "$manifest_digest" != null ] \
-    || fail 'could not read Container-Base manifest digest from index.json'
+  # Negative form rather than `A && B || fail`, which reads as if-then-else
+  # without being one (SC2015) and older shellcheck releases reject.
+  if [ -z "$manifest_digest" ] || [ "$manifest_digest" = null ]; then
+    fail 'could not read Container-Base manifest digest from index.json'
+  fi
   layer_digest=$(jq -r '.layers[0].digest | sub("^sha256:"; "")' "$oci_dir/blobs/sha256/$manifest_digest")
-  [ -n "$layer_digest" ] && [ "$layer_digest" != null ] \
-    || fail 'could not read Container-Base layer digest from its manifest'
+  if [ -z "$layer_digest" ] || [ "$layer_digest" = null ]; then
+    fail 'could not read Container-Base layer digest from its manifest'
+  fi
   tar -xzf "$oci_dir/blobs/sha256/$layer_digest" -C "$container_root"
 elif [ -f "$oci_dir/manifest.json" ]; then
   jq -r '.[0].Layers[]' "$oci_dir/manifest.json" | while IFS= read -r layer; do

--- a/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-rocky-in-guest.sh
@@ -52,7 +52,11 @@ container_url="${rocky_repository_base}/${rocky_release}/images/${rocky_arch}/${
 # actions invoke `dnf` on the serial console.
 rootfs_packages='kernel dracut systemd systemd-udev NetworkManager iproute iputils bind-utils curl ca-certificates procps-ng openssh-server kmod util-linux dhcp-client e2fsprogs dnf'
 
-info() { printf '[INFO] %s\n' "$*"; }
+# Seconds since the script started, on every line — see the same helper in
+# bootstrap-ubuntu-in-guest.sh for why the session log is useless for finding
+# where a slow build spent its time without it.
+script_started=$(date +%s)
+info() { printf '[INFO +%ss] %s\n' "$(( $(date +%s) - script_started ))" "$*"; }
 fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
 
 chroot_mounts=''

--- a/scripts/firecracker-menual/bootstrap-ubuntu-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-ubuntu-in-guest.sh
@@ -17,7 +17,18 @@ ubuntu_base_url='https://cdimage.ubuntu.com/ubuntu-base/releases'
 series='@M2IMAGE_DISTRO_SERIES@'
 rootfs_size='2G'
 rootfs_hostname='firecrab'
-rootfs_packages='systemd systemd-sysv systemd-resolved udev kmod util-linux linux-image-generic iproute2 iputils-ping net-tools dnsutils curl ca-certificates procps openssh-server'
+# linux-image-virtual, not linux-image-generic: both resolve to the identical
+# linux-image-<abi>-generic binary, but generic also carries
+# "Depends: linux-firmware | linux-firmware-minimal", whose first alternative
+# apt always takes — a hard dependency --no-install-recommends cannot decline.
+# That pulled 656 MB of Qualcomm/Intel wireless, NVIDIA/AMD graphics and
+# Mellanox NIC firmware (measured in the built image: 5233 files, 53% of its
+# content) into a microVM with none of that hardware, and none of it is on
+# the boot path — this template has no initrd and mounts root=/dev/vda from
+# the kernel's built-in virtio/ext4. Same reasoning as
+# install-ubuntu-roofs.sh's copy of this list, and the same choice Alpine's
+# `linux-virt` already makes.
+rootfs_packages='systemd systemd-sysv systemd-resolved udev kmod util-linux linux-image-virtual iproute2 iputils-ping net-tools dnsutils curl ca-certificates procps openssh-server'
 
 info() { printf '[INFO] %s\n' "$*"; }
 fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
@@ -201,7 +212,7 @@ chroot "$mount_dir" apt-get clean
 rm -rf "${mount_dir}/var/lib/apt/lists/"*
 
 vmlinuz_path=$(find "${mount_dir}/boot" -maxdepth 1 -name 'vmlinuz-*' | sort -V | tail -n1)
-[ -n "$vmlinuz_path" ] || fail 'linux-image-generic did not install a vmlinuz'
+[ -n "$vmlinuz_path" ] || fail 'linux-image-virtual did not install a vmlinuz'
 cp "$vmlinuz_path" "$out/vmlinuz-raw"
 
 # Enable systemd-resolved only when the package actually shipped a unit.

--- a/scripts/firecracker-menual/bootstrap-ubuntu-in-guest.sh
+++ b/scripts/firecracker-menual/bootstrap-ubuntu-in-guest.sh
@@ -30,7 +30,13 @@ rootfs_hostname='firecrab'
 # `linux-virt` already makes.
 rootfs_packages='systemd systemd-sysv systemd-resolved udev kmod util-linux linux-image-virtual iproute2 iputils-ping net-tools dnsutils curl ca-certificates procps openssh-server'
 
-info() { printf '[INFO] %s\n' "$*"; }
+# Every line carries seconds since this script started. A MicroBoot build is
+# tens of minutes of mostly-silent work, and the session log is the only
+# record of it, so without this there is no way to tell afterwards which step
+# spent the time — download, dpkg, or either mkfs pass — and any attempt to
+# make it faster is guesswork.
+script_started=$(date +%s)
+info() { printf '[INFO +%ss] %s\n' "$(( $(date +%s) - script_started ))" "$*"; }
 fail() { printf '[FAIL] %s\n' "$*" >&2; exit 1; }
 
 cleanup_mounts() {

--- a/scripts/firecracker-menual/extract-arm64-image
+++ b/scripts/firecracker-menual/extract-arm64-image
@@ -1,0 +1,230 @@
+#!/bin/sh
+# ----------------------------------------------------------------------
+# extract-arm64-image - Extract a raw Linux/arm64 "Image" from a distro vmlinuz
+#
+# Firecracker's aarch64 loader (rust-vmm linux-loader) boots exactly one
+# kernel format: a raw Linux/arm64 Image. It checks ARM64_IMAGE_MAGIC
+# ("ARMd", 4 bytes at offset 0x38, per Documentation/arch/arm64/booting.rst)
+# and then hands the guest CPU the start of the file. A distro's
+# /boot/vmlinuz on arm64 is usually *not* that file. It comes in one of
+# three shapes:
+#
+#   raw Image   "ARMd" already at 0x38. Passed through untouched.
+#
+#   EFI zboot   "MZ" at 0x00 and "zimg" at 0x04 (CONFIG_EFI_ZBOOT, Linux
+#               6.1+). A PE application wrapping a *compressed* Image plus a
+#               decompressor stub that runs under EFI. Header layout, from
+#               drivers/firmware/efi/libstub/zboot-header.S: payload offset
+#               u32 @0x08, payload size u32 @0x0c, NUL-terminated compression
+#               name @0x18, and LINUX_PE_MAGIC (0x818223cd) — not "ARMd" —
+#               at 0x38. Shipped by Alpine (gzip) and Rocky (gzip).
+#
+#   UKI         A PE carrying the kernel in a ".linux" section, next to
+#               .dtbauto/.uname/.sbat (systemd-stub layout). Ubuntu 26.04
+#               ships its arm64 vmlinuz this way, and the .linux payload is
+#               itself an EFI zboot image (zstd), so it unwraps twice.
+#
+# Only the first shape boots under Firecracker. Writing "ARMd" over offset
+# 0x38 of either of the other two makes the loader *accept* the file and then
+# jump into an EFI stub that never receives EFI boot services: the guest dies
+# before it emits a single console byte, and the only symptom upstack is a
+# VM that boots to silence. So unwrap the real Image instead, and verify the
+# magic is genuinely present rather than stamping it on.
+#
+# Usage: extract-arm64-image <vmlinuz>   # raw Image on stdout
+# ----------------------------------------------------------------------
+
+set -u
+
+me=${0##*/}
+
+# ARM64_IMAGE_MAGIC ("ARMd") and the "zimg"/"MZ" tags, as hex, so that the
+# comparisons never carry NUL or non-printable bytes through a shell variable.
+arm64_image_magic=41524d64
+zboot_magic=7a696d67
+mz_magic=4d5a
+pe_magic=50450000
+
+arm64_image_magic_offset=56 # 0x38
+
+fail() {
+	echo "${me}: $1" >&2
+	exit 1
+}
+
+# Hex of $3 bytes at offset $2 of file $1, lowercase and unseparated. Reading
+# past the end of a file that is too short to hold the field yields an empty
+# string, which never equals a magic the callers look for.
+hex_at() {
+	od -An -tx1 -j "$2" -N "$3" "$1" 2>/dev/null | tr -d ' \n'
+}
+
+# Little-endian u16 at offset $2 of file $1, as a decimal. Assembled from
+# individual bytes so the result does not depend on the host's endianness.
+# A field that runs past the end of the file reads as 0, which every caller
+# already has to treat as a malformed header.
+u16_at() {
+	_f=$1
+	_o=$2
+	# shellcheck disable=SC2046 # word splitting is how the bytes arrive
+	set -- $(od -An -tu1 -j "$_o" -N 2 "$_f" 2>/dev/null)
+	if [ "$#" -lt 2 ]; then
+		echo 0
+		return
+	fi
+	echo $(( $2 * 256 + $1 ))
+}
+
+# Little-endian u32 at offset $2 of file $1, as a decimal.
+u32_at() {
+	_f=$1
+	_o=$2
+	# shellcheck disable=SC2046 # word splitting is how the bytes arrive
+	set -- $(od -An -tu1 -j "$_o" -N 4 "$_f" 2>/dev/null)
+	if [ "$#" -lt 4 ]; then
+		echo 0
+		return
+	fi
+	echo $(( $4 * 16777216 + $3 * 65536 + $2 * 256 + $1 ))
+}
+
+# Writes $3 bytes from offset $2 of file $1 to stdout.
+slice() {
+	tail -c "+$(( $2 + 1 ))" "$1" | head -c "$3"
+}
+
+is_arm64_image() {
+	[ -s "$1" ] && [ "$(hex_at "$1" "$arm64_image_magic_offset" 4)" = "$arm64_image_magic" ]
+}
+
+# Decompresses stdin using the named algorithm. The decompressor's own exit
+# status is deliberately ignored by the callers: EFI zboot's declared payload
+# size excludes gzip's 4-byte trailer (ZBOOT_SIZE_LEN), so gzip reports
+# "unexpected end of file" after having already written every byte of the
+# kernel. The extracted Image is validated on its own merits instead, the same
+# way extract-vmlinux validates its output rather than trusting exit codes.
+decompress_stream() {
+	case $1 in
+		gzip) gzip -dc 2>/dev/null ;;
+		lzma) xz -dc --format=lzma 2>/dev/null ;;
+		xz) xz -dc 2>/dev/null ;;
+		lz4) lz4 -dc 2>/dev/null ;;
+		lzo) lzop -dc 2>/dev/null ;;
+		zstd) zstd -dc 2>/dev/null ;;
+		*) return 1 ;;
+	esac
+}
+
+# EFI zboot: decompress the payload the header points at.
+unwrap_zboot() {
+	src=$1
+	dest=$2
+	payload_offset=$(u32_at "$src" 8)
+	compression=$(od -An -c -j 24 -N 8 "$src" | tr -d ' \n' | sed 's/\\0.*$//')
+	if [ -z "$payload_offset" ] || [ "$payload_offset" -le 0 ]; then
+		fail "EFI zboot header in ${source_image} declares no payload offset"
+	fi
+	case $compression in
+		gzip | lzma | xz | lz4 | lzo | zstd) ;;
+		*) fail "unsupported EFI zboot compression '${compression}' in ${source_image}" ;;
+	esac
+	echo "${me}: EFI zboot payload at offset ${payload_offset}, ${compression}-compressed" >&2
+	# Fed to the end of the file rather than the declared payload size: the
+	# decompressor stops at the end of its own stream, and the declared size
+	# is short by the trailer for some algorithms (see decompress_stream).
+	tail -c "+$(( payload_offset + 1 ))" "$src" | decompress_stream "$compression" >"$dest"
+}
+
+# UKI: lift out the ".linux" PE section holding the kernel.
+unwrap_uki() {
+	src=$1
+	dest=$2
+	pe_offset=$(u32_at "$src" 60) # 0x3c
+	if [ "$(hex_at "$src" "$pe_offset" 4)" != "$pe_magic" ]; then
+		fail "${source_image} is an MZ file with no PE header and no EFI zboot payload"
+	fi
+	section_count=$(u16_at "$src" $(( pe_offset + 6 )))
+	optional_header_size=$(u16_at "$src" $(( pe_offset + 20 )))
+	section_table=$(( pe_offset + 24 + optional_header_size ))
+	index=0
+	while [ "$index" -lt "$section_count" ]; do
+		entry=$(( section_table + index * 40 ))
+		index=$(( index + 1 ))
+		# ".linux", NUL-padded to the 8-byte PE section name field.
+		[ "$(hex_at "$src" "$entry" 8)" = 2e6c696e75780000 ] || continue
+		virtual_size=$(u32_at "$src" $(( entry + 8 )))
+		raw_size=$(u32_at "$src" $(( entry + 16 )))
+		raw_offset=$(u32_at "$src" $(( entry + 20 )))
+		# SizeOfRawData is padded up to the file alignment; VirtualSize is
+		# the payload's real length, but never trust it past the data that
+		# is actually in the file.
+		size=$raw_size
+		if [ "$virtual_size" -gt 0 ] && [ "$virtual_size" -lt "$raw_size" ]; then
+			size=$virtual_size
+		fi
+		if [ "$size" -le 0 ]; then
+			fail "${source_image} has an empty .linux section"
+		fi
+		echo "${me}: UKI .linux section at offset ${raw_offset}, ${size} bytes" >&2
+		slice "$src" "$raw_offset" "$size" >"$dest"
+		return 0
+	done
+	fail "${source_image} is a PE image with neither an EFI zboot payload nor a .linux section"
+}
+
+# A bare Image.gz and friends: no PE wrapper, just a compressed stream.
+unwrap_compressed_image() {
+	src=$1
+	dest=$2
+	for compression in gzip zstd xz lzma lz4 lzo; do
+		# A missing decompressor just yields no output, same as a stream that
+		# was not compressed that way — both mean "try the next one".
+		decompress_stream "$compression" <"$src" >"$dest"
+		if is_arm64_image "$dest"; then
+			echo "${me}: bare ${compression}-compressed Image" >&2
+			return 0
+		fi
+	done
+	fail "${source_image} is neither a raw ARM64 Image, an EFI zboot image, a UKI, nor a compressed Image"
+}
+
+if [ "$#" -ne 1 ] || [ ! -s "$1" ]; then
+	echo "Usage: ${me} <vmlinuz>" >&2
+	exit 2
+fi
+
+source_image=$1
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/extract-arm64-image-XXXXXX") || exit 1
+trap 'rm -rf "$work_dir"' 0 INT HUP TERM
+
+current=$source_image
+# Ubuntu needs two (UKI then zboot); the bound just stops a malformed image
+# from looping. No real kernel nests deeper than that.
+depth=0
+while [ "$depth" -lt 4 ]; do
+	# Every shape below carries a 64-byte header, so anything shorter cannot
+	# be a kernel in any of them — say so rather than reading past the end.
+	if [ "$(wc -c <"$current")" -lt 64 ]; then
+		fail "${source_image} is too small to hold an ARM64 kernel header"
+	fi
+	if is_arm64_image "$current"; then
+		cat "$current"
+		[ "$depth" -eq 0 ] && echo "${me}: already a raw ARM64 Image" >&2
+		exit 0
+	fi
+	next="${work_dir}/stage${depth}"
+	depth=$(( depth + 1 ))
+	if [ "$(hex_at "$current" 0 2)" = "$mz_magic" ]; then
+		if [ "$(hex_at "$current" 4 4)" = "$zboot_magic" ]; then
+			unwrap_zboot "$current" "$next"
+		else
+			unwrap_uki "$current" "$next"
+		fi
+	else
+		unwrap_compressed_image "$current" "$next"
+	fi
+	[ -s "$next" ] || fail "extracting the kernel from ${source_image} produced no data"
+	current=$next
+done
+
+fail "could not reach a raw ARM64 Image in ${source_image} after ${depth} unwrapping passes"

--- a/scripts/firecracker-menual/install-alpine-rootfs.sh
+++ b/scripts/firecracker-menual/install-alpine-rootfs.sh
@@ -14,6 +14,7 @@ kernel_artifact_dir="${repo_dir}/images/kernel"
 kernel_image_name=''
 initrd_image_name=''
 extract_vmlinux="${script_dir}/extract-vmlinux"
+extract_arm64_image="${script_dir}/extract-arm64-image"
 build_dir="${repo_dir}/build/alpine-rootfs"
 rootfs_size='512M'
 rootfs_hostname='firecrab'
@@ -307,7 +308,8 @@ test -L "${staging}/etc/runlevels/default/firecrab-network-ready" || { echo 'fir
 # linux-virt's boot files land under the staging root, not this container's
 # own /boot — pulled out to /kernel-out (mounted from the host) so the host
 # side can prepare the architecture-specific Firecracker kernel. x86_64
-# needs an uncompressed ELF vmlinux; ARM64 must retain the PE32+ Image.
+# needs an uncompressed ELF vmlinux; ARM64 needs the raw Image unwrapped out
+# of the EFI zboot wrapper Alpine ships.
 test -e "${staging}/boot/vmlinuz-virt" || { echo 'missing boot/vmlinuz-virt (linux-virt)' >&2; exit 1; }
 test -e "${staging}/boot/initramfs-virt" || { echo 'missing boot/initramfs-virt (linux-virt)' >&2; exit 1; }
 cp "${staging}/boot/vmlinuz-virt" "${kernel_out}/vmlinuz-virt-raw"
@@ -340,28 +342,19 @@ restore_output_ownership() {
   chown -h "${SUDO_UID}:${SUDO_GID}" "${artifact_dir}/alpine-rootfs.ext4" 2>/dev/null || true
 }
 
-# Alpine's linux-virt arm64 vmlinuz ships with the Linux/arm64 "Image" boot
-# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
-# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
-# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
-# linux-loader) validates that field independently of the PE header and
-# refuses to boot with "invalid Image magic number" if it's missing, so
-# restore it before packaging.
-restore_arm64_image_magic() {
-  image_path=$1
-  source_path=$2
-  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
-  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
-  if [ "$image_magic" != '41524d64' ]; then
-    rm -f "$image_path"
-    fail "failed to restore ARM64 Image magic number in ${source_path}"
-  fi
+# True when the file is a raw Linux/arm64 Image: ARM64_IMAGE_MAGIC ("ARMd")
+# at offset 0x38, the field Firecracker's loader checks before it jumps into
+# the image. Read, never written — a wrapped kernel (a UKI or an EFI zboot
+# image) with the magic stamped on top passes the loader and then dies
+# silently in the guest instead of failing here.
+is_arm64_image() {
+  [ -s "$1" ] && [ "$(od -An -tx1 -j56 -N4 "$1" | tr -d ' \n')" = '41524d64' ]
 }
 
 # Prepares the raw vmlinuz-virt copied out to /kernel-out. Firecracker expects
-# uncompressed ELF on x86_64, but the distro's PE32+ ARM64 Image must be kept
-# intact (aside from the magic-number repair above) rather than passed
-# through extract-vmlinux.
+# an uncompressed ELF vmlinux on x86_64 and a raw Linux/arm64 Image on ARM64.
+# Alpine's linux-virt arm64 vmlinuz is neither: it is an EFI zboot image, a PE
+# wrapper around a gzip-compressed Image, so it has to be unwrapped.
 extract_kernel() {
   raw_path="${kernel_artifact_dir}/vmlinuz-virt-raw"
   if [ ! -s "$raw_path" ]; then
@@ -371,13 +364,12 @@ extract_kernel() {
   kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
   kernel_image_tmp="${kernel_image_path}.tmp"
   if [ "$alpine_arch" = aarch64 ]; then
-    info "preserving ARM64 PE kernel Image from: ${raw_path}"
-    cp "$raw_path" "$kernel_image_tmp"
-    if ! file "$kernel_image_tmp" | grep -Eq 'PE32.*ARM64'; then
+    info "extracting raw ARM64 Image from: ${raw_path}"
+    if ! "$extract_arm64_image" "$raw_path" >"$kernel_image_tmp" \
+      || ! is_arm64_image "$kernel_image_tmp"; then
       rm -f "$kernel_image_tmp"
-      fail "ARM64 kernel is not a PE32+ Image: ${raw_path}"
+      fail "extract-arm64-image could not extract a raw ARM64 Image from ${raw_path}"
     fi
-    restore_arm64_image_magic "$kernel_image_tmp" "$raw_path"
   else
     info "extracting ELF vmlinux from: ${raw_path}"
     if ! "$extract_vmlinux" "$raw_path" >"$kernel_image_tmp"; then
@@ -420,6 +412,7 @@ main() {
   require_command mkfs.ext4
   require_command mount
   require_command mv
+  require_command od
   require_command rm
   require_command sha256sum
   require_command tar
@@ -428,6 +421,9 @@ main() {
   require_command uname
   if [ ! -x "$extract_vmlinux" ]; then
     fail "extract-vmlinux helper not found or not executable: ${extract_vmlinux}"
+  fi
+  if [ ! -x "$extract_arm64_image" ]; then
+    fail "extract-arm64-image helper not found or not executable: ${extract_arm64_image}"
   fi
 
   if [ "$(id -u)" -ne 0 ]; then

--- a/scripts/firecracker-menual/install-alpine-rootfs.sh
+++ b/scripts/firecracker-menual/install-alpine-rootfs.sh
@@ -340,9 +340,28 @@ restore_output_ownership() {
   chown -h "${SUDO_UID}:${SUDO_GID}" "${artifact_dir}/alpine-rootfs.ext4" 2>/dev/null || true
 }
 
+# Alpine's linux-virt arm64 vmlinuz ships with the Linux/arm64 "Image" boot
+# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
+# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
+# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
+# linux-loader) validates that field independently of the PE header and
+# refuses to boot with "invalid Image magic number" if it's missing, so
+# restore it before packaging.
+restore_arm64_image_magic() {
+  image_path=$1
+  source_path=$2
+  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
+  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
+  if [ "$image_magic" != '41524d64' ]; then
+    rm -f "$image_path"
+    fail "failed to restore ARM64 Image magic number in ${source_path}"
+  fi
+}
+
 # Prepares the raw vmlinuz-virt copied out to /kernel-out. Firecracker expects
 # uncompressed ELF on x86_64, but the distro's PE32+ ARM64 Image must be kept
-# intact rather than passed through extract-vmlinux.
+# intact (aside from the magic-number repair above) rather than passed
+# through extract-vmlinux.
 extract_kernel() {
   raw_path="${kernel_artifact_dir}/vmlinuz-virt-raw"
   if [ ! -s "$raw_path" ]; then
@@ -358,6 +377,7 @@ extract_kernel() {
       rm -f "$kernel_image_tmp"
       fail "ARM64 kernel is not a PE32+ Image: ${raw_path}"
     fi
+    restore_arm64_image_magic "$kernel_image_tmp" "$raw_path"
   else
     info "extracting ELF vmlinux from: ${raw_path}"
     if ! "$extract_vmlinux" "$raw_path" >"$kernel_image_tmp"; then

--- a/scripts/firecracker-menual/install-alpine-rootfs.sh
+++ b/scripts/firecracker-menual/install-alpine-rootfs.sh
@@ -123,7 +123,7 @@ resolve_ssh_public_key() {
 
 # Resolve the exact manifest-pinned minirootfs. A branch's
 # latest-releases.yaml changes whenever Alpine publishes a patch release, so
-# using it would make an alias such as alpine-3.24 silently change contents
+# using it would make an alias such as alpine-3.24.1 silently change contents
 # while package paths and runtime specs still expect 3.24.1.
 resolve_alpine_minirootfs() {
   local branch="v${alpine_series}"

--- a/scripts/firecracker-menual/install-rocky-rootfs.sh
+++ b/scripts/firecracker-menual/install-rocky-rootfs.sh
@@ -26,6 +26,7 @@ rocky_container_build=${ROCKY_CONTAINER_BUILD:-20260525.0}
 rootfs_size='2G'
 rootfs_hostname='firecrab'
 extract_vmlinux="${script_dir}/extract-vmlinux"
+extract_arm64_image="${script_dir}/extract-arm64-image"
 container_mounts=()
 
 case "${M2IMAGE_ARCH:-$(uname -m 2>/dev/null || printf unknown)}" in
@@ -429,23 +430,13 @@ echo "ROOTFS_IMAGE=${rootfs_image}"
 EOF
 }
 
-# Rocky's official arm64 vmlinuz ships with the Linux/arm64 "Image" boot
-# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
-# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
-# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
-# linux-loader) validates that field independently of the PE header and
-# refuses to boot with "invalid Image magic number" if it's missing, so
-# restore it before packaging.
-restore_arm64_image_magic() {
-  local image_path=$1
-  local source_path=$2
-  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
-  local image_magic
-  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
-  if [ "$image_magic" != '41524d64' ]; then
-    rm -f "$image_path"
-    fail "failed to restore ARM64 Image magic number in ${source_path}"
-  fi
+# True when the file is a raw Linux/arm64 Image: ARM64_IMAGE_MAGIC ("ARMd")
+# at offset 0x38, the field Firecracker's loader checks before it jumps into
+# the image. Read, never written — a wrapped kernel (a UKI or an EFI zboot
+# image) with the magic stamped on top passes the loader and then dies
+# silently in the guest instead of failing here.
+is_arm64_image() {
+  [ -s "$1" ] && [ "$(od -An -tx1 -j56 -N4 "$1" | tr -d ' \n')" = '41524d64' ]
 }
 
 prepare_kernel() {
@@ -455,13 +446,14 @@ prepare_kernel() {
 
   [ -s "$raw_path" ] || fail "Rocky kernel was not copied out to ${raw_path}"
   if [ "$rocky_arch" = aarch64 ]; then
-    info "preserving ARM64 PE kernel Image from: ${raw_path}"
-    cp "$raw_path" "$kernel_image_tmp"
-    if ! file "$kernel_image_tmp" | grep -Eq 'PE32\+.*(ARM64|Aarch64)'; then
+    # Rocky's arm64 vmlinuz is an EFI zboot image (a PE wrapper around a
+    # gzip-compressed Image), which Firecracker cannot boot — unwrap it.
+    info "extracting raw ARM64 Image from: ${raw_path}"
+    if ! "$extract_arm64_image" "$raw_path" >"$kernel_image_tmp" \
+      || ! is_arm64_image "$kernel_image_tmp"; then
       rm -f "$kernel_image_tmp"
-      fail "Rocky aarch64 kernel is not a PE32+ ARM64 Image: ${raw_path}"
+      fail "extract-arm64-image could not extract a raw ARM64 Image from ${raw_path}"
     fi
-    restore_arm64_image_magic "$kernel_image_tmp" "$raw_path"
   else
     info "extracting x86_64 ELF vmlinux from: ${raw_path}"
     if ! "$extract_vmlinux" "$raw_path" >"$kernel_image_tmp"; then
@@ -595,11 +587,13 @@ main() {
   [ "$#" -eq 0 ] || fail 'install-rocky-rootfs.sh does not accept arguments.'
 
   for command in awk chmod chown chroot cp curl file find grep head id install jq \
-    mkdir mount mv rm sed sha256sum sort tail tar truncate umount uname xz; do
+    mkdir mount mv od rm sed sha256sum sort tail tar truncate umount uname xz; do
     require_command "$command"
   done
   if [ "$rocky_arch" = x86_64 ]; then
     [ -x "$extract_vmlinux" ] || fail "extract-vmlinux helper not found or not executable: ${extract_vmlinux}"
+  else
+    [ -x "$extract_arm64_image" ] || fail "extract-arm64-image helper not found or not executable: ${extract_arm64_image}"
   fi
 
   if [ "$(id -u)" -ne 0 ]; then

--- a/scripts/firecracker-menual/install-rocky-rootfs.sh
+++ b/scripts/firecracker-menual/install-rocky-rootfs.sh
@@ -429,6 +429,25 @@ echo "ROOTFS_IMAGE=${rootfs_image}"
 EOF
 }
 
+# Rocky's official arm64 vmlinuz ships with the Linux/arm64 "Image" boot
+# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
+# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
+# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
+# linux-loader) validates that field independently of the PE header and
+# refuses to boot with "invalid Image magic number" if it's missing, so
+# restore it before packaging.
+restore_arm64_image_magic() {
+  local image_path=$1
+  local source_path=$2
+  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
+  local image_magic
+  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
+  if [ "$image_magic" != '41524d64' ]; then
+    rm -f "$image_path"
+    fail "failed to restore ARM64 Image magic number in ${source_path}"
+  fi
+}
+
 prepare_kernel() {
   local raw_path="${kernel_artifact_dir}/vmlinuz-rocky-raw"
   local kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
@@ -442,6 +461,7 @@ prepare_kernel() {
       rm -f "$kernel_image_tmp"
       fail "Rocky aarch64 kernel is not a PE32+ ARM64 Image: ${raw_path}"
     fi
+    restore_arm64_image_magic "$kernel_image_tmp" "$raw_path"
   else
     info "extracting x86_64 ELF vmlinux from: ${raw_path}"
     if ! "$extract_vmlinux" "$raw_path" >"$kernel_image_tmp"; then

--- a/scripts/firecracker-menual/install-rocky-rootfs.sh
+++ b/scripts/firecracker-menual/install-rocky-rootfs.sh
@@ -418,6 +418,13 @@ cp "$vmlinuz_path" /kernel-out/vmlinuz-rocky-raw
 cp "$initrd_path" "/kernel-out/${initrd_image_name}"
 chmod 0644 /kernel-out/vmlinuz-rocky-raw "/kernel-out/${initrd_image_name}"
 
+# Dropped from the rootfs now that it is in /kernel-out: the runtime boots
+# the initrd artifact this just produced, never one from inside the guest
+# filesystem, so keeping the 27.9 MB duplicate only inflates every package.
+# Same reasoning (and the same %ghost ownership) as
+# bootstrap-rocky-in-guest.sh's copy of this step.
+rm -f "$initrd_path"
+
 rootfs_image="/out/${rootfs_image_name}"
 rootfs_tmp="${rootfs_image}.tmp"
 rm -f "$rootfs_tmp"

--- a/scripts/firecracker-menual/install-rocky-rootfs.sh
+++ b/scripts/firecracker-menual/install-rocky-rootfs.sh
@@ -550,8 +550,12 @@ extract_container_base() {
   if [ -f "$archive_tree/index.json" ]; then
     manifest_digest=$(jq -r '.manifests[0].digest | sub("^sha256:"; "")' \
       "$archive_tree/index.json")
-    [ -n "$manifest_digest" ] && [ "$manifest_digest" != null ] \
-      || fail 'Could not read Container-Base manifest digest from index.json'
+    # Negative form for the same reason as publish-m2images-r2.sh's version
+    # check: `A && B || fail` reads as if-then-else without being one
+    # (SC2015), which older shellcheck releases reject outright.
+    if [ -z "$manifest_digest" ] || [ "$manifest_digest" = null ]; then
+      fail 'Could not read Container-Base manifest digest from index.json'
+    fi
     mapfile -t layers < <(
       jq -r '.layers[].digest | sub("^sha256:"; "")' \
         "$archive_tree/blobs/sha256/${manifest_digest}"

--- a/scripts/firecracker-menual/install-ubuntu-roofs.sh
+++ b/scripts/firecracker-menual/install-ubuntu-roofs.sh
@@ -12,6 +12,7 @@ artifact_dir="${repo_dir}/images/rootfs"
 kernel_artifact_dir="${repo_dir}/images/kernel"
 kernel_image_name=''
 extract_vmlinux="${script_dir}/extract-vmlinux"
+extract_arm64_image="${script_dir}/extract-arm64-image"
 build_dir="${repo_dir}/build/ubuntu-rootfs"
 rootfs_image=''
 rootfs_link=''
@@ -519,28 +520,20 @@ install_rootfs_packages() {
   cleanup_chroot_mounts
 }
 
-# Ubuntu's official arm64 vmlinuz ships with the Linux/arm64 "Image" boot
-# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
-# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
-# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
-# linux-loader) validates that field independently of the PE header and
-# refuses to boot with "invalid Image magic number" if it's missing, so
-# restore it before packaging.
-restore_arm64_image_magic() {
-  image_path=$1
-  source_path=$2
-  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
-  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
-  if [ "$image_magic" != '41524d64' ]; then
-    rm -f "$image_path"
-    fail "failed to restore ARM64 Image magic number in ${source_path}"
-  fi
+# True when the file is a raw Linux/arm64 Image: ARM64_IMAGE_MAGIC ("ARMd")
+# at offset 0x38, the field Firecracker's loader checks before it jumps into
+# the image. Read, never written — a wrapped kernel (a UKI or an EFI zboot
+# image) with the magic stamped on top passes the loader and then dies
+# silently in the guest instead of failing here.
+is_arm64_image() {
+  [ -s "$1" ] && [ "$(od -An -tx1 -j56 -N4 "$1" | tr -d ' \n')" = '41524d64' ]
 }
 
 # Pulls the distro kernel out of the rootfs. x86_64 is converted to the
-# uncompressed ELF vmlinux Firecracker expects. ARM64 keeps the packaged
-# PE32+ Image unchanged (aside from the magic-number repair above), which is
-# the only kernel format Firecracker accepts on that architecture.
+# uncompressed ELF vmlinux Firecracker expects. ARM64 is unwrapped to the raw
+# Linux/arm64 Image, the only format Firecracker boots on that architecture:
+# Ubuntu's arm64 vmlinuz is a UKI whose .linux section holds an EFI zboot
+# image, so neither the file itself nor its first payload is bootable.
 extract_kernel() {
   vmlinuz_path=$(find "${mount_dir}/boot" -maxdepth 1 -name 'vmlinuz-*' | sort -V | tail -n 1)
   if [ -z "$vmlinuz_path" ]; then
@@ -550,13 +543,12 @@ extract_kernel() {
   kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"
   kernel_image_tmp="${kernel_image_path}.tmp"
   if [ "$ubuntu_arch" = arm64 ]; then
-    info "preserving ARM64 PE kernel Image from: ${vmlinuz_path}"
-    cp "$vmlinuz_path" "$kernel_image_tmp"
-    if ! file "$kernel_image_tmp" | grep -Eq 'PE32.*ARM64'; then
+    info "extracting raw ARM64 Image from: ${vmlinuz_path}"
+    if ! "$extract_arm64_image" "$vmlinuz_path" >"$kernel_image_tmp" \
+      || ! is_arm64_image "$kernel_image_tmp"; then
       rm -f "$kernel_image_tmp"
-      fail "ARM64 kernel is not a PE32+ Image: ${vmlinuz_path}"
+      fail "extract-arm64-image could not extract a raw ARM64 Image from ${vmlinuz_path}"
     fi
-    restore_arm64_image_magic "$kernel_image_tmp" "$vmlinuz_path"
   else
     info "extracting ELF vmlinux from: ${vmlinuz_path}"
     if ! "$extract_vmlinux" "$vmlinuz_path" >"$kernel_image_tmp"; then
@@ -654,8 +646,8 @@ verify_rootfs_content() {
         || fail "Extracted kernel image is not ELF: ${kernel_image_path}"
       ;;
     arm64)
-      file "$kernel_image_path" | grep -Eq 'PE32.*ARM64' \
-        || fail "ARM64 kernel is not a PE32+ Image: ${kernel_image_path}"
+      is_arm64_image "$kernel_image_path" \
+        || fail "ARM64 kernel is not a raw Image: ${kernel_image_path}"
       ;;
   esac
 }
@@ -689,8 +681,12 @@ main() {
   require_command truncate
   require_command uname
   require_command umount
+  require_command od
   if [ ! -x "$extract_vmlinux" ]; then
     fail "extract-vmlinux helper not found or not executable: ${extract_vmlinux}"
+  fi
+  if [ ! -x "$extract_arm64_image" ]; then
+    fail "extract-arm64-image helper not found or not executable: ${extract_arm64_image}"
   fi
 
   if [ "$(id -u)" -ne 0 ]; then

--- a/scripts/firecracker-menual/install-ubuntu-roofs.sh
+++ b/scripts/firecracker-menual/install-ubuntu-roofs.sh
@@ -19,12 +19,29 @@ rootfs_link=''
 rootfs_size='2G'
 rootfs_hostname='firecrab'
 
-# linux-image-generic: Ubuntu's own officially-maintained cloud/generic
-# kernel package (public-docs/images.md) — replaces the
-# self-built vanilla kernel every template used to share, so security
-# patches and driver support follow Ubuntu's own release cadence instead
-# of this project having to track kernel.org itself.
-rootfs_boot_packages='systemd systemd-sysv systemd-resolved udev kmod util-linux linux-image-generic'
+# linux-image-virtual: Ubuntu's own officially-maintained kernel package
+# (public-docs/images.md) — replaces the self-built vanilla kernel every
+# template used to share, so security patches and driver support follow
+# Ubuntu's own release cadence instead of this project having to track
+# kernel.org itself.
+#
+# The *virtual* meta-package, not *generic*, though both resolve to the
+# identical binary (both Depend on linux-image-<abi>-generic, so the kernel,
+# its cadence and its module set are unchanged). The difference is one line
+# of packaging: linux-image-generic additionally carries
+# "Depends: linux-firmware | linux-firmware-minimal", and apt always takes
+# the first alternative — which is a hard dependency, so
+# --no-install-recommends cannot decline it. That dragged in every
+# linux-firmware-* subpackage: Qualcomm/Intel/Broadcom/Marvell/Realtek
+# wireless, NVIDIA/AMD/Intel graphics, Mellanox/Netronome/QLogic NICs.
+# Measured inside the built image with debugfs, that was 656 MB across 5233
+# files — 53% of the rootfs's 1.24 GiB of content — for hardware a
+# Firecracker microVM cannot have. None of it is reachable at boot either:
+# this template ships no initrd (`"initrd": null` in packaging/m2images.json)
+# and mounts root=/dev/vda straight from the kernel's built-in
+# CONFIG_VIRTIO_BLK/VIRTIO_MMIO/EXT4_FS, so firmware and modules play no part
+# in bringing the guest up.
+rootfs_boot_packages='systemd systemd-sysv systemd-resolved udev kmod util-linux linux-image-virtual'
 rootfs_packages="${rootfs_boot_packages} iproute2 iputils-ping net-tools dnsutils curl ca-certificates procps openssh-server"
 
 mount_dir=''
@@ -537,7 +554,7 @@ is_arm64_image() {
 extract_kernel() {
   vmlinuz_path=$(find "${mount_dir}/boot" -maxdepth 1 -name 'vmlinuz-*' | sort -V | tail -n 1)
   if [ -z "$vmlinuz_path" ]; then
-    fail "linux-image-generic did not install a vmlinuz under ${mount_dir}/boot"
+    fail "linux-image-virtual did not install a vmlinuz under ${mount_dir}/boot"
   fi
   mkdir -p "$kernel_artifact_dir"
   kernel_image_path="${kernel_artifact_dir}/${kernel_image_name}"

--- a/scripts/firecracker-menual/install-ubuntu-roofs.sh
+++ b/scripts/firecracker-menual/install-ubuntu-roofs.sh
@@ -519,10 +519,28 @@ install_rootfs_packages() {
   cleanup_chroot_mounts
 }
 
+# Ubuntu's official arm64 vmlinuz ships with the Linux/arm64 "Image" boot
+# header magic (ARM64_IMAGE_MAGIC, 4 bytes at offset 0x38) zeroed out, even
+# though its PE/EFI wrapper is otherwise intact and passes `file`'s PE32+
+# ARM64 detection. Firecracker's aarch64 kernel loader (rust-vmm
+# linux-loader) validates that field independently of the PE header and
+# refuses to boot with "invalid Image magic number" if it's missing, so
+# restore it before packaging.
+restore_arm64_image_magic() {
+  image_path=$1
+  source_path=$2
+  printf '\x41\x52\x4d\x64' | dd of="$image_path" bs=1 seek=56 count=4 conv=notrunc status=none 2>/dev/null
+  image_magic=$(od -An -tx1 -j56 -N4 "$image_path" | tr -d ' \n')
+  if [ "$image_magic" != '41524d64' ]; then
+    rm -f "$image_path"
+    fail "failed to restore ARM64 Image magic number in ${source_path}"
+  fi
+}
+
 # Pulls the distro kernel out of the rootfs. x86_64 is converted to the
 # uncompressed ELF vmlinux Firecracker expects. ARM64 keeps the packaged
-# PE32+ Image unchanged, which is the only kernel format Firecracker accepts
-# on that architecture.
+# PE32+ Image unchanged (aside from the magic-number repair above), which is
+# the only kernel format Firecracker accepts on that architecture.
 extract_kernel() {
   vmlinuz_path=$(find "${mount_dir}/boot" -maxdepth 1 -name 'vmlinuz-*' | sort -V | tail -n 1)
   if [ -z "$vmlinuz_path" ]; then
@@ -538,6 +556,7 @@ extract_kernel() {
       rm -f "$kernel_image_tmp"
       fail "ARM64 kernel is not a PE32+ Image: ${vmlinuz_path}"
     fi
+    restore_arm64_image_magic "$kernel_image_tmp" "$vmlinuz_path"
   else
     info "extracting ELF vmlinux from: ${vmlinuz_path}"
     if ! "$extract_vmlinux" "$vmlinuz_path" >"$kernel_image_tmp"; then

--- a/scripts/publish-m2images-r2.sh
+++ b/scripts/publish-m2images-r2.sh
@@ -73,8 +73,12 @@ fi
 if [ "$dry_run" -eq 0 ]; then require_command "$backend"; fi
 if [ "$backend" = wrangler ] && [ "$dry_run" -eq 0 ]; then
   wrangler_version=$(wrangler --version 2>/dev/null | sed -nE 's/.* ([0-9]+)\..*/\1/p' | head -n1)
-  [ -n "$wrangler_version" ] && [ "$wrangler_version" -ge 4 ] \
-    || fail 'Wrangler v4 or newer is required'
+  # Spelled as the negative rather than `A && B || fail`: that reads as
+  # if-then-else but is not one (SC2015), and older shellcheck releases fail
+  # the build over it.
+  if [ -z "$wrangler_version" ] || [ "$wrangler_version" -lt 4 ]; then
+    fail 'Wrangler v4 or newer is required'
+  fi
 fi
 
 mapfile -t aliases < <(python3 "${script_dir}/m2image-manifest.py" --manifest "$manifest" aliases)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added versioned Alpine 3.24.1, Ubuntu 26.04, and Rocky Linux 9.8 images.
  - Added x86_64 and aarch64 image support with architecture-specific artifacts.
  - Added active-bootstrap detection and automatic resume in the Images panel.
  - Added manifest-driven image building, packaging, catalogs, and Cloudflare R2 publishing.
  - Added native host image creation without Docker.

- **Bug Fixes**
  - Improved ARM64 kernel extraction and validation.
  - Increased network readiness and image build timeouts for slower environments.

- **Documentation**
  - Updated installation, API, operations, troubleshooting, and multilingual README guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->