### PR TITLE
feat(rootfs): create VM disks with FICLONE reflink when supported

### DIFF
--- a/firecrab-api/src/rootfs.rs
+++ b/firecrab-api/src/rootfs.rs
@@ -5,6 +5,7 @@
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Seek, SeekFrom};
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -561,6 +562,61 @@ pub(crate) fn run_debugfs(
         })
 }
 
+/// Which mechanism produced a VM disk from its template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CopyMode {
+    /// The host filesystem shared the template's blocks copy-on-write.
+    Cloned,
+    /// The template's bytes were copied one by one.
+    Copied,
+}
+
+/// Asks the host filesystem to share `source`'s blocks with `destination`
+/// copy-on-write, replacing whatever `destination` held.
+///
+/// Only reflink-capable host filesystems (XFS, Btrfs, bcachefs) implement
+/// this, and both files must live on the *same* one — the filesystem the
+/// `.ext4` files sit on, which has nothing to do with the ext4 filesystem
+/// inside them. A template under `FIRECRAB_IMAGE_ROOT` and a disk under
+/// `data/vms` on separate mounts fail here with `EXDEV`.
+fn ficlone(source: &File, destination: &File) -> io::Result<()> {
+    // SAFETY: both descriptors stay open across the call, and FICLONE takes
+    // the source descriptor by value rather than writing through a pointer.
+    let result = unsafe { libc::ioctl(destination.as_raw_fd(), libc::FICLONE, source.as_raw_fd()) };
+    if result == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Fills `destination` with `source`'s contents, sharing blocks copy-on-write
+/// when the host filesystem supports it and copying the bytes when it does not.
+pub(crate) fn clone_or_copy(source: &mut File, destination: &mut File) -> io::Result<CopyMode> {
+    clone_or_copy_with(source, destination, ficlone)
+}
+
+/// The testable half of [`clone_or_copy`], with the clone attempt injected so
+/// the fallback can be exercised on a filesystem that does support reflinks.
+fn clone_or_copy_with<F>(
+    source: &mut File,
+    destination: &mut File,
+    clone: F,
+) -> io::Result<CopyMode>
+where
+    F: FnOnce(&File, &File) -> io::Result<()>,
+{
+    if clone(source, destination).is_ok() {
+        return Ok(CopyMode::Cloned);
+    }
+    // A refused FICLONE leaves the destination untouched, so every reason it
+    // can fail — an unsupported filesystem, a cross-device pair, a kernel
+    // without the ioctl — is answered the same way, with a plain byte copy.
+    // Probing the filesystem type up front would only duplicate this answer.
+    source.seek(SeekFrom::Start(0))?;
+    io::copy(source, destination)?;
+    Ok(CopyMode::Copied)
+}
+
 /// Copies `template` into `tmp` and atomically renames it to `rootfs`.
 fn publish(template: &mut File, tmp: &Path, rootfs: &Path) -> Result<(), RootfsError> {
     let copy_error = |source| RootfsError::Copy {
@@ -568,11 +624,10 @@ fn publish(template: &mut File, tmp: &Path, rootfs: &Path) -> Result<(), RootfsE
         source,
     };
 
-    // The registry's hash verification shares the descriptor offset, so the
-    // template handle arrives at EOF.
-    template.seek(SeekFrom::Start(0)).map_err(copy_error)?;
     let mut out = File::create(tmp).map_err(copy_error)?;
-    io::copy(template, &mut out).map_err(copy_error)?;
+    // The registry's hash verification shares the descriptor offset, so the
+    // template handle arrives at EOF; the byte-copy path rewinds it itself.
+    clone_or_copy(template, &mut out).map_err(copy_error)?;
     out.sync_all().map_err(copy_error)?;
 
     fs::rename(tmp, rootfs).map_err(|source| RootfsError::Publish {
@@ -689,6 +744,51 @@ mod tests {
         assert!(matches!(error, RootfsError::Copy { .. }));
         assert!(!paths.rootfs_tmp(generation).exists());
         assert!(!paths.rootfs(generation).exists());
+    }
+
+    #[test]
+    fn falls_back_to_a_byte_copy_when_the_filesystem_cannot_clone() {
+        let directory = tempdir().unwrap();
+        let mut source = template_file(directory.path(), b"template-bytes");
+        let destination_path = directory.path().join("destination.ext4");
+        let mut destination = File::create(&destination_path).unwrap();
+
+        let mode = clone_or_copy_with(&mut source, &mut destination, |_, _| {
+            Err(io::Error::from_raw_os_error(libc::EOPNOTSUPP))
+        })
+        .unwrap();
+
+        assert_eq!(mode, CopyMode::Copied);
+        assert_eq!(fs::read(&destination_path).unwrap(), b"template-bytes");
+    }
+
+    #[test]
+    fn skips_the_byte_copy_when_the_clone_succeeds() {
+        let directory = tempdir().unwrap();
+        let mut source = template_file(directory.path(), b"template-bytes");
+        let destination_path = directory.path().join("destination.ext4");
+        let mut destination = File::create(&destination_path).unwrap();
+
+        let mode = clone_or_copy_with(&mut source, &mut destination, |_, _| Ok(())).unwrap();
+
+        // A real FICLONE populates the destination itself. This stub does not,
+        // so an empty destination is what proves the byte copy was skipped.
+        assert_eq!(mode, CopyMode::Cloned);
+        assert_eq!(fs::read(&destination_path).unwrap(), b"");
+    }
+
+    #[test]
+    fn clone_or_copy_reproduces_the_source_on_the_hosts_own_filesystem() {
+        let directory = tempdir().unwrap();
+        let mut source = template_file(directory.path(), b"template-bytes");
+        let destination_path = directory.path().join("destination.ext4");
+        let mut destination = File::create(&destination_path).unwrap();
+
+        // Exercises the real ioctl: clones on XFS/Btrfs, falls back elsewhere.
+        // Either outcome must leave the same bytes behind.
+        clone_or_copy(&mut source, &mut destination).unwrap();
+
+        assert_eq!(fs::read(&destination_path).unwrap(), b"template-bytes");
     }
 
     #[test]

--- a/public-docs/storage.md
+++ b/public-docs/storage.md
@@ -79,6 +79,22 @@ firecrab does not copy an existing disk between pools.
 The disk generation survives stop and start.
 Each start gets a new runtime directory.
 
+## Disk creation
+
+A VM disk begins as a copy-on-write clone of its template.
+firecrab asks the host filesystem for a reflink so both share the same blocks.
+
+Reflinks need a reflink-capable host filesystem such as XFS or Btrfs.
+This is the filesystem holding the `.ext4` files, not the ext4 filesystem inside them.
+
+A reflink cannot cross filesystems.
+Keep the image root and the storage root on one filesystem.
+
+firecrab falls back to a full byte copy whenever the host refuses.
+The disk is identical either way; only creation speed and disk usage differ.
+
+Run `firecrab-doctor` to check for a split layout.
+
 ## Delete
 
 A pool cannot be deleted while a VM uses it.

--- a/scripts/firecrab-doctor.sh
+++ b/scripts/firecrab-doctor.sh
@@ -769,6 +769,53 @@ check_image_install_tools() {
     pass
 }
 
+resolve_vms_root() {
+    local candidate
+    for candidate in "$DATADIR/vms" "$PWD/data/vms" "$DATADIR" "$PWD/data"; do
+        [ -d "$candidate" ] || continue
+        (cd -- "$candidate" && pwd)
+        return
+    done
+}
+
+# Reports only the one thing an operator can act on: a template and the VM
+# disks cloned from it sitting on two different filesystems.
+#
+# firecrab creates each VM disk with a FICLONE reflink and falls back to a full
+# byte copy when the host refuses (firecrab-api/src/rootfs.rs). A reflink cannot
+# cross filesystems, so a split layout silently costs a full template copy per
+# VM — the symptom is slow VM creation on a host chosen for Btrfs/XFS precisely
+# to avoid it. Whether a single filesystem supports reflinks at all is a host
+# choice rather than a misconfiguration, so that case stays quiet.
+#
+# Both probes are read-only; doctor must not write to the host, so support is
+# never confirmed by attempting a real clone.
+check_reflink() {
+    local roots image_root vms_root image_device vms_device image_type vms_type
+    mapfile -t roots < <(resolve_image_roots)
+    vms_root=$(resolve_vms_root)
+
+    if [ "${#roots[@]}" -eq 0 ] || [ -z "$vms_root" ] || ! have stat; then
+        pass
+        return
+    fi
+    image_root=${roots[0]}
+
+    image_device=$(stat -c %d -- "$image_root" 2>/dev/null || true)
+    vms_device=$(stat -c %d -- "$vms_root" 2>/dev/null || true)
+    if [ -z "$image_device" ] || [ -z "$vms_device" ] || [ "$image_device" = "$vms_device" ]; then
+        pass
+        return
+    fi
+
+    image_type=$(stat -f -c %T -- "$image_root" 2>/dev/null || printf unknown)
+    vms_type=$(stat -f -c %T -- "$vms_root" 2>/dev/null || printf unknown)
+    skip "reflink: templates and VM disks are on different filesystems" \
+        "$(printf 'templates: %s (%s)\nVM disks:  %s (%s)' \
+            "$image_root" "$image_type" "$vms_root" "$vms_type")" \
+        "put both on one XFS/Btrfs filesystem, or accept a full template copy per VM"
+}
+
 # --- run ---------------------------------------------------------------------
 
 check_kvm
@@ -781,6 +828,7 @@ check_ufw
 check_data_root
 check_images
 check_image_install_tools
+check_reflink
 
 if [ "$FAIL" -eq 0 ] && [ "$SKIP" -eq 0 ]; then
     printf 'doctor: all checks passed (%s ok)\n' "$OK"


### PR DESCRIPTION
Refs #87

Implements the reflink follow-up from the MicroImage structure decisions.

## Disk

- Share template blocks copy-on-write via `FICLONE` in `publish()`
- Fall back to the byte copy on any ioctl failure, leaving the result identical

`FICLONE` is attempted rather than probed: a refused clone leaves the
destination untouched, so every reason it can fail — unsupported filesystem,
cross-device pair, kernel without the ioctl — is answered the same way. That
removes any filesystem allowlist to maintain.

## Doctor

- Add `check_reflink`, comparing the image root and VM disk devices
- Stay silent when both share one filesystem

Only the fixable case is reported. Whether a single filesystem supports
reflinks is a host choice, not a misconfiguration, so ext4 hosts are not
nagged on every run. Both probes are read-only, since `--doctor` must not
mutate host state.

## Docs

- Describe reflink disk creation and its same-filesystem requirement

## Verification

| Check | Result |
| --- | --- |
| `cargo test --workspace` | 352 passed, 1 pre-existing environment failure |
| `cargo clippy --all-targets --all-features` | no new findings |
| `shellcheck` / `bash -n` | clean |
| `./install.sh --doctor` before/after | no host mutation, exit 1 |
| `cargo llvm-cov` | `rootfs.rs` 88.54% line |

The failing test needs 8 GiB free on the temp filesystem; `/tmp` is a 7.93 GiB
tmpfs on this machine. Reproduced on `main` without these changes.

`ficlone`'s success return is the one uncovered line — this host is ext4 and
tmpfs, so the ioctl always fails. The clone-success path is covered through an
injected stub instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM disks can be created using fast copy-on-write cloning when supported by the host filesystem.
  * Disk creation automatically falls back to a standard copy when cloning is unavailable.
  * Added `firecrab-doctor` checks to identify storage layouts that prevent efficient cloning.
* **Documentation**
  * Added guidance on filesystem requirements for VM disk creation and troubleshooting split storage layouts.
* **Bug Fixes**
  * Preserved reliable disk publishing with atomic replacement and improved fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
