### PR TITLE
Decompress OCI layers (#90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +22,18 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-compression"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -118,6 +136,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -145,6 +165,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -243,6 +291,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 name = "firecrab-api"
 version = "0.1.0"
 dependencies = [
+ "async-compression",
  "axum",
  "firecrab-api-types",
  "firecrab-helper-protocol",
@@ -298,6 +347,16 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -744,6 +803,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +920,16 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1469,6 +1548,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "slab"
@@ -2379,3 +2464,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/firecrab-api/Cargo.toml
+++ b/firecrab-api/Cargo.toml
@@ -6,6 +6,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
+async-compression = { version = "0.4.43", features = ["gzip", "tokio", "zstd"] }
 axum = { version = "0.8.9", features = ["ws"] }
 firecrab-api-types = { path = "../firecrab-api-types" }
 firecrab-helper-protocol = { path = "../firecrab-helper-protocol" }

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -4,16 +4,19 @@ use std::collections::HashMap;
 use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
+use async_compression::tokio::bufread::{GzipDecoder, ZstdDecoder};
 use futures_util::{StreamExt, TryStreamExt, stream};
 use serde::{Deserialize, Deserializer};
 use sha2::{Digest as _, Sha256};
 use thiserror::Error;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::Mutex as AsyncMutex;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
+use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 use uuid::Uuid;
 
 use crate::image_install::Architecture;
@@ -450,12 +453,37 @@ struct RawImageManifest {
     layers: Vec<RawDescriptor>,
 }
 
+#[derive(Debug, Deserialize)]
+struct RawImageConfiguration {
+    rootfs: RawRootFilesystem,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawRootFilesystem {
+    #[serde(rename = "type")]
+    kind: String,
+    diff_ids: Vec<Sha256Digest>,
+}
+
 const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
 const DOCKER_INDEX_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.list.v2+json";
 const OCI_MANIFEST_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
 const DOCKER_MANIFEST_MEDIA_TYPE: &str = "application/vnd.docker.distribution.manifest.v2+json";
 const OCI_CONFIG_MEDIA_TYPE: &str = "application/vnd.oci.image.config.v1+json";
 const DOCKER_CONFIG_MEDIA_TYPE: &str = "application/vnd.docker.container.image.v1+json";
+const OCI_LAYER_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar";
+const OCI_LAYER_GZIP_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+gzip";
+const OCI_LAYER_ZSTD_MEDIA_TYPE: &str = "application/vnd.oci.image.layer.v1.tar+zstd";
+const OCI_NONDISTRIBUTABLE_LAYER_MEDIA_TYPE: &str =
+    "application/vnd.oci.image.layer.nondistributable.v1.tar";
+const OCI_NONDISTRIBUTABLE_LAYER_GZIP_MEDIA_TYPE: &str =
+    "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip";
+const OCI_NONDISTRIBUTABLE_LAYER_ZSTD_MEDIA_TYPE: &str =
+    "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd";
+const DOCKER_LAYER_MEDIA_TYPE: &str = "application/vnd.docker.image.rootfs.diff.tar";
+const DOCKER_LAYER_GZIP_MEDIA_TYPE: &str = "application/vnd.docker.image.rootfs.diff.tar.gzip";
+const DOCKER_FOREIGN_LAYER_GZIP_MEDIA_TYPE: &str =
+    "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip";
 
 /// Whether a descriptor points at an image manifest rather than an artifact.
 fn is_manifest_media_type(media_type: &str) -> bool {
@@ -470,21 +498,42 @@ fn is_config_media_type(media_type: &str) -> bool {
     matches!(media_type, OCI_CONFIG_MEDIA_TYPE | DOCKER_CONFIG_MEDIA_TYPE)
 }
 
-/// Layer encodings whose raw bytes Firecrab can safely cache. Decompression
-/// and application are deliberately left to the next import stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum LayerCompression {
+    Identity,
+    Gzip,
+    Zstd,
+}
+
+impl LayerCompression {
+    fn cache_name(self) -> &'static str {
+        match self {
+            Self::Identity => "identity",
+            Self::Gzip => "gzip",
+            Self::Zstd => "zstd",
+        }
+    }
+}
+
+fn layer_compression(media_type: &str) -> Option<LayerCompression> {
+    match media_type {
+        OCI_LAYER_MEDIA_TYPE | OCI_NONDISTRIBUTABLE_LAYER_MEDIA_TYPE | DOCKER_LAYER_MEDIA_TYPE => {
+            Some(LayerCompression::Identity)
+        }
+        OCI_LAYER_GZIP_MEDIA_TYPE
+        | OCI_NONDISTRIBUTABLE_LAYER_GZIP_MEDIA_TYPE
+        | DOCKER_LAYER_GZIP_MEDIA_TYPE
+        | DOCKER_FOREIGN_LAYER_GZIP_MEDIA_TYPE => Some(LayerCompression::Gzip),
+        OCI_LAYER_ZSTD_MEDIA_TYPE | OCI_NONDISTRIBUTABLE_LAYER_ZSTD_MEDIA_TYPE => {
+            Some(LayerCompression::Zstd)
+        }
+        _ => None,
+    }
+}
+
+/// Layer encodings whose raw bytes Firecrab can safely cache and unpack.
 fn is_layer_media_type(media_type: &str) -> bool {
-    matches!(
-        media_type,
-        "application/vnd.oci.image.layer.v1.tar"
-            | "application/vnd.oci.image.layer.v1.tar+gzip"
-            | "application/vnd.oci.image.layer.v1.tar+zstd"
-            | "application/vnd.oci.image.layer.nondistributable.v1.tar"
-            | "application/vnd.oci.image.layer.nondistributable.v1.tar+gzip"
-            | "application/vnd.oci.image.layer.nondistributable.v1.tar+zstd"
-            | "application/vnd.docker.image.rootfs.diff.tar"
-            | "application/vnd.docker.image.rootfs.diff.tar.gzip"
-            | "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
-    )
+    layer_compression(media_type).is_some()
 }
 
 /// Media types a manifest request accepts. Both index forms are listed so a
@@ -505,6 +554,19 @@ const TOKEN_MAX_BYTES: usize = 64 * 1024;
 /// descriptor and streamed-body checks below.
 const DEFAULT_MAX_BLOB_BYTES: u64 = 16 * 1024 * 1024 * 1024;
 const MAX_BLOB_BYTES_ENV: &str = "FIRECRAB_OCI_MAX_BLOB_BYTES";
+/// Image configuration is metadata and is parsed in memory before unpacking.
+const CONFIG_MAX_BYTES: u64 = 4 * 1024 * 1024;
+/// A separate ceiling for decoder output prevents a small compressed layer
+/// from expanding until it fills the image volume.
+const DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+const MAX_UNCOMPRESSED_LAYER_BYTES_ENV: &str = "FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES";
+/// libzstd's normal maximum window is 128 MiB. Setting it explicitly keeps a
+/// hostile frame header from requesting an unexpectedly large decoder window.
+const ZSTD_MAX_WINDOW_LOG: u32 = 27;
+/// Decompression has a separate concurrency ceiling because each zstd decoder
+/// may retain a 128 MiB window. Keeping at most two active bounds those windows
+/// to 256 MiB instead of multiplying them by a many-core host's CPU count.
+const MAX_PARALLEL_DECOMPRESSIONS: usize = 2;
 
 /// What a reference resolved to on this host.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -571,6 +633,54 @@ pub enum ResolveError {
         size: u64,
         /// Configured maximum size of one downloaded blob.
         limit: u64,
+    },
+    /// The verified image configuration could not be interpreted.
+    #[error("OCI image configuration is invalid: {0}")]
+    MalformedConfig(String),
+    /// OCI defines only the `layers` root filesystem model.
+    #[error("unsupported OCI rootfs type {0:?}; expected \"layers\"")]
+    UnsupportedRootfsType(String),
+    /// The config must name one uncompressed digest for every manifest layer.
+    #[error("OCI config has {actual} rootfs diff_ids but the manifest has {expected} layers")]
+    DiffIdCountMismatch {
+        /// Number of layer descriptors in the manifest.
+        expected: usize,
+        /// Number of uncompressed digests in the configuration.
+        actual: usize,
+    },
+    /// A compressed layer stream could not be decoded completely.
+    #[error("could not decompress OCI layer {digest} ({media_type}): {message}")]
+    Decompression {
+        /// Digest of the exact registry bytes being decoded.
+        digest: Sha256Digest,
+        /// Layer media type that selected the decoder.
+        media_type: String,
+        /// Codec or source-read failure.
+        message: String,
+    },
+    /// Decoder output did not match the config's uncompressed digest.
+    #[error(
+        "diff ID mismatch for OCI layer {compressed_digest}: expected {expected}, got {actual}"
+    )]
+    DiffIdMismatch {
+        /// Manifest digest of the compressed registry blob.
+        compressed_digest: Sha256Digest,
+        /// Uncompressed digest declared by the image configuration.
+        expected: Sha256Digest,
+        /// Digest calculated from the decoded tar stream.
+        actual: Sha256Digest,
+    },
+    /// Decoder output exceeded the operator's per-layer policy.
+    #[error(
+        "OCI layer {compressed_digest} decompressed to more than the {limit}-byte limit ({actual} bytes observed)"
+    )]
+    UncompressedLayerTooLarge {
+        /// Manifest digest of the compressed registry blob.
+        compressed_digest: Sha256Digest,
+        /// Configured maximum uncompressed size of one layer.
+        limit: u64,
+        /// Size observed from metadata or while streaming.
+        actual: u64,
     },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
@@ -1174,8 +1284,36 @@ pub struct BlobCache {
     max_blob_bytes: u64,
 }
 
-type DigestLockMap = HashMap<PathBuf, Weak<AsyncMutex<()>>>;
-static DIGEST_LOCKS: OnceLock<StdMutex<DigestLockMap>> = OnceLock::new();
+type CacheLockMap = HashMap<PathBuf, Weak<AsyncMutex<()>>>;
+static CACHE_LOCKS: OnceLock<StdMutex<CacheLockMap>> = OnceLock::new();
+static DECOMPRESSION_PERMITS: OnceLock<Arc<Semaphore>> = OnceLock::new();
+
+fn shared_decompression_permits() -> Arc<Semaphore> {
+    Arc::clone(
+        DECOMPRESSION_PERMITS.get_or_init(|| Arc::new(Semaphore::new(MAX_PARALLEL_DECOMPRESSIONS))),
+    )
+}
+
+async fn cache_path_lock(
+    root: &Path,
+    relative_path: &Path,
+) -> Result<Arc<AsyncMutex<()>>, ResolveError> {
+    let canonical_root = tokio::fs::canonicalize(root)
+        .await
+        .map_err(|source| cache_io("canonicalize directory", root.to_owned(), source))?;
+    let key = canonical_root.join(relative_path);
+    let mut locks = CACHE_LOCKS
+        .get_or_init(|| StdMutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return Ok(lock);
+    }
+    let lock = Arc::new(AsyncMutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    Ok(lock)
+}
 
 impl BlobCache {
     /// Creates a cache rooted at `<image-root>/.oci/blobs/sha256/`.
@@ -1203,21 +1341,7 @@ impl BlobCache {
         &self,
         digest: &Sha256Digest,
     ) -> Result<Arc<AsyncMutex<()>>, ResolveError> {
-        let canonical_root = tokio::fs::canonicalize(&self.root)
-            .await
-            .map_err(|source| cache_io("canonicalize directory", self.root.clone(), source))?;
-        let key = canonical_root.join(digest.encoded());
-        let mut locks = DIGEST_LOCKS
-            .get_or_init(|| StdMutex::new(HashMap::new()))
-            .lock()
-            .unwrap_or_else(|poison| poison.into_inner());
-        locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
-            return Ok(lock);
-        }
-        let lock = Arc::new(AsyncMutex::new(()));
-        locks.insert(key, Arc::downgrade(&lock));
-        Ok(lock)
+        cache_path_lock(&self.root, Path::new(digest.encoded())).await
     }
 
     async fn cache_descriptor(
@@ -1363,6 +1487,32 @@ fn configured_max_blob_bytes() -> u64 {
                 "non-Unicode OCI blob limit; using default"
             );
             DEFAULT_MAX_BLOB_BYTES
+        }
+    }
+}
+
+fn configured_max_uncompressed_layer_bytes() -> u64 {
+    match std::env::var(MAX_UNCOMPRESSED_LAYER_BYTES_ENV) {
+        Ok(value) => match value.trim().parse::<u64>() {
+            Ok(limit) if limit > 0 => limit,
+            _ => {
+                tracing::warn!(
+                    variable = MAX_UNCOMPRESSED_LAYER_BYTES_ENV,
+                    value,
+                    default = DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES,
+                    "invalid OCI uncompressed layer limit; using default"
+                );
+                DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES
+            }
+        },
+        Err(std::env::VarError::NotPresent) => DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                variable = MAX_UNCOMPRESSED_LAYER_BYTES_ENV,
+                default = DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES,
+                "non-Unicode OCI uncompressed layer limit; using default"
+            );
+            DEFAULT_MAX_UNCOMPRESSED_LAYER_BYTES
         }
     }
 }
@@ -1529,6 +1679,495 @@ pub struct CachedImageBlobs {
     pub config: CachedBlob,
     /// Cached filesystem layers in manifest application order.
     pub layers: Vec<CachedBlob>,
+}
+
+/// Content-addressed storage for verified, uncompressed layer tar streams.
+///
+/// A cache filename records both identities involved in unpacking: the
+/// config's digest of the uncompressed tar and the manifest's digest of the
+/// exact registry blob. This prevents a cached tar from making a new, false
+/// compressed-digest-to-diff-ID relationship appear verified.
+#[derive(Debug, Clone)]
+pub struct LayerCache {
+    root: PathBuf,
+    max_uncompressed_layer_bytes: u64,
+    decompression_permits: Arc<Semaphore>,
+}
+
+struct CompressedReadState {
+    size: u64,
+    hasher: Sha256,
+}
+
+impl CompressedReadState {
+    fn finish(&self) -> (u64, Sha256Digest) {
+        (
+            self.size,
+            Sha256Digest(format!("sha256:{:x}", self.hasher.clone().finalize())),
+        )
+    }
+}
+
+struct VerifyingReader<R> {
+    inner: R,
+    state: Arc<StdMutex<CompressedReadState>>,
+}
+
+impl<R> VerifyingReader<R> {
+    fn new(inner: R) -> (Self, Arc<StdMutex<CompressedReadState>>) {
+        let state = Arc::new(StdMutex::new(CompressedReadState {
+            size: 0,
+            hasher: Sha256::new(),
+        }));
+        (
+            Self {
+                inner,
+                state: Arc::clone(&state),
+            },
+            state,
+        )
+    }
+}
+
+impl<R: AsyncRead + Unpin> AsyncRead for VerifyingReader<R> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buffer: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let filled_before = buffer.filled().len();
+        let result = Pin::new(&mut self.inner).poll_read(context, buffer);
+        if let Poll::Ready(Ok(())) = &result {
+            let bytes = &buffer.filled()[filled_before..];
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(|poison| poison.into_inner());
+            let Some(size) = state.size.checked_add(bytes.len() as u64) else {
+                return Poll::Ready(Err(io::Error::other(
+                    "compressed layer byte count overflow",
+                )));
+            };
+            state.size = size;
+            state.hasher.update(bytes);
+        }
+        result
+    }
+}
+
+impl LayerCache {
+    /// Creates a cache rooted at `<image-root>/.oci/layers/sha256/`.
+    pub fn new(image_root: impl AsRef<Path>) -> Self {
+        Self::with_max_uncompressed_layer_bytes(
+            image_root,
+            configured_max_uncompressed_layer_bytes(),
+        )
+    }
+
+    /// Creates a layer cache with an explicit decoded-output ceiling.
+    pub fn with_max_uncompressed_layer_bytes(
+        image_root: impl AsRef<Path>,
+        max_uncompressed_layer_bytes: u64,
+    ) -> Self {
+        Self {
+            root: image_root.as_ref().join(".oci/layers/sha256"),
+            max_uncompressed_layer_bytes,
+            decompression_permits: shared_decompression_permits(),
+        }
+    }
+
+    /// Returns the verified tar path for one compressed descriptor/diff-ID pair.
+    pub fn path_for(
+        &self,
+        descriptor: &Descriptor,
+        diff_id: &Sha256Digest,
+    ) -> Result<PathBuf, ResolveError> {
+        let compression = layer_compression(&descriptor.media_type)
+            .ok_or_else(|| ResolveError::UnsupportedMediaType(descriptor.media_type.clone()))?;
+        Ok(self.root.join(layer_relative_path(
+            &descriptor.digest,
+            diff_id,
+            compression,
+        )))
+    }
+
+    async fn cache_layer(
+        &self,
+        source: &CachedBlob,
+        diff_id: &Sha256Digest,
+        compression: LayerCompression,
+    ) -> Result<(PathBuf, u64), ResolveError> {
+        let relative = layer_relative_path(&source.descriptor.digest, diff_id, compression);
+        let path = self.root.join(&relative);
+        let parent = path
+            .parent()
+            .expect("a layer cache path always has a digest directory");
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|source| cache_io("create directory", parent.to_owned(), source))?;
+        let lock = cache_path_lock(&self.root, &relative).await?;
+        let _guard = lock.lock().await;
+
+        match verify_uncompressed_layer_file(
+            &path,
+            source,
+            diff_id,
+            self.max_uncompressed_layer_bytes,
+        )
+        .await?
+        {
+            LayerFileState::Valid(size) => return Ok((path, size)),
+            LayerFileState::Missing => {}
+            LayerFileState::Corrupt => remove_cache_file(&path).await?,
+        }
+
+        let size = self
+            .decode_layer(source, diff_id, compression, &path)
+            .await?;
+        Ok((path, size))
+    }
+
+    async fn decode_layer(
+        &self,
+        source: &CachedBlob,
+        diff_id: &Sha256Digest,
+        compression: LayerCompression,
+        destination: &Path,
+    ) -> Result<u64, ResolveError> {
+        let _decompression_permit = self
+            .decompression_permits
+            .acquire()
+            .await
+            .expect("the shared decompression semaphore is never closed");
+        let input = tokio::fs::File::open(&source.path)
+            .await
+            .map_err(|error| cache_io("open compressed layer", source.path.clone(), error))?;
+        // Hash the exact opened file stream underneath the decoder. A separate
+        // preflight check would leave a path-replacement race between blob
+        // verification and decompression.
+        let (input, compressed_state) = VerifyingReader::new(input);
+        let input = BufReader::new(input);
+        let mut reader: Box<dyn AsyncRead + Send + Unpin> = match compression {
+            LayerCompression::Identity => Box::new(input),
+            LayerCompression::Gzip => {
+                let mut decoder = GzipDecoder::new(input);
+                decoder.multiple_members(true);
+                Box::new(decoder)
+            }
+            LayerCompression::Zstd => {
+                let mut decoder = ZstdDecoder::with_params(
+                    input,
+                    &[async_compression::zstd::DParameter::window_log_max(
+                        ZSTD_MAX_WINDOW_LOG,
+                    )],
+                );
+                decoder.multiple_members(true);
+                Box::new(decoder)
+            }
+        };
+
+        let parent = destination
+            .parent()
+            .expect("a layer cache path always has a digest directory");
+        let (temporary, mut output) =
+            create_partial_file(parent, &source.descriptor.digest).await?;
+        let mut cleanup = PartialCleanup::new(temporary.clone());
+        let mut hasher = Sha256::new();
+        let mut size = 0_u64;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read =
+                reader
+                    .read(&mut buffer)
+                    .await
+                    .map_err(|error| ResolveError::Decompression {
+                        digest: source.descriptor.digest.clone(),
+                        media_type: source.descriptor.media_type.clone(),
+                        message: error.to_string(),
+                    })?;
+            if read == 0 {
+                break;
+            }
+            let next_size = size.checked_add(read as u64).ok_or_else(|| {
+                ResolveError::UncompressedLayerTooLarge {
+                    compressed_digest: source.descriptor.digest.clone(),
+                    limit: self.max_uncompressed_layer_bytes,
+                    actual: u64::MAX,
+                }
+            })?;
+            if next_size > self.max_uncompressed_layer_bytes {
+                return Err(ResolveError::UncompressedLayerTooLarge {
+                    compressed_digest: source.descriptor.digest.clone(),
+                    limit: self.max_uncompressed_layer_bytes,
+                    actual: next_size,
+                });
+            }
+            hasher.update(&buffer[..read]);
+            output
+                .write_all(&buffer[..read])
+                .await
+                .map_err(|error| cache_io("write", temporary.clone(), error))?;
+            size = next_size;
+            // Codec reads may remain immediately ready while input is
+            // buffered. Yield between chunks so a large layer cannot occupy a
+            // Tokio worker for the duration of its entire decompression.
+            tokio::task::yield_now().await;
+        }
+
+        let (compressed_size, compressed_digest) = compressed_state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .finish();
+        if compressed_size != source.descriptor.size {
+            return Err(ResolveError::SizeMismatch {
+                subject: source.descriptor.digest.to_string(),
+                expected: source.descriptor.size,
+                actual: compressed_size,
+            });
+        }
+        if compressed_digest != source.descriptor.digest {
+            return Err(ResolveError::DigestMismatch {
+                subject: format!("compressed layer {}", source.descriptor.digest),
+                expected: source.descriptor.digest.clone(),
+                actual: compressed_digest,
+            });
+        }
+
+        let actual = Sha256Digest(format!("sha256:{:x}", hasher.finalize()));
+        if actual != *diff_id {
+            return Err(ResolveError::DiffIdMismatch {
+                compressed_digest: source.descriptor.digest.clone(),
+                expected: diff_id.clone(),
+                actual,
+            });
+        }
+        output
+            .flush()
+            .await
+            .map_err(|error| cache_io("flush", temporary.clone(), error))?;
+        output
+            .sync_all()
+            .await
+            .map_err(|error| cache_io("sync", temporary.clone(), error))?;
+        drop(output);
+        tokio::fs::rename(&temporary, destination)
+            .await
+            .map_err(|error| cache_io("publish", destination.to_owned(), error))?;
+        cleanup.published = true;
+        Ok(size)
+    }
+}
+
+fn layer_relative_path(
+    compressed_digest: &Sha256Digest,
+    diff_id: &Sha256Digest,
+    compression: LayerCompression,
+) -> PathBuf {
+    PathBuf::from(diff_id.encoded()).join(format!(
+        "{}.{}.tar",
+        compressed_digest.encoded(),
+        compression.cache_name()
+    ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LayerFileState {
+    Missing,
+    Valid(u64),
+    Corrupt,
+}
+
+async fn verify_uncompressed_layer_file(
+    path: &Path,
+    source: &CachedBlob,
+    diff_id: &Sha256Digest,
+    max_uncompressed_layer_bytes: u64,
+) -> Result<LayerFileState, ResolveError> {
+    let metadata = match tokio::fs::symlink_metadata(path).await {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LayerFileState::Missing);
+        }
+        Err(error) => return Err(cache_io("inspect", path.to_owned(), error)),
+    };
+    if !metadata.file_type().is_file() {
+        return Ok(LayerFileState::Corrupt);
+    }
+    if metadata.len() > max_uncompressed_layer_bytes {
+        return Err(ResolveError::UncompressedLayerTooLarge {
+            compressed_digest: source.descriptor.digest.clone(),
+            limit: max_uncompressed_layer_bytes,
+            actual: metadata.len(),
+        });
+    }
+
+    let (size, actual) = match hash_file(path).await {
+        Ok(result) => result,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LayerFileState::Missing);
+        }
+        Err(error) => return Err(cache_io("verify", path.to_owned(), error)),
+    };
+    if actual != *diff_id {
+        return Ok(LayerFileState::Corrupt);
+    }
+    Ok(LayerFileState::Valid(size))
+}
+
+/// One verified uncompressed layer, retaining both OCI content identities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecompressedLayer {
+    /// Original cached registry bytes and their manifest descriptor.
+    pub source: CachedBlob,
+    /// Digest of the uncompressed tar stream from config `rootfs.diff_ids`.
+    pub diff_id: Sha256Digest,
+    /// Verified uncompressed tar path below `.oci/layers/sha256/`.
+    pub path: PathBuf,
+    /// Number of bytes in the uncompressed tar stream.
+    pub size: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct LayerWorkKey {
+    compressed_digest: Sha256Digest,
+    diff_id: Sha256Digest,
+    compression: LayerCompression,
+}
+
+/// Decompresses and verifies every cached layer against config `diff_ids`.
+///
+/// Decoder work is bounded by the host's logical CPU count and the returned
+/// vector always retains manifest order. This stage produces tar streams only;
+/// member validation, extraction, whiteouts, and layer merging happen later.
+pub async fn decompress_cached_layers(
+    image: &CachedImageBlobs,
+    cache: &LayerCache,
+) -> Result<Vec<DecompressedLayer>, ResolveError> {
+    let available = std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1);
+    let parallelism = decompression_parallelism(available);
+    decompress_cached_layers_with_parallelism(image, cache, parallelism).await
+}
+
+fn decompression_parallelism(available: usize) -> usize {
+    available.clamp(1, MAX_PARALLEL_DECOMPRESSIONS)
+}
+
+async fn decompress_cached_layers_with_parallelism(
+    image: &CachedImageBlobs,
+    cache: &LayerCache,
+    parallelism: usize,
+) -> Result<Vec<DecompressedLayer>, ResolveError> {
+    let diff_ids = read_config_diff_ids(image).await?;
+    let layers = image
+        .layers
+        .iter()
+        .cloned()
+        .zip(diff_ids)
+        .map(|(source, diff_id)| {
+            let compression =
+                layer_compression(&source.descriptor.media_type).ok_or_else(|| {
+                    ResolveError::UnsupportedMediaType(source.descriptor.media_type.clone())
+                })?;
+            let key = LayerWorkKey {
+                compressed_digest: source.descriptor.digest.clone(),
+                diff_id,
+                compression,
+            };
+            Ok((key, source))
+        })
+        .collect::<Result<Vec<_>, ResolveError>>()?;
+
+    let mut seen = std::collections::HashSet::new();
+    let work: Vec<(LayerWorkKey, CachedBlob)> = layers
+        .iter()
+        .filter(|(key, _)| seen.insert(key.clone()))
+        .cloned()
+        .collect();
+    let completed: Vec<(LayerWorkKey, PathBuf, u64)> = stream::iter(work)
+        .map(|(key, source)| {
+            let cache = cache.clone();
+            async move {
+                let (path, size) = cache
+                    .cache_layer(&source, &key.diff_id, key.compression)
+                    .await?;
+                Ok::<_, ResolveError>((key, path, size))
+            }
+        })
+        .buffer_unordered(parallelism.max(1))
+        .try_collect()
+        .await?;
+    let completed: HashMap<LayerWorkKey, (PathBuf, u64)> = completed
+        .into_iter()
+        .map(|(key, path, size)| (key, (path, size)))
+        .collect();
+
+    Ok(layers
+        .into_iter()
+        .map(|(key, source)| {
+            let (path, size) = completed
+                .get(&key)
+                .expect("every unique layer relationship produces one cache path");
+            DecompressedLayer {
+                source,
+                diff_id: key.diff_id,
+                path: path.clone(),
+                size: *size,
+            }
+        })
+        .collect())
+}
+
+async fn read_config_diff_ids(image: &CachedImageBlobs) -> Result<Vec<Sha256Digest>, ResolveError> {
+    if image.config.descriptor.size > CONFIG_MAX_BYTES {
+        return Err(ResolveError::MalformedConfig(format!(
+            "configuration {} exceeds the {CONFIG_MAX_BYTES}-byte parse limit",
+            image.config.descriptor.digest
+        )));
+    }
+    let file = tokio::fs::File::open(&image.config.path)
+        .await
+        .map_err(|error| cache_io("open config", image.config.path.clone(), error))?;
+    let mut body = Vec::with_capacity(image.config.descriptor.size as usize);
+    file.take(CONFIG_MAX_BYTES + 1)
+        .read_to_end(&mut body)
+        .await
+        .map_err(|error| cache_io("read config", image.config.path.clone(), error))?;
+    if body.len() as u64 > CONFIG_MAX_BYTES {
+        return Err(ResolveError::MalformedConfig(format!(
+            "configuration {} exceeds the {CONFIG_MAX_BYTES}-byte parse limit",
+            image.config.descriptor.digest
+        )));
+    }
+    if body.len() as u64 != image.config.descriptor.size {
+        return Err(ResolveError::SizeMismatch {
+            subject: image.config.descriptor.digest.to_string(),
+            expected: image.config.descriptor.size,
+            actual: body.len() as u64,
+        });
+    }
+    let actual = Sha256Digest::of_bytes(&body);
+    if actual != image.config.descriptor.digest {
+        return Err(ResolveError::DigestMismatch {
+            subject: format!("config blob {}", image.config.descriptor.digest),
+            expected: image.config.descriptor.digest.clone(),
+            actual,
+        });
+    }
+
+    let config: RawImageConfiguration = serde_json::from_slice(&body)
+        .map_err(|error| ResolveError::MalformedConfig(error.to_string()))?;
+    if config.rootfs.kind != "layers" {
+        return Err(ResolveError::UnsupportedRootfsType(config.rootfs.kind));
+    }
+    if config.rootfs.diff_ids.len() != image.layers.len() {
+        return Err(ResolveError::DiffIdCountMismatch {
+            expected: image.layers.len(),
+            actual: config.rootfs.diff_ids.len(),
+        });
+    }
+    Ok(config.rootfs.diff_ids)
 }
 
 /// Resolves an image and fills a verified content-addressed config/layer cache.

--- a/firecrab-api/src/oci/cache_tests.rs
+++ b/firecrab-api/src/oci/cache_tests.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use async_compression::tokio::bufread::{GzipEncoder, ZstdEncoder};
 use axum::body::{Body, Bytes};
 use axum::extract::{Path as AxumPath, State};
 use axum::http::{Response, StatusCode, header::CONTENT_TYPE};
@@ -40,6 +41,43 @@ impl FixtureBlob {
             self.bytes.len() as u64,
         )
     }
+}
+
+fn config_blob(diff_ids: &[Sha256Digest]) -> FixtureBlob {
+    FixtureBlob::new(
+        OCI_CONFIG_MEDIA_TYPE,
+        serde_json::to_vec(&serde_json::json!({
+            "architecture": "amd64",
+            "os": "linux",
+            "rootfs": {
+                "type": "layers",
+                "diff_ids": diff_ids.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            },
+        }))
+        .expect("serialize image configuration"),
+    )
+}
+
+async fn gzip(bytes: &[u8]) -> Vec<u8> {
+    let input = tokio::io::BufReader::new(bytes);
+    let mut encoder = GzipEncoder::new(input);
+    let mut output = Vec::new();
+    encoder
+        .read_to_end(&mut output)
+        .await
+        .expect("gzip fixture bytes");
+    output
+}
+
+async fn zstd(bytes: &[u8]) -> Vec<u8> {
+    let input = tokio::io::BufReader::new(bytes);
+    let mut encoder = ZstdEncoder::new(input);
+    let mut output = Vec::new();
+    encoder
+        .read_to_end(&mut output)
+        .await
+        .expect("zstd fixture bytes");
+    output
 }
 
 fn descriptor(media_type: &str, digest: &str, size: u64) -> serde_json::Value {
@@ -302,6 +340,88 @@ async fn assert_no_cache_artifacts(cache: &BlobCache, digest: &Sha256Digest) {
         assert!(
             !name.ends_with(".partial"),
             "failed download left partial file {name}"
+        );
+    }
+}
+
+async fn local_cached_image(
+    image_root: &Path,
+    config: FixtureBlob,
+    layers: Vec<FixtureBlob>,
+) -> CachedImageBlobs {
+    let blob_cache = BlobCache::new(image_root);
+    tokio::fs::create_dir_all(&blob_cache.root)
+        .await
+        .expect("create raw blob cache");
+    for blob in std::iter::once(&config).chain(&layers) {
+        tokio::fs::write(blob_cache.path_for(&blob.digest), &blob.bytes)
+            .await
+            .expect("write cached fixture blob");
+    }
+    let manifest = ImageManifest {
+        schema_version: 2,
+        media_type: OCI_MANIFEST_MEDIA_TYPE.to_owned(),
+        config: Descriptor {
+            media_type: config.media_type.to_owned(),
+            digest: config.digest.clone(),
+            size: config.bytes.len() as u64,
+        },
+        layers: layers
+            .iter()
+            .map(|layer| Descriptor {
+                media_type: layer.media_type.to_owned(),
+                digest: layer.digest.clone(),
+                size: layer.bytes.len() as u64,
+            })
+            .collect(),
+    };
+    CachedImageBlobs {
+        resolved: ResolvedImage {
+            digest: Sha256Digest::of_bytes(b"manifest").to_string(),
+            architecture: Architecture::X86_64,
+            single_platform: true,
+        },
+        config: CachedBlob {
+            descriptor: manifest.config.clone(),
+            path: blob_cache.path_for(&config.digest),
+        },
+        layers: manifest
+            .layers
+            .iter()
+            .cloned()
+            .map(|descriptor| CachedBlob {
+                path: blob_cache.path_for(&descriptor.digest),
+                descriptor,
+            })
+            .collect(),
+        manifest,
+    }
+}
+
+async fn assert_no_layer_artifacts(
+    cache: &LayerCache,
+    descriptor: &Descriptor,
+    diff_id: &Sha256Digest,
+) {
+    let path = cache
+        .path_for(descriptor, diff_id)
+        .expect("supported fixture media type");
+    assert!(
+        tokio::fs::metadata(&path).await.is_err(),
+        "failed decompression unexpectedly has a final cache entry"
+    );
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let mut entries = match tokio::fs::read_dir(parent).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return,
+        Err(error) => panic!("read layer cache directory: {error}"),
+    };
+    while let Some(entry) = entries.next_entry().await.expect("read layer cache entry") {
+        assert!(
+            !entry.file_name().to_string_lossy().ends_with(".partial"),
+            "failed decompression left a partial file"
         );
     }
 }
@@ -841,4 +961,477 @@ async fn an_unsupported_descriptor_digest_is_a_digest_error() {
             if algorithm == "sha512"
     ));
     assert_eq!(registry.total_blob_requests(), 0);
+}
+
+#[tokio::test]
+async fn supported_layer_media_types_produce_verified_ordered_tar_streams() {
+    let media_types = [
+        OCI_LAYER_MEDIA_TYPE,
+        OCI_LAYER_GZIP_MEDIA_TYPE,
+        OCI_LAYER_ZSTD_MEDIA_TYPE,
+        OCI_NONDISTRIBUTABLE_LAYER_MEDIA_TYPE,
+        OCI_NONDISTRIBUTABLE_LAYER_GZIP_MEDIA_TYPE,
+        OCI_NONDISTRIBUTABLE_LAYER_ZSTD_MEDIA_TYPE,
+        DOCKER_LAYER_MEDIA_TYPE,
+        DOCKER_LAYER_GZIP_MEDIA_TYPE,
+        DOCKER_FOREIGN_LAYER_GZIP_MEDIA_TYPE,
+    ];
+    let mut layers = Vec::new();
+    let mut payloads = Vec::new();
+    let mut diff_ids = Vec::new();
+    for (index, media_type) in media_types.into_iter().enumerate() {
+        let payload = format!("layer-{index}-uncompressed-tar-bytes").into_bytes();
+        let bytes = match layer_compression(media_type).expect("supported fixture media type") {
+            LayerCompression::Identity => payload.clone(),
+            LayerCompression::Gzip => gzip(&payload).await,
+            LayerCompression::Zstd => zstd(&payload).await,
+        };
+        layers.push(FixtureBlob::new(media_type, bytes));
+        diff_ids.push(Sha256Digest::of_bytes(&payload));
+        payloads.push(payload);
+    }
+    let config = config_blob(&diff_ids);
+    let registry = TestRegistry::start(
+        ordinary_manifest(&config, &layers),
+        replies(
+            &std::iter::once(config.clone())
+                .chain(layers.iter().cloned())
+                .collect::<Vec<_>>(),
+        ),
+    )
+    .await;
+    let directory = tempdir().expect("create image root");
+    let blobs = cache_image_blobs(
+        &registry.reference(),
+        Architecture::X86_64,
+        true,
+        &BlobCache::new(directory.path()),
+    )
+    .await
+    .expect("cache compressed image blobs");
+    let layer_cache = LayerCache::new(directory.path());
+
+    let unpacked = decompress_cached_layers(&blobs, &layer_cache)
+        .await
+        .expect("decompress every supported layer encoding");
+
+    assert_eq!(unpacked.len(), layers.len());
+    for (index, layer) in unpacked.iter().enumerate() {
+        assert_eq!(layer.source.descriptor.digest, layers[index].digest);
+        assert_eq!(layer.diff_id, diff_ids[index]);
+        assert_eq!(layer.size, payloads[index].len() as u64);
+        assert_eq!(
+            layer.path,
+            layer_cache
+                .path_for(&layer.source.descriptor, &layer.diff_id)
+                .unwrap()
+        );
+        assert_eq!(tokio::fs::read(&layer.path).await.unwrap(), payloads[index]);
+        assert_eq!(
+            tokio::fs::read(&layer.source.path).await.unwrap(),
+            layers[index].bytes
+        );
+        if layer_compression(media_types[index]) == Some(LayerCompression::Identity) {
+            assert_eq!(layer.source.descriptor.digest, layer.diff_id);
+        } else {
+            assert_ne!(layer.source.descriptor.digest, layer.diff_id);
+        }
+    }
+}
+
+#[tokio::test]
+async fn concatenated_gzip_members_and_zstd_frames_are_consumed_completely() {
+    let first = b"first tar segment";
+    let second = b" and second tar segment";
+    let expected = [first.as_slice(), second.as_slice()].concat();
+    for (media_type, mut bytes) in [
+        (OCI_LAYER_GZIP_MEDIA_TYPE, gzip(first).await),
+        (OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(first).await),
+    ] {
+        bytes.extend(match layer_compression(media_type).unwrap() {
+            LayerCompression::Gzip => gzip(second).await,
+            LayerCompression::Zstd => zstd(second).await,
+            LayerCompression::Identity => unreachable!(),
+        });
+        let layer = FixtureBlob::new(media_type, bytes);
+        let diff_id = Sha256Digest::of_bytes(&expected);
+        let config = config_blob(std::slice::from_ref(&diff_id));
+        let directory = tempdir().expect("create image root");
+        let image = local_cached_image(directory.path(), config, vec![layer]).await;
+
+        let unpacked = decompress_cached_layers(&image, &LayerCache::new(directory.path()))
+            .await
+            .expect("consume every gzip member or zstd frame");
+
+        assert_eq!(tokio::fs::read(&unpacked[0].path).await.unwrap(), expected);
+    }
+}
+
+#[tokio::test]
+async fn invalid_configs_fail_before_a_layer_cache_is_created() {
+    let payload = b"plain layer".to_vec();
+    let layer = FixtureBlob::new(OCI_LAYER_MEDIA_TYPE, payload.clone());
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let cases = [
+        ("malformed", b"{".to_vec()),
+        (
+            "rootfs type",
+            serde_json::to_vec(&serde_json::json!({
+                "rootfs": { "type": "unknown", "diff_ids": [diff_id.to_string()] }
+            }))
+            .unwrap(),
+        ),
+        (
+            "count",
+            serde_json::to_vec(&serde_json::json!({
+                "rootfs": { "type": "layers", "diff_ids": [] }
+            }))
+            .unwrap(),
+        ),
+        (
+            "digest",
+            serde_json::to_vec(&serde_json::json!({
+                "rootfs": { "type": "layers", "diff_ids": [format!("sha512:{}", "a".repeat(64))] }
+            }))
+            .unwrap(),
+        ),
+    ];
+
+    for (kind, bytes) in cases {
+        let directory = tempdir().expect("create image root");
+        let config = FixtureBlob::new(OCI_CONFIG_MEDIA_TYPE, bytes);
+        let image = local_cached_image(directory.path(), config, vec![layer.clone()]).await;
+        let cache = LayerCache::new(directory.path());
+
+        let error = decompress_cached_layers(&image, &cache)
+            .await
+            .expect_err("invalid config must fail before decompression");
+
+        match kind {
+            "rootfs type" => assert!(matches!(error, ResolveError::UnsupportedRootfsType(_))),
+            "count" => assert!(matches!(
+                error,
+                ResolveError::DiffIdCountMismatch {
+                    expected: 1,
+                    actual: 0
+                }
+            )),
+            _ => assert!(matches!(error, ResolveError::MalformedConfig(_))),
+        }
+        assert!(tokio::fs::metadata(&cache.root).await.is_err());
+    }
+}
+
+#[tokio::test]
+async fn an_unsupported_layer_media_type_fails_before_output() {
+    let payload = b"unknown encoding".to_vec();
+    let layer = FixtureBlob::new("application/vnd.example.layer+unknown", payload.clone());
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let config = config_blob(std::slice::from_ref(&diff_id));
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, vec![layer]).await;
+    let cache = LayerCache::new(directory.path());
+
+    let error = decompress_cached_layers(&image, &cache)
+        .await
+        .expect_err("unknown layer encoding must be rejected");
+
+    assert!(matches!(error, ResolveError::UnsupportedMediaType(_)));
+    assert!(tokio::fs::metadata(&cache.root).await.is_err());
+}
+
+#[tokio::test]
+async fn a_diff_id_mismatch_preserves_the_compressed_blob_and_leaves_no_output() {
+    let payload = b"actual uncompressed bytes".to_vec();
+    let layer = FixtureBlob::new(OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await);
+    let wrong_diff_id = Sha256Digest::of_bytes(b"different uncompressed bytes");
+    let config = config_blob(std::slice::from_ref(&wrong_diff_id));
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, vec![layer.clone()]).await;
+    let cache = LayerCache::new(directory.path());
+
+    let error = decompress_cached_layers(&image, &cache)
+        .await
+        .expect_err("wrong config diff ID must fail");
+
+    assert!(matches!(
+        error,
+        ResolveError::DiffIdMismatch {
+            compressed_digest,
+            expected,
+            ..
+        } if compressed_digest == layer.digest && expected == wrong_diff_id
+    ));
+    assert_no_layer_artifacts(&cache, &image.layers[0].descriptor, &wrong_diff_id).await;
+    assert_eq!(
+        tokio::fs::read(&image.layers[0].path).await.unwrap(),
+        layer.bytes
+    );
+}
+
+#[tokio::test]
+async fn the_exact_compressed_stream_is_verified_while_it_is_decoded() {
+    let payload = b"unchanged decoder output".to_vec();
+    let layer = FixtureBlob::new(OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await);
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let config = config_blob(std::slice::from_ref(&diff_id));
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, vec![layer.clone()]).await;
+    let mut changed_header = layer.bytes.clone();
+    assert_eq!(&changed_header[..3], &[0x1f, 0x8b, 0x08]);
+    changed_header[4] ^= 1; // gzip mtime: metadata that does not affect decoder output
+    assert_ne!(Sha256Digest::of_bytes(&changed_header), layer.digest);
+    tokio::fs::write(&image.layers[0].path, &changed_header)
+        .await
+        .expect("replace cached blob after its earlier verification");
+    let cache = LayerCache::new(directory.path());
+
+    let error = decompress_cached_layers(&image, &cache)
+        .await
+        .expect_err("the decoder must verify its exact compressed input");
+
+    assert!(matches!(
+        error,
+        ResolveError::DigestMismatch {
+            expected,
+            actual,
+            ..
+        } if expected == layer.digest && actual == Sha256Digest::of_bytes(&changed_header)
+    ));
+    assert_no_layer_artifacts(&cache, &image.layers[0].descriptor, &diff_id).await;
+}
+
+#[tokio::test]
+async fn truncated_gzip_and_zstd_layers_leave_no_output_or_partial() {
+    let payload = b"payload whose codec checksum must be verified".to_vec();
+    for (media_type, mut bytes) in [
+        (OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await),
+        (OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(&payload).await),
+    ] {
+        bytes.truncate(bytes.len().saturating_sub(4));
+        let layer = FixtureBlob::new(media_type, bytes);
+        let diff_id = Sha256Digest::of_bytes(&payload);
+        let config = config_blob(std::slice::from_ref(&diff_id));
+        let directory = tempdir().expect("create image root");
+        let image = local_cached_image(directory.path(), config, vec![layer]).await;
+        let cache = LayerCache::new(directory.path());
+
+        let error = decompress_cached_layers(&image, &cache)
+            .await
+            .expect_err("truncated compressed stream must fail");
+
+        assert!(matches!(error, ResolveError::Decompression { .. }));
+        assert_no_layer_artifacts(&cache, &image.layers[0].descriptor, &diff_id).await;
+    }
+}
+
+#[tokio::test]
+async fn trailing_bytes_after_gzip_and_zstd_streams_are_rejected() {
+    let payload = b"complete payload".to_vec();
+    for (media_type, mut bytes) in [
+        (OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await),
+        (OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(&payload).await),
+    ] {
+        bytes.extend_from_slice(b"not another valid member");
+        let layer = FixtureBlob::new(media_type, bytes);
+        let diff_id = Sha256Digest::of_bytes(&payload);
+        let config = config_blob(std::slice::from_ref(&diff_id));
+        let directory = tempdir().expect("create image root");
+        let image = local_cached_image(directory.path(), config, vec![layer]).await;
+        let cache = LayerCache::new(directory.path());
+
+        let error = decompress_cached_layers(&image, &cache)
+            .await
+            .expect_err("trailing non-frame bytes must fail");
+
+        assert!(matches!(error, ResolveError::Decompression { .. }));
+        assert_no_layer_artifacts(&cache, &image.layers[0].descriptor, &diff_id).await;
+    }
+}
+
+#[tokio::test]
+async fn decoded_output_limit_is_inclusive_and_cleans_an_oversized_partial() {
+    let payload = b"ten bytes!".to_vec();
+    assert_eq!(payload.len(), 10);
+    let layer = FixtureBlob::new(OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await);
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let config = config_blob(std::slice::from_ref(&diff_id));
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, vec![layer]).await;
+    let too_small = LayerCache::with_max_uncompressed_layer_bytes(directory.path(), 9);
+
+    let error = decompress_cached_layers(&image, &too_small)
+        .await
+        .expect_err("decoded output over the limit must fail");
+
+    assert!(matches!(
+        error,
+        ResolveError::UncompressedLayerTooLarge {
+            limit: 9,
+            actual: 10,
+            ..
+        }
+    ));
+    assert_no_layer_artifacts(&too_small, &image.layers[0].descriptor, &diff_id).await;
+
+    let exact = LayerCache::with_max_uncompressed_layer_bytes(directory.path(), 10);
+    let unpacked = decompress_cached_layers(&image, &exact)
+        .await
+        .expect("the decoded output limit is inclusive");
+    assert_eq!(tokio::fs::read(&unpacked[0].path).await.unwrap(), payload);
+}
+
+#[tokio::test]
+async fn a_verified_layer_hit_survives_source_removal_and_corruption_is_rebuilt() {
+    let payload = b"cached uncompressed tar stream".to_vec();
+    let layer = FixtureBlob::new(OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await);
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let config = config_blob(std::slice::from_ref(&diff_id));
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, vec![layer.clone()]).await;
+    let cache = LayerCache::new(directory.path());
+
+    let first = decompress_cached_layers(&image, &cache)
+        .await
+        .expect("populate decoded layer cache");
+    tokio::fs::remove_file(&image.layers[0].path)
+        .await
+        .expect("remove compressed source");
+    let hit = decompress_cached_layers(&image, &cache)
+        .await
+        .expect("reuse a verified decoded cache entry");
+    assert_eq!(hit[0].path, first[0].path);
+
+    tokio::fs::write(&image.layers[0].path, &layer.bytes)
+        .await
+        .expect("restore compressed source");
+    tokio::fs::write(&first[0].path, vec![b'x'; payload.len()])
+        .await
+        .expect("corrupt decoded cache entry without changing its size");
+    let repaired = decompress_cached_layers(&image, &cache)
+        .await
+        .expect("rebuild a corrupt decoded cache entry");
+    assert_eq!(tokio::fs::read(&repaired[0].path).await.unwrap(), payload);
+}
+
+#[tokio::test]
+async fn identical_diff_ids_keep_distinct_compressed_relationships() {
+    let payload = b"one tar stream encoded two ways".to_vec();
+    let gzip_layer = FixtureBlob::new(OCI_LAYER_GZIP_MEDIA_TYPE, gzip(&payload).await);
+    let zstd_layer = FixtureBlob::new(OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(&payload).await);
+    let diff_id = Sha256Digest::of_bytes(&payload);
+    let config = config_blob(&[diff_id.clone(), diff_id.clone(), diff_id.clone()]);
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(
+        directory.path(),
+        config,
+        vec![gzip_layer.clone(), zstd_layer.clone(), gzip_layer],
+    )
+    .await;
+
+    let layers = decompress_cached_layers(&image, &LayerCache::new(directory.path()))
+        .await
+        .expect("verify both compressed relationships");
+
+    assert_eq!(
+        layers
+            .iter()
+            .map(|layer| &layer.diff_id)
+            .collect::<Vec<_>>(),
+        vec![&diff_id; 3]
+    );
+    assert_eq!(layers[0].path, layers[2].path);
+    assert_ne!(layers[0].path, layers[1].path);
+    assert_ne!(
+        layers[0].source.descriptor.digest,
+        layers[1].source.descriptor.digest
+    );
+    for layer in layers {
+        assert_eq!(tokio::fs::read(layer.path).await.unwrap(), payload);
+    }
+}
+
+#[tokio::test]
+async fn an_image_without_layers_accepts_an_empty_diff_id_list() {
+    let config = config_blob(&[]);
+    let directory = tempdir().expect("create image root");
+    let image = local_cached_image(directory.path(), config, Vec::new()).await;
+
+    let layers = decompress_cached_layers(&image, &LayerCache::new(directory.path()))
+        .await
+        .expect("empty images have no layer work");
+
+    assert!(layers.is_empty());
+}
+
+#[test]
+fn decompression_parallelism_has_a_separate_memory_bound() {
+    assert_eq!(decompression_parallelism(0), 1);
+    assert_eq!(decompression_parallelism(1), 1);
+    assert_eq!(decompression_parallelism(2), 2);
+    assert_eq!(decompression_parallelism(64), MAX_PARALLEL_DECOMPRESSIONS);
+}
+
+#[tokio::test]
+async fn concurrent_calls_share_the_process_wide_decompression_permits() {
+    let permits = shared_decompression_permits();
+    let held = Arc::clone(&permits)
+        .acquire_many_owned(MAX_PARALLEL_DECOMPRESSIONS as u32)
+        .await
+        .expect("the shared semaphore stays open");
+
+    let first_directory = tempdir().expect("create first image root");
+    let first_payload = b"first concurrent zstd layer".to_vec();
+    let first_diff_id = Sha256Digest::of_bytes(&first_payload);
+    let first_layer = FixtureBlob::new(OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(&first_payload).await);
+    let first_image = local_cached_image(
+        first_directory.path(),
+        config_blob(std::slice::from_ref(&first_diff_id)),
+        vec![first_layer],
+    )
+    .await;
+    let first_cache = LayerCache::new(first_directory.path());
+
+    let second_directory = tempdir().expect("create second image root");
+    let second_payload = b"second concurrent zstd layer".to_vec();
+    let second_diff_id = Sha256Digest::of_bytes(&second_payload);
+    let second_layer = FixtureBlob::new(OCI_LAYER_ZSTD_MEDIA_TYPE, zstd(&second_payload).await);
+    let second_image = local_cached_image(
+        second_directory.path(),
+        config_blob(std::slice::from_ref(&second_diff_id)),
+        vec![second_layer],
+    )
+    .await;
+    let second_cache = LayerCache::new(second_directory.path());
+    assert!(Arc::ptr_eq(&first_cache.decompression_permits, &permits));
+    assert!(Arc::ptr_eq(&second_cache.decompression_permits, &permits));
+
+    let mut first = Box::pin(decompress_cached_layers(&first_image, &first_cache));
+    let mut second = Box::pin(decompress_cached_layers(&second_image, &second_cache));
+    let early_completion = tokio::time::timeout(Duration::from_millis(20), async {
+        tokio::select! {
+            result = &mut first => result,
+            result = &mut second => result,
+        }
+    })
+    .await;
+    assert!(
+        early_completion.is_err(),
+        "neither independent call may decode while all global permits are held"
+    );
+
+    drop(held);
+    let (first_result, second_result) = tokio::join!(first, second);
+    assert_eq!(
+        tokio::fs::read(&first_result.unwrap()[0].path)
+            .await
+            .unwrap(),
+        first_payload
+    );
+    assert_eq!(
+        tokio::fs::read(&second_result.unwrap()[0].path)
+            .await
+            .unwrap(),
+        second_payload
+    );
 }

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -28,8 +28,8 @@ populates the blob cache.
 
 Internal OCI pulls cache image configs and layers by their SHA-256 digest at
 `<FIRECRAB_IMAGE_ROOT>/.oci/blobs/sha256/<hex>`.
-Entries contain the raw bytes returned by the registry; they are not unpacked
-or merged into a root filesystem.
+Entries contain the raw bytes returned by the registry and are never replaced
+with decompressed data.
 
 Every cache lookup streams the complete entry and verifies both its expected
 size and SHA-256 digest before reuse. A corrupt entry is discarded and fetched
@@ -37,6 +37,25 @@ again, and a download becomes visible at its final path only after the same
 checks succeed.
 One config or layer download is limited to 16 GiB by default; operators can
 change this with `FIRECRAB_OCI_MAX_BLOB_BYTES`.
+
+## Layer decompression
+
+The internal import pipeline decompresses plain, gzip, and zstd layer streams
+into `.oci/layers/sha256/<diff-id>/<compressed-digest>.<codec>.tar`.
+Each result keeps the manifest descriptor, whose digest covers the registry
+bytes, separate from the matching config `rootfs.diff_ids` entry, whose digest
+covers the uncompressed tar stream.
+
+The decoder streams output while calculating that diff ID and publishes a tar
+only after it matches. Cache hits are rehashed, corrupt entries are rebuilt
+from the verified blob, and failed work leaves no partial tar. Decoder output
+is limited to 64 GiB per layer by default; change it with
+`FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`. At most two layer decoders run
+process-wide, and each zstd decoder has a 128 MiB window limit.
+
+Tar member validation, extraction, whiteout handling, and layer merging remain
+separate import stages. Inspect does not run decompression or fill either OCI
+cache.
 
 ## Related
 

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -42,6 +42,7 @@ systemctl restart firecrab-api
 | `FIRECRAB_IMAGE_ROOT` | Installed image path | Kernels and rootfs files |
 | `FIRECRAB_IMAGE_BASE_URL` | Public MicroRegistry | Image package base URL; `none` disables remote installs |
 | `FIRECRAB_OCI_MAX_BLOB_BYTES` | 16 GiB | Maximum compressed size of one downloaded OCI config or layer blob |
+| `FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES` | 64 GiB | Maximum decoded size of one OCI layer tar stream |
 | `FIRECRAB_STATIC_ROOT` | Installed dashboard | Static UI path |
 | `FIRECRAB_STORAGE_ROOTS` | `default=data` | Fixed storage roots |
 | `FIRECRAB_NET_HELPER_SOCK` | `/run/firecrab/net-helper.sock` | Helper socket |

--- a/public-docs/storage.md
+++ b/public-docs/storage.md
@@ -27,6 +27,7 @@ MicroVM control-plane records and VM filesystem artifacts have separate storage 
     .templates.json              # persisted runtime template registrations
     .microboot/                  # Alpine netboot kernel, initramfs, and placeholder disk
     .oci/blobs/sha256/<hex>       # verified raw OCI config and layer blobs
+    .oci/layers/sha256/<diff-id>/ # verified uncompressed layer tar streams
     .packages/                   # staged M2Image archives and origin markers
     kernel/
     rootfs/
@@ -39,7 +40,7 @@ It is the writable ext4 file under the selected storage root's `vms/<vm-id>/d/` 
 The `images/` directory is the default `FIRECRAB_IMAGE_ROOT` and contains immutable source templates used when preparing new VM disks.
 Replacing a source image does not modify a VM disk that was already prepared.
 Temporary download, package-build, and bootstrap scratch files can also appear under `.packages/` while a job is running or after an interrupted job.
-OCI config and layer blobs are stored as raw registry bytes under `.oci/blobs/sha256/`; every cache hit is re-verified against its expected size and SHA-256 digest.
+OCI config and layer blobs stay as raw registry bytes under `.oci/blobs/sha256/`; verified tar streams stay separately under `.oci/layers/sha256/`, retaining both the uncompressed config diff ID and compressed manifest digest. Both caches rehash entries before reuse.
 `GET /api/oci/inspect` reads metadata only and does not populate this cache.
 
 Other installed and runtime files live outside `/var/lib/firecrab`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added OCI layer decompression for gzip, Zstandard, and uncompressed layers.
  - Added integrity verification using compressed and uncompressed digests.
  - Added configurable decoded-layer size limits and controlled decompression concurrency.
  - Added automatic recovery and reuse of validated layer cache entries.

- **Bug Fixes**
  - Improved handling of malformed configurations, unsupported formats, corrupted data, mismatched digests, truncated layers, and oversized output.

- **Documentation**
  - Documented OCI decompression, cache behavior, integrity checks, storage locations, and the new size-limit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->