### PR TITLE
feat(images): verify kernel architecture at registration

### DIFF
--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -14,7 +14,7 @@ use firecrab_api_types::{MicroRegistryImageResponse, MicroRegistryResponse};
 use serde::Deserialize;
 
 use crate::error::AppError;
-use crate::image_install;
+use crate::image_install::{self, Architecture};
 use crate::server::RequestId;
 use crate::state::AppState;
 use crate::templates::TemplateRegistry;
@@ -30,34 +30,13 @@ struct Catalog {
 #[serde(rename_all = "camelCase")]
 struct CatalogImage {
     alias: String,
-    architecture: CatalogArchitecture,
+    architecture: Architecture,
     #[serde(deserialize_with = "catalog_version")]
     version: String,
     package: String,
     sha256: String,
     min_disk_gb: u16,
     published_at: String,
-}
-
-#[derive(Debug, Deserialize, PartialEq, Eq)]
-enum CatalogArchitecture {
-    #[serde(rename = "x86_64")]
-    X86_64,
-    #[serde(rename = "aarch64")]
-    Aarch64,
-}
-
-impl CatalogArchitecture {
-    fn is_host(&self) -> bool {
-        #[cfg(target_arch = "aarch64")]
-        {
-            *self == Self::Aarch64
-        }
-        #[cfg(target_arch = "x86_64")]
-        {
-            *self == Self::X86_64
-        }
-    }
 }
 
 /// Accept both the first publisher's numeric version and the current string
@@ -138,7 +117,7 @@ pub async fn list_microregistry(
     let mut images = catalog
         .images
         .into_iter()
-        .filter(|image| image.architecture.is_host())
+        .filter(|image| image.architecture == Architecture::HOST)
         .map(|image| {
             let package_origin = image_install::staged_package_origin(&image_root, &image.alias);
             MicroRegistryImageResponse {
@@ -171,11 +150,6 @@ mod tests {
     use tempfile::tempdir;
     use tokio::net::TcpListener;
 
-    #[cfg(target_arch = "aarch64")]
-    const OTHER_ARCHITECTURE: &str = "x86_64";
-    #[cfg(target_arch = "x86_64")]
-    const OTHER_ARCHITECTURE: &str = "aarch64";
-
     async fn empty_state(root: &std::path::Path) -> AppState {
         let templates = TemplateRegistry::from_specs(root, std::iter::empty()).unwrap();
         AppState::with_db_file(templates, root.join("state.db"))
@@ -207,7 +181,7 @@ mod tests {
                         "publishedAt": "2026-08-09T10:00:00Z"
                     }, {
                         "alias": "wrong-architecture",
-                        "architecture": OTHER_ARCHITECTURE,
+                        "architecture": Architecture::HOST.other().as_str(),
                         "version": "1",
                         "package": "wrong/package.tar.zst",
                         "sha256": "eeff",
@@ -255,5 +229,31 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("architecture"));
+    }
+
+    /// `arm64` and `amd64` are the vocabulary of rootfs *filenames*, not of
+    /// catalog entries. Accepting them here would let a package be published
+    /// under a label nothing else in firecrab resolves.
+    #[test]
+    fn catalog_entries_reject_a_debian_architecture_spelling() {
+        for spelling in ["arm64", "amd64"] {
+            let error = serde_json::from_value::<Catalog>(json!({
+                "images": [{
+                    "alias": "ubuntu-26.04",
+                    "version": 1,
+                    "architecture": spelling,
+                    "package": "ubuntu/26.04/ubuntu-26.04.tar.zst",
+                    "sha256": "aabb",
+                    "minDiskGb": 2,
+                    "publishedAt": "2026-08-09T10:00:00Z"
+                }]
+            }))
+            .unwrap_err();
+
+            let message = error.to_string();
+            assert!(message.contains(spelling), "{message}");
+            assert!(message.contains("x86_64"), "{message}");
+            assert!(message.contains("aarch64"), "{message}");
+        }
     }
 }

--- a/firecrab-api/src/image_install.rs
+++ b/firecrab-api/src/image_install.rs
@@ -15,6 +15,7 @@
 
 use std::collections::HashMap;
 use std::env;
+use std::fmt;
 use std::path::{Component, Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
@@ -29,15 +30,50 @@ use crate::templates::{TemplateRegistry, TemplateSpec};
 /// registry, or set `FIRECRAB_IMAGE_BASE_URL=none` to disable remote access.
 pub const DEFAULT_IMAGE_BASE_URL: &str = "https://registry.firecrab.dev";
 
-/// Architecture label used by MicroRegistry catalog entries and object keys.
-#[cfg(target_arch = "aarch64")]
-pub const HOST_ARCHITECTURE: &str = "aarch64";
-/// Architecture label used by MicroRegistry catalog entries and object keys.
-#[cfg(target_arch = "x86_64")]
-pub const HOST_ARCHITECTURE: &str = "x86_64";
+/// A CPU architecture Firecracker can boot a guest on.
+///
+/// Firecrab deals in two unrelated architecture vocabularies: this one, used
+/// by kernels, MicroRegistry object keys and catalog entries, and Debian's
+/// `amd64`/`arm64` labels that appear inside rootfs *filenames*. Keeping this
+/// one a type is what stops the two from being compared to each other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Architecture {
+    /// 64-bit x86. Firecracker boots an ELF `vmlinux` here.
+    X86_64,
+    /// 64-bit ARM. Firecracker boots Linux's own `Image` container here.
+    Aarch64,
+}
+
+impl Architecture {
+    /// The architecture this build of the API runs on. Any target that is
+    /// neither is rejected by the `compile_error!` below, so the `else` arm
+    /// only ever resolves for x86_64.
+    pub const HOST: Self = if cfg!(target_arch = "aarch64") {
+        Self::Aarch64
+    } else {
+        Self::X86_64
+    };
+
+    /// The label MicroRegistry catalog entries and object keys use.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::X86_64 => "x86_64",
+            Self::Aarch64 => "aarch64",
+        }
+    }
+}
+
+impl fmt::Display for Architecture {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
 #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
 compile_error!("Firecrab supports only x86_64 and aarch64 hosts");
+
+/// Architecture label used by MicroRegistry catalog entries and object keys.
+pub const HOST_ARCHITECTURE: &str = Architecture::HOST.as_str();
 
 pub const fn host_architecture() -> &'static str {
     HOST_ARCHITECTURE

--- a/firecrab-api/src/image_install.rs
+++ b/firecrab-api/src/image_install.rs
@@ -36,11 +36,16 @@ pub const DEFAULT_IMAGE_BASE_URL: &str = "https://registry.firecrab.dev";
 /// by kernels, MicroRegistry object keys and catalog entries, and Debian's
 /// `amd64`/`arm64` labels that appear inside rootfs *filenames*. Keeping this
 /// one a type is what stops the two from being compared to each other.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Deserializes only from the exact catalog labels, so a package published
+/// under a Debian spelling is rejected rather than silently mis-resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
 pub enum Architecture {
     /// 64-bit x86. Firecracker boots an ELF `vmlinux` here.
+    #[serde(rename = "x86_64")]
     X86_64,
     /// 64-bit ARM. Firecracker boots Linux's own `Image` container here.
+    #[serde(rename = "aarch64")]
     Aarch64,
 }
 
@@ -59,6 +64,16 @@ impl Architecture {
         match self {
             Self::X86_64 => "x86_64",
             Self::Aarch64 => "aarch64",
+        }
+    }
+
+    /// The architecture this host is not. Tests use it to build artifacts and
+    /// catalog entries that must be rejected, on either supported host.
+    #[cfg(test)]
+    pub(crate) const fn other(self) -> Self {
+        match self {
+            Self::X86_64 => Self::Aarch64,
+            Self::Aarch64 => Self::X86_64,
         }
     }
 }

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
+use crate::image_install::Architecture;
+
 /// Manifest of every template registered at runtime (image install or web
 /// build), relative to the image root. Rebuilt into the registry on the next
 /// startup so a template that was never part of [`default_specs`] — a web
@@ -53,6 +55,28 @@ pub enum TemplateError {
     /// Two [`TemplateSpec`]s declared the same alias.
     #[error("template registry contains a duplicate alias: {0}")]
     DuplicateAlias(String),
+    /// A kernel artifact declares a CPU architecture this host cannot boot.
+    #[error("kernel {path} is built for {found}, but this host is {host}")]
+    KernelArchitectureMismatch {
+        /// The offending kernel, relative to the image root.
+        path: PathBuf,
+        /// The architecture the kernel's own header declares.
+        found: Architecture,
+        /// The architecture this build of the API runs on.
+        host: Architecture,
+    },
+    /// A kernel artifact is a well-formed ELF for an architecture Firecracker
+    /// cannot boot on any host — distinct from one this check simply could
+    /// not classify, which is allowed through.
+    #[error(
+        "kernel {path} targets an architecture firecrab does not support (ELF machine {machine:#06x})"
+    )]
+    UnsupportedKernelArchitecture {
+        /// The offending kernel, relative to the image root.
+        path: PathBuf,
+        /// The ELF `e_machine` value that identified it.
+        machine: u16,
+    },
     /// A filesystem operation failed while building the registry.
     #[error("template registry I/O failed: {0}")]
     Io(#[from] io::Error),
@@ -469,6 +493,7 @@ impl TemplateRegistry {
             .as_ref()
             .map(|path| verify_artifact(&self.image_root, path))
             .transpose()?;
+        verify_kernel_architecture(&self.image_root, &spec.kernel)?;
         let version = Arc::new(TemplateVersion {
             name: spec.alias.clone(),
             version: spec.version.clone(),
@@ -857,6 +882,81 @@ fn open_beneath(root: &File, path: &Path) -> Result<File, TemplateError> {
     Ok(unsafe { File::from_raw_fd(fd as i32) })
 }
 
+/// What a kernel artifact's header says about it.
+///
+/// The split between [`Foreign`](KernelFormat::Foreign) and
+/// [`Unrecognized`](KernelFormat::Unrecognized) is the point of this type:
+/// only one of them may be treated leniently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KernelFormat {
+    /// A kernel for an architecture Firecracker supports.
+    Bootable(Architecture),
+    /// A well-formed ELF for an architecture Firecracker cannot boot at all,
+    /// carrying the `e_machine` value that identified it.
+    Foreign {
+        /// The ELF `e_machine` value, for the error message.
+        machine: u16,
+    },
+    /// Nothing this function can classify. Hosts that installed a template
+    /// before this check existed hold artifacts that land here, so it stays
+    /// permissive.
+    Unrecognized,
+}
+
+/// Classifies a kernel artifact from its own header.
+///
+/// x86_64 boots an ELF `vmlinux`; ARM64 boots Linux's `Image` container.
+fn kernel_architecture(header: &[u8]) -> KernelFormat {
+    if header.starts_with(b"\x7fELF") {
+        // e_machine, a little-endian u16 at offset 18. Both architectures
+        // Firecrab supports are little-endian, so the byte order is fixed.
+        // An ELF too short to hold the field is corrupt rather than foreign,
+        // and gets the same benefit of the doubt as an unknown format.
+        let (Some(low), Some(high)) = (header.get(18), header.get(19)) else {
+            return KernelFormat::Unrecognized;
+        };
+        let machine = u16::from_le_bytes([*low, *high]);
+        return match machine {
+            0x3e => KernelFormat::Bootable(Architecture::X86_64),
+            0xb7 => KernelFormat::Bootable(Architecture::Aarch64),
+            _ => KernelFormat::Foreign { machine },
+        };
+    }
+    // ARM64 `Image`: a 64-byte header with its magic at offset 56. The
+    // leading `MZ` only appears on EFI-bootable builds, so the magic — not
+    // the first two bytes — is what identifies the format.
+    if header.get(56..60) == Some(&0x644d_5241_u32.to_le_bytes()[..]) {
+        return KernelFormat::Bootable(Architecture::Aarch64);
+    }
+    KernelFormat::Unrecognized
+}
+
+/// Rejects a kernel this host cannot boot. Firecracker's own failure mode
+/// there is a silent hang with no console output, so the cost of letting one
+/// through is an unbootable VM with nothing to diagnose.
+fn verify_kernel_architecture(root: &File, path: &Path) -> Result<(), TemplateError> {
+    let mut file = open_beneath(root, path)?;
+    let mut header = Vec::new();
+    // A kernel shorter than one header is simply unclassifiable, so read
+    // what exists rather than requiring 64 bytes.
+    (&mut file).take(64).read_to_end(&mut header)?;
+
+    match kernel_architecture(&header) {
+        KernelFormat::Bootable(found) if found != Architecture::HOST => {
+            Err(TemplateError::KernelArchitectureMismatch {
+                path: path.to_owned(),
+                found,
+                host: Architecture::HOST,
+            })
+        }
+        KernelFormat::Foreign { machine } => Err(TemplateError::UnsupportedKernelArchitecture {
+            path: path.to_owned(),
+            machine,
+        }),
+        KernelFormat::Bootable(_) | KernelFormat::Unrecognized => Ok(()),
+    }
+}
+
 /// Opens `path` beneath `root` and pins its identity/hash into a
 /// [`VerifiedArtifact`].
 fn verify_artifact(root: &File, path: &Path) -> Result<VerifiedArtifact, TemplateError> {
@@ -987,6 +1087,202 @@ mod tests {
                 .resolve_version("my-nginx-base", "my-nginx-base-abc123")
                 .is_some()
         );
+    }
+
+    /// A 64-byte ELF64 header carrying `machine` in `e_machine`. That field
+    /// is the only part architecture detection reads.
+    fn elf_kernel(machine: u16) -> Vec<u8> {
+        let mut header = vec![0_u8; 64];
+        header[0..4].copy_from_slice(b"\x7fELF");
+        header[4] = 2; // ELFCLASS64
+        header[5] = 1; // ELFDATA2LSB
+        header[6] = 1; // EV_CURRENT
+        header[16..18].copy_from_slice(&2_u16.to_le_bytes()); // ET_EXEC
+        header[18..20].copy_from_slice(&machine.to_le_bytes());
+        header
+    }
+
+    /// A 64-byte ARM64 `Image` header. Linux puts its magic at offset 56;
+    /// the leading `MZ` only appears on EFI-bootable builds, so the magic is
+    /// what identifies the format.
+    fn arm64_image_kernel() -> Vec<u8> {
+        let mut header = vec![0_u8; 64];
+        header[0..2].copy_from_slice(b"MZ");
+        header[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+        header
+    }
+
+    fn kernel_bytes_for(architecture: Architecture) -> Vec<u8> {
+        match architecture {
+            Architecture::Aarch64 => arm64_image_kernel(),
+            Architecture::X86_64 => elf_kernel(0x3e),
+        }
+    }
+
+    fn other_architecture() -> Architecture {
+        match Architecture::HOST {
+            Architecture::Aarch64 => Architecture::X86_64,
+            Architecture::X86_64 => Architecture::Aarch64,
+        }
+    }
+
+    /// The three outcomes are deliberately distinct. `Unrecognized` has to
+    /// stay permissive — templates registered before this check existed hold
+    /// artifacts it cannot classify — while `Foreign` is a kernel it *can*
+    /// identify as unbootable, which must not inherit that leniency.
+    #[test]
+    fn kernel_architecture_classifies_a_header_by_its_format() {
+        let cases: [(&str, Vec<u8>, KernelFormat); 8] = [
+            (
+                "x86_64 ELF vmlinux",
+                elf_kernel(0x3e),
+                KernelFormat::Bootable(Architecture::X86_64),
+            ),
+            (
+                "aarch64 ELF vmlinux",
+                elf_kernel(0xb7),
+                KernelFormat::Bootable(Architecture::Aarch64),
+            ),
+            (
+                "aarch64 PE Image",
+                arm64_image_kernel(),
+                KernelFormat::Bootable(Architecture::Aarch64),
+            ),
+            (
+                "32-bit ARM ELF",
+                elf_kernel(0x28),
+                KernelFormat::Foreign { machine: 0x28 },
+            ),
+            (
+                "RISC-V ELF",
+                elf_kernel(0xf3),
+                KernelFormat::Foreign { machine: 0xf3 },
+            ),
+            (
+                "ELF truncated before e_machine",
+                b"\x7fELF\x02\x01\x01".to_vec(),
+                KernelFormat::Unrecognized,
+            ),
+            (
+                "pre-check placeholder",
+                b"kernel".to_vec(),
+                KernelFormat::Unrecognized,
+            ),
+            ("empty file", Vec::new(), KernelFormat::Unrecognized),
+        ];
+
+        for (name, header, expected) in cases {
+            assert_eq!(kernel_architecture(&header), expected, "{name}");
+        }
+    }
+
+    /// Firecracker cannot boot a kernel built for another architecture, and
+    /// the symptom is a silent hang rather than an error — so registration
+    /// is where it has to be caught.
+    #[test]
+    fn registering_a_kernel_for_another_architecture_is_rejected() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        fs::write(root.join("kernel"), kernel_bytes_for(other_architecture())).unwrap();
+        fs::write(root.join("rootfs"), b"rootfs").unwrap();
+
+        let registry = TemplateRegistry::load_from(root).unwrap();
+        let error = registry
+            .register_spec(TemplateSpec {
+                alias: "foreign".to_owned(),
+                version: "foreign-v1".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: String::new(),
+            })
+            .unwrap_err();
+
+        assert!(
+            matches!(error, TemplateError::KernelArchitectureMismatch { found, .. }
+                if found == other_architecture()),
+            "{error:?}"
+        );
+        assert!(registry.resolve_alias("foreign").is_none());
+    }
+
+    /// A RISC-V kernel is not a mismatch against this host so much as a
+    /// kernel Firecracker cannot boot anywhere. It is identifiable, so the
+    /// leniency granted to unclassifiable artifacts must not cover it.
+    #[test]
+    fn registering_a_kernel_for_an_unsupported_architecture_is_rejected() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        fs::write(root.join("kernel"), elf_kernel(0xf3)).unwrap();
+        fs::write(root.join("rootfs"), b"rootfs").unwrap();
+
+        let registry = TemplateRegistry::load_from(root).unwrap();
+        let error = registry
+            .register_spec(TemplateSpec {
+                alias: "riscv".to_owned(),
+                version: "riscv-v1".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: String::new(),
+            })
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                TemplateError::UnsupportedKernelArchitecture { machine: 0xf3, .. }
+            ),
+            "{error:?}"
+        );
+        assert!(registry.resolve_alias("riscv").is_none());
+    }
+
+    /// An artifact this check cannot classify has to keep registering, or
+    /// every host that installed a template before the check existed would
+    /// lose it on the next restart.
+    #[test]
+    fn registering_an_unclassifiable_kernel_is_still_allowed() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        fs::write(root.join("kernel"), b"kernel").unwrap();
+        fs::write(root.join("rootfs"), b"rootfs").unwrap();
+
+        let registry = TemplateRegistry::load_from(root).unwrap();
+        registry
+            .register_spec(TemplateSpec {
+                alias: "legacy".to_owned(),
+                version: "legacy-v1".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: String::new(),
+            })
+            .expect("an unclassifiable kernel must keep registering");
+
+        assert!(registry.resolve_alias("legacy").is_some());
+    }
+
+    #[test]
+    fn registering_a_kernel_for_this_host_is_accepted() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        fs::write(root.join("kernel"), kernel_bytes_for(Architecture::HOST)).unwrap();
+        fs::write(root.join("rootfs"), b"rootfs").unwrap();
+
+        let registry = TemplateRegistry::load_from(root).unwrap();
+        registry
+            .register_spec(TemplateSpec {
+                alias: "native".to_owned(),
+                version: "native-v1".to_owned(),
+                kernel: PathBuf::from("kernel"),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs"),
+                boot_args: String::new(),
+            })
+            .expect("a kernel matching the host must register");
+
+        assert!(registry.resolve_alias("native").is_some());
     }
 
     /// Deleting a template must not leave it in the manifest, or every

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -1119,13 +1119,6 @@ mod tests {
         }
     }
 
-    fn other_architecture() -> Architecture {
-        match Architecture::HOST {
-            Architecture::Aarch64 => Architecture::X86_64,
-            Architecture::X86_64 => Architecture::Aarch64,
-        }
-    }
-
     /// The three outcomes are deliberately distinct. `Unrecognized` has to
     /// stay permissive — templates registered before this check existed hold
     /// artifacts it cannot classify — while `Foreign` is a kernel it *can*
@@ -1183,7 +1176,11 @@ mod tests {
     fn registering_a_kernel_for_another_architecture_is_rejected() {
         let directory = tempdir().unwrap();
         let root = directory.path();
-        fs::write(root.join("kernel"), kernel_bytes_for(other_architecture())).unwrap();
+        fs::write(
+            root.join("kernel"),
+            kernel_bytes_for(Architecture::HOST.other()),
+        )
+        .unwrap();
         fs::write(root.join("rootfs"), b"rootfs").unwrap();
 
         let registry = TemplateRegistry::load_from(root).unwrap();
@@ -1200,7 +1197,7 @@ mod tests {
 
         assert!(
             matches!(error, TemplateError::KernelArchitectureMismatch { found, .. }
-                if found == other_architecture()),
+                if found == Architecture::HOST.other()),
             "{error:?}"
         );
         assert!(registry.resolve_alias("foreign").is_none());

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -9,6 +9,14 @@ Rocky Linux 9 is currently x86_64-only.
 ARM64 packages keep the distro PE32+ `Image`; x86_64 packages use an ELF
 `vmlinux`. Firecracker cannot boot an x86_64 kernel on an ARM64 host.
 
+Registration reads the kernel's own header and rejects a mismatch.
+A kernel in a format firecrab cannot classify is registered without that check.
+
+A rootfs carrying no `/lib/modules` can only boot on a kernel with the boot
+path built in: `virtio_blk`, `virtio_net`, `virtio_mmio`, and `ext4`.
+Firecracker has no PCI, so the virtio drivers must be the MMIO variants.
+An image whose kernel keeps those as modules needs the matching initrd.
+
 ## Build
 
 Build all images supported by the current Linux host architecture.


### PR DESCRIPTION
Refs #89

Does not close #89 — see "Remaining" below.

## Images

- Add an `Architecture` enum with the registry label as its string form
- Derive `HOST` from `cfg!` and keep `HOST_ARCHITECTURE` as its label
- Fold `CatalogArchitecture` into it, dropping a duplicate type and its
  `cfg`-duplicated `is_host`

Four pairs of `#[cfg(target_arch)]` branches collapse into one `Architecture::HOST`.

## Templates

- Classify a kernel from its ELF `e_machine` or ARM64 `Image` magic
- Fail registration when that architecture is not the host's
- Fail it too for an ELF targeting an architecture firecrab cannot boot
- Leave unclassifiable and truncated kernels registered as before

Firecracker's failure mode for a foreign kernel is a silent hang with no
console output, so registration is where it has to be caught. The three
outcomes are deliberately distinct: an artifact this check cannot classify
stays permitted, because hosts that installed a template before the check
existed hold exactly those. A RISC-V ELF is identifiable as unbootable and
must not inherit that leniency.

## Docs

- State the check and the builtin drivers a module-less rootfs needs
- Pin that Debian `arm64`/`amd64` spellings stay rejected in catalog entries

## Verification

| Check | Result |
| --- | --- |
| `cargo test --workspace` | 355 passed, 1 pre-existing environment failure |
| `cargo clippy --all-targets --all-features` | no new findings |
| `cargo doc --no-deps --workspace` | clean |
| `cargo llvm-cov` | `templates.rs` 95.50% line, `image_install.rs` 91.58% line |
| `scripts/check-doc-links.py` | pass |

The failing test needs 8 GiB free on the temp filesystem; `/tmp` is a 7.93 GiB
tmpfs on this machine. Reproduced on `main` without these changes.

## Remaining

#89 also asks to record and verify whether a kernel boots without an initrd.
That cannot be done by inspection: whether `virtio_blk` is builtin or a module
lives in the kernel config, and a kernel built without `CONFIG_IKCONFIG`
carries no config at all. It can only be *declared*, which `TemplateSpec.initrd`
already does. Real verification needs a boot, so it belongs in the CI boot
matrix as separate work.
