### PR TITLE
Validate OCI layer archives (#90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +313,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1641,6 +1652,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
 ]
 
 [[package]]

--- a/firecrab-api/Cargo.toml
+++ b/firecrab-api/Cargo.toml
@@ -17,6 +17,7 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+tar = { version = "0.4.46", default-features = false }
 thiserror = { workspace = true }
 tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors", "fs"] }

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::io;
+use std::io::{self, Read as _, Seek as _};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
@@ -567,6 +567,10 @@ const ZSTD_MAX_WINDOW_LOG: u32 = 27;
 /// may retain a 128 MiB window. Keeping at most two active bounds those windows
 /// to 256 MiB instead of multiplying them by a many-core host's CPU count.
 const MAX_PARALLEL_DECOMPRESSIONS: usize = 2;
+/// GNU long-name and PAX records are buffered by the tar parser. Real
+/// filesystem metadata is far smaller; this ceiling prevents a crafted layer
+/// from turning an otherwise streamed preflight into an unbounded allocation.
+const TAR_METADATA_MAX_BYTES: u64 = 1024 * 1024;
 
 /// What a reference resolved to on this host.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -681,6 +685,25 @@ pub enum ResolveError {
         limit: u64,
         /// Size observed from metadata or while streaming.
         actual: u64,
+    },
+    /// A verified layer is not a structurally readable tar stream.
+    #[error("OCI layer {compressed_digest} is not a readable tar archive: {message}")]
+    MalformedLayerArchive {
+        /// Manifest digest of the compressed registry blob.
+        compressed_digest: Sha256Digest,
+        /// Tar parser or truncated-payload failure.
+        message: String,
+    },
+    /// A tar entry could write outside the future extraction root or create an
+    /// unsupported filesystem object.
+    #[error("unsafe tar member {path:?} in OCI layer {compressed_digest}: {reason}")]
+    UnsafeTarMember {
+        /// Manifest digest of the compressed registry blob.
+        compressed_digest: Sha256Digest,
+        /// Effective entry path after GNU and PAX metadata is applied.
+        path: PathBuf,
+        /// Safety rule rejected by the entry.
+        reason: TarMemberViolation,
     },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
@@ -1659,6 +1682,9 @@ fn cache_io(operation: &'static str, path: PathBuf, source: io::Error) -> Resolv
 #[cfg(test)]
 mod cache_tests;
 
+#[cfg(test)]
+mod tar_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2027,6 +2053,80 @@ pub struct DecompressedLayer {
     pub size: u64,
 }
 
+/// A decompressed layer whose complete tar metadata passed the import safety
+/// preflight.
+///
+/// The wrapper is deliberately distinct from [`DecompressedLayer`] so future
+/// extraction and merge stages can require proof that validation ran first.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedLayer {
+    layer: DecompressedLayer,
+}
+
+impl ValidatedLayer {
+    /// Original cached registry bytes and their manifest descriptor.
+    pub fn source(&self) -> &CachedBlob {
+        &self.layer.source
+    }
+
+    /// Digest of the uncompressed tar stream from config `rootfs.diff_ids`.
+    pub fn diff_id(&self) -> &Sha256Digest {
+        &self.layer.diff_id
+    }
+
+    /// Path of the validated, uncompressed layer tar.
+    pub fn path(&self) -> &Path {
+        &self.layer.path
+    }
+
+    /// Number of bytes in the validated tar stream.
+    pub fn size(&self) -> u64 {
+        self.layer.size
+    }
+}
+
+/// Why an otherwise valid layer tar entry is unsafe for later extraction.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum TarMemberViolation {
+    /// The member name is empty, absolute, or contains a parent/root/prefix
+    /// component.
+    #[error("member path must be a non-empty relative path beneath the extraction root")]
+    Path,
+    /// Character and block devices are never imported from an OCI layer.
+    #[error("device nodes are not permitted")]
+    DeviceNode,
+    /// Only regular files, directories, symbolic links, and hard links are
+    /// supported by the MVP extraction contract.
+    #[error("tar entry type 0x{entry_type:02x} is not permitted")]
+    UnsupportedEntryType {
+        /// Raw tar typeflag byte.
+        entry_type: u8,
+    },
+    /// A hard link did not identify the archive member it aliases.
+    #[error("hard link target is missing")]
+    MissingHardlinkTarget,
+    /// A symbolic link did not identify the path stored in the link.
+    #[error("symbolic link target is missing")]
+    MissingSymlinkTarget,
+    /// A symbolic link target cannot be represented by filesystem APIs.
+    #[error("symbolic link target contains a NUL byte")]
+    InvalidSymlinkTarget,
+    /// Tar hard-link names are archive-root-relative and cannot leave that
+    /// root.
+    #[error("hard link target {target:?} is outside the archive root")]
+    HardlinkTarget {
+        /// Unsafe target recorded in the tar header or extension metadata.
+        target: PathBuf,
+    },
+    /// A PAX attribute is unsupported because different tar parsers can apply
+    /// it to a different path, link, or payload boundary.
+    #[error("unsupported PAX attribute {key:?}")]
+    UnsupportedPaxAttribute {
+        /// Attribute name supplied by the archive.
+        key: String,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct LayerWorkKey {
     compressed_digest: Sha256Digest,
@@ -2117,6 +2217,608 @@ async fn decompress_cached_layers_with_parallelism(
             }
         })
         .collect())
+}
+
+/// Validates every decompressed layer tar before any extraction may begin.
+///
+/// Validation reads the effective GNU/PAX member paths, rejects member names
+/// and hard-link targets that leave an archive root, and permits only regular
+/// files, directories, symbolic links, and archive-root-confined hard links.
+/// Symbolic links remain inert at this stage; the later extractor must not
+/// follow one while creating another member. The input content-addressed tar
+/// remains cached when validation fails: unsafe contents do not make a
+/// correctly hashed cache entry corrupt.
+///
+/// Repeated manifest entries that resolve to the same cache path are scanned
+/// once, while the returned wrappers retain manifest order and multiplicity.
+pub async fn validate_decompressed_layers(
+    layers: Vec<DecompressedLayer>,
+) -> Result<Vec<ValidatedLayer>, ResolveError> {
+    let mut validated_paths = std::collections::HashSet::new();
+    for layer in &layers {
+        if validated_paths.insert(layer.path.clone()) {
+            validate_layer_archive(layer).await?;
+        }
+    }
+    Ok(layers
+        .into_iter()
+        .map(|layer| ValidatedLayer { layer })
+        .collect())
+}
+
+async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {
+    let path = layer.path.clone();
+    let compressed_digest = layer.source.descriptor.digest.clone();
+    let task_digest = compressed_digest.clone();
+    tokio::task::spawn_blocking(move || validate_layer_archive_blocking(&path, &task_digest))
+        .await
+        .map_err(|error| ResolveError::MalformedLayerArchive {
+            compressed_digest,
+            message: format!("validation task failed: {error}"),
+        })?
+}
+
+fn validate_layer_archive_blocking(
+    path: &Path,
+    compressed_digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
+    let file = std::fs::File::open(path)
+        .map_err(|error| cache_io("open layer tar", path.to_owned(), error))?;
+    let file_len = file
+        .metadata()
+        .map_err(|error| cache_io("inspect layer tar", path.to_owned(), error))?
+        .len();
+    if file_len % 512 != 0 {
+        return Err(malformed_layer_archive(
+            compressed_digest,
+            format!("archive length {file_len} is not a multiple of the 512-byte tar block size"),
+        ));
+    }
+    let mut archive = tar::Archive::new(file);
+    let raw_last_end = validate_raw_tar_metadata(&mut archive, file_len, compressed_digest)?;
+    let mut file = archive.into_inner();
+    validate_tar_terminator(&mut file, raw_last_end, file_len, compressed_digest)?;
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| cache_io("rewind layer tar", path.to_owned(), error))?;
+    let mut archive = tar::Archive::new(file);
+    let entries = archive
+        .entries()
+        .map_err(|error| malformed_layer_archive(compressed_digest, error))?;
+
+    let mut semantic_last_end = 0;
+    for (index, entry) in entries.enumerate() {
+        let mut entry = entry.map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("could not read member {}: {error}", index + 1),
+            )
+        })?;
+        let entry_type = entry.header().entry_type();
+        let mut pax_linkpaths = Vec::new();
+        if let Some(extensions) = entry.pax_extensions().map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("could not read member {} PAX metadata: {error}", index + 1),
+            )
+        })? {
+            for extension in extensions {
+                let extension = extension.map_err(|error| {
+                    malformed_layer_archive(
+                        compressed_digest,
+                        format!("member {} has malformed PAX metadata: {error}", index + 1),
+                    )
+                })?;
+                if extension.key_bytes() == b"linkpath" {
+                    pax_linkpaths.push(extension.value_bytes().to_vec());
+                }
+            }
+        }
+
+        semantic_last_end = tar_entry_end(&entry, file_len, compressed_digest, index + 1)?;
+        if entry_type.is_pax_global_extensions() {
+            // The raw pass already parsed and restricted the global records.
+            // tar-rs deliberately does not apply them; the remaining allowed
+            // attributes cannot affect path, link, size, or entry type.
+            continue;
+        }
+        let member_path = entry
+            .path()
+            .map_err(|error| {
+                malformed_layer_archive(
+                    compressed_digest,
+                    format!("could not decode member {} path: {error}", index + 1),
+                )
+            })?
+            .into_owned();
+        if !is_safe_layer_member_path(&member_path) {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::Path,
+            ));
+        }
+        if entry_type.is_character_special() || entry_type.is_block_special() {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::DeviceNode,
+            ));
+        }
+        if entry_type.is_hard_link() {
+            for target in pax_linkpaths {
+                if !is_safe_layer_member_bytes(&target) {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        member_path,
+                        TarMemberViolation::HardlinkTarget {
+                            target: PathBuf::from(String::from_utf8_lossy(&target).into_owned()),
+                        },
+                    ));
+                }
+            }
+            let target = entry
+                .link_name()
+                .map_err(|error| {
+                    malformed_layer_archive(
+                        compressed_digest,
+                        format!(
+                            "could not decode hard link target for member {}: {error}",
+                            index + 1
+                        ),
+                    )
+                })?
+                .map(|target| target.into_owned())
+                .ok_or_else(|| {
+                    unsafe_tar_member(
+                        compressed_digest,
+                        member_path.clone(),
+                        TarMemberViolation::MissingHardlinkTarget,
+                    )
+                })?;
+            if target.as_os_str().is_empty() {
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    member_path,
+                    TarMemberViolation::MissingHardlinkTarget,
+                ));
+            }
+            if !is_safe_layer_member_path(&target) {
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    member_path,
+                    TarMemberViolation::HardlinkTarget { target },
+                ));
+            }
+        } else if entry_type.is_symlink() {
+            for target in pax_linkpaths {
+                if target.is_empty() {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        member_path,
+                        TarMemberViolation::MissingSymlinkTarget,
+                    ));
+                }
+                if target.contains(&0) {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        member_path,
+                        TarMemberViolation::InvalidSymlinkTarget,
+                    ));
+                }
+            }
+            let target = entry
+                .link_name()
+                .map_err(|error| {
+                    malformed_layer_archive(
+                        compressed_digest,
+                        format!(
+                            "could not decode symbolic link target for member {}: {error}",
+                            index + 1
+                        ),
+                    )
+                })?
+                .map(|target| target.into_owned())
+                .ok_or_else(|| {
+                    unsafe_tar_member(
+                        compressed_digest,
+                        member_path.clone(),
+                        TarMemberViolation::MissingSymlinkTarget,
+                    )
+                })?;
+            if target.as_os_str().is_empty() {
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    member_path,
+                    TarMemberViolation::MissingSymlinkTarget,
+                ));
+            }
+            if target.as_os_str().as_encoded_bytes().contains(&0) {
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    member_path,
+                    TarMemberViolation::InvalidSymlinkTarget,
+                ));
+            }
+            // Absolute and parent-relative symbolic links are ordinary inside
+            // container root filesystems. They are safe only while inert; the
+            // later extractor must never follow a link while creating another
+            // member beneath the staging root.
+            drop(target);
+        } else if !entry_type.is_file() && !entry_type.is_dir() && !entry_type.is_symlink() {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::UnsupportedEntryType {
+                    entry_type: entry_type.as_byte(),
+                },
+            ));
+        }
+
+        let expected = entry.size();
+        let actual = io::copy(&mut entry, &mut io::sink()).map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("could not read member {} payload: {error}", index + 1),
+            )
+        })?;
+        if actual != expected {
+            return Err(malformed_layer_archive(
+                compressed_digest,
+                format!(
+                    "member {} payload is truncated: expected {expected} bytes, got {actual}",
+                    index + 1
+                ),
+            ));
+        }
+    }
+    let mut file = archive.into_inner();
+    validate_tar_terminator(&mut file, semantic_last_end, file_len, compressed_digest)
+}
+
+fn validate_raw_tar_metadata(
+    archive: &mut tar::Archive<std::fs::File>,
+    file_len: u64,
+    compressed_digest: &Sha256Digest,
+) -> Result<u64, ResolveError> {
+    let entries = archive
+        .entries_with_seek()
+        .map_err(|error| malformed_layer_archive(compressed_digest, error))?
+        .raw(true);
+    let mut last_end = 0;
+    for (index, entry) in entries.enumerate() {
+        let mut entry = entry.map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("could not inspect raw member {}: {error}", index + 1),
+            )
+        })?;
+        let entry_type = entry.header().entry_type();
+        last_end = tar_entry_end(&entry, file_len, compressed_digest, index + 1)?;
+        if entry_type.is_gnu_sparse() {
+            let path = entry
+                .path()
+                .map(|path| path.into_owned())
+                .unwrap_or_else(|_| PathBuf::from("<GNU sparse member>"));
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                path,
+                TarMemberViolation::UnsupportedEntryType { entry_type: b'S' },
+            ));
+        }
+        let buffers_metadata = entry_type.is_gnu_longname()
+            || entry_type.is_gnu_longlink()
+            || entry_type.is_pax_local_extensions()
+            || entry_type.is_pax_global_extensions();
+        if buffers_metadata && entry.size() > TAR_METADATA_MAX_BYTES {
+            return Err(malformed_layer_archive(
+                compressed_digest,
+                format!(
+                    "member {} declares {} bytes of tar metadata, exceeding the {}-byte limit",
+                    index + 1,
+                    entry.size(),
+                    TAR_METADATA_MAX_BYTES
+                ),
+            ));
+        }
+        if entry_type.is_pax_local_extensions() || entry_type.is_pax_global_extensions() {
+            validate_pax_metadata(
+                &mut entry,
+                entry_type.is_pax_global_extensions(),
+                compressed_digest,
+                index + 1,
+            )?;
+        }
+        if buffers_metadata {
+            continue;
+        }
+
+        let member_path = entry
+            .path()
+            .map_err(|error| {
+                malformed_layer_archive(
+                    compressed_digest,
+                    format!("could not decode raw member {} path: {error}", index + 1),
+                )
+            })?
+            .into_owned();
+        if !is_safe_layer_member_path(&member_path) {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::Path,
+            ));
+        }
+        if entry_type.is_character_special() || entry_type.is_block_special() {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::DeviceNode,
+            ));
+        }
+        if entry_type.is_hard_link() {
+            if let Some(target) = entry
+                .link_name()
+                .map_err(|error| {
+                    malformed_layer_archive(
+                        compressed_digest,
+                        format!(
+                            "could not decode raw hard link target for member {}: {error}",
+                            index + 1
+                        ),
+                    )
+                })?
+                .map(|target| target.into_owned())
+                && !is_safe_layer_member_path(&target)
+            {
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    member_path,
+                    TarMemberViolation::HardlinkTarget { target },
+                ));
+            }
+        } else if !entry_type.is_file() && !entry_type.is_dir() && !entry_type.is_symlink() {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                member_path,
+                TarMemberViolation::UnsupportedEntryType {
+                    entry_type: entry_type.as_byte(),
+                },
+            ));
+        }
+    }
+    Ok(last_end)
+}
+
+fn validate_pax_metadata<R: io::Read>(
+    entry: &mut tar::Entry<'_, R>,
+    global: bool,
+    compressed_digest: &Sha256Digest,
+    index: usize,
+) -> Result<(), ResolveError> {
+    let metadata_path = entry
+        .path()
+        .map(|path| path.into_owned())
+        .unwrap_or_else(|_| PathBuf::from("<PAX metadata>"));
+    let extensions = entry
+        .pax_extensions()
+        .map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("could not read raw member {index} PAX metadata: {error}"),
+            )
+        })?
+        .expect("the caller passes only PAX extension entries");
+    let mut security_keys = std::collections::HashSet::new();
+    for extension in extensions {
+        let extension = extension.map_err(|error| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("raw member {index} has malformed PAX metadata: {error}"),
+            )
+        })?;
+        let key = extension.key_bytes();
+        let value = extension.value_bytes();
+        if key.starts_with(b"GNU.sparse.") {
+            return Err(unsafe_tar_member(
+                compressed_digest,
+                metadata_path,
+                TarMemberViolation::UnsupportedPaxAttribute {
+                    key: String::from_utf8_lossy(key).into_owned(),
+                },
+            ));
+        }
+        if matches!(key, b"path" | b"linkpath" | b"size") && !security_keys.insert(key.to_vec()) {
+            return Err(malformed_layer_archive(
+                compressed_digest,
+                format!(
+                    "raw member {index} repeats security-sensitive PAX key {:?}",
+                    String::from_utf8_lossy(key)
+                ),
+            ));
+        }
+        match key {
+            b"path" => {
+                if global {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        metadata_path,
+                        TarMemberViolation::UnsupportedPaxAttribute {
+                            key: "path".to_owned(),
+                        },
+                    ));
+                }
+                if !is_safe_layer_member_bytes(value) {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        PathBuf::from(String::from_utf8_lossy(value).into_owned()),
+                        TarMemberViolation::Path,
+                    ));
+                }
+            }
+            b"linkpath" => {
+                if global {
+                    return Err(unsafe_tar_member(
+                        compressed_digest,
+                        metadata_path,
+                        TarMemberViolation::UnsupportedPaxAttribute {
+                            key: "linkpath".to_owned(),
+                        },
+                    ));
+                }
+            }
+            b"size" => {
+                // The raw safety pass must know each payload boundary before
+                // the semantic parser allocates GNU/PAX buffers. tar-rs raw
+                // iteration intentionally ignores PAX size overrides, so
+                // accepting one would create a parser differential capable of
+                // hiding a following header inside file data.
+                return Err(unsafe_tar_member(
+                    compressed_digest,
+                    metadata_path,
+                    TarMemberViolation::UnsupportedPaxAttribute {
+                        key: "size".to_owned(),
+                    },
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn tar_entry_end<R: io::Read>(
+    entry: &tar::Entry<'_, R>,
+    file_len: u64,
+    compressed_digest: &Sha256Digest,
+    index: usize,
+) -> Result<u64, ResolveError> {
+    let padded_size = entry
+        .size()
+        .checked_add(511)
+        .map(|size| size / 512 * 512)
+        .ok_or_else(|| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("member {index} size overflows the tar block calculation"),
+            )
+        })?;
+    let end = entry
+        .raw_file_position()
+        .checked_add(padded_size)
+        .ok_or_else(|| {
+            malformed_layer_archive(
+                compressed_digest,
+                format!("member {index} end offset overflows"),
+            )
+        })?;
+    if end > file_len {
+        return Err(malformed_layer_archive(
+            compressed_digest,
+            format!(
+                "member {index} extends beyond the archive: padded end {end}, file length {file_len}"
+            ),
+        ));
+    }
+    Ok(end)
+}
+
+fn validate_tar_terminator(
+    file: &mut std::fs::File,
+    last_entry_end: u64,
+    file_len: u64,
+    compressed_digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
+    let trailing = file_len.checked_sub(last_entry_end).ok_or_else(|| {
+        malformed_layer_archive(compressed_digest, "last member ends beyond the archive")
+    })?;
+    if trailing < 1024 {
+        return Err(malformed_layer_archive(
+            compressed_digest,
+            "archive is missing the two zero end-of-archive records",
+        ));
+    }
+    file.seek(io::SeekFrom::Start(last_entry_end))
+        .map_err(|error| malformed_layer_archive(compressed_digest, error))?;
+    let mut remaining = trailing;
+    let mut buffer = [0_u8; 64 * 1024];
+    while remaining > 0 {
+        let chunk_len = usize::try_from(remaining.min(buffer.len() as u64))
+            .expect("the read size is bounded by the fixed buffer");
+        let read = file
+            .read(&mut buffer[..chunk_len])
+            .map_err(|error| malformed_layer_archive(compressed_digest, error))?;
+        if read == 0 {
+            return Err(malformed_layer_archive(
+                compressed_digest,
+                "archive ended while reading end-of-archive records",
+            ));
+        }
+        if buffer[..read].iter().any(|byte| *byte != 0) {
+            return Err(malformed_layer_archive(
+                compressed_digest,
+                "non-zero data follows the final tar member",
+            ));
+        }
+        remaining -= read as u64;
+    }
+    Ok(())
+}
+
+fn is_safe_layer_member_bytes(path: &[u8]) -> bool {
+    if path.is_empty() || path[0] == b'/' || path.contains(&0) {
+        return false;
+    }
+    let mut has_name = false;
+    for component in path.split(|byte| *byte == b'/') {
+        match component {
+            b"" | b"." => {}
+            b".." => return false,
+            _ => has_name = true,
+        }
+    }
+    has_name
+}
+
+fn is_safe_layer_member_path(path: &Path) -> bool {
+    if path.as_os_str().is_empty()
+        || path.as_os_str().as_encoded_bytes().contains(&0)
+        || path.is_absolute()
+    {
+        return false;
+    }
+    let mut has_name = false;
+    for component in path.components() {
+        match component {
+            std::path::Component::Normal(_) => has_name = true,
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => return false,
+        }
+    }
+    has_name
+}
+
+fn malformed_layer_archive(
+    compressed_digest: &Sha256Digest,
+    message: impl fmt::Display,
+) -> ResolveError {
+    ResolveError::MalformedLayerArchive {
+        compressed_digest: compressed_digest.clone(),
+        message: message.to_string(),
+    }
+}
+
+fn unsafe_tar_member(
+    compressed_digest: &Sha256Digest,
+    path: PathBuf,
+    reason: TarMemberViolation,
+) -> ResolveError {
+    ResolveError::UnsafeTarMember {
+        compressed_digest: compressed_digest.clone(),
+        path,
+        reason,
+    }
 }
 
 async fn read_config_diff_ids(image: &CachedImageBlobs) -> Result<Vec<Sha256Digest>, ResolveError> {

--- a/firecrab-api/src/oci/tar_tests.rs
+++ b/firecrab-api/src/oci/tar_tests.rs
@@ -480,6 +480,12 @@ async fn invalid_link_targets_are_rejected() {
             TarMemberViolation::MissingSymlinkTarget,
         ),
         (
+            "empty-pax-symlink",
+            pax_override_tar("linkpath", "", EntryType::Symlink, Some("safe")),
+            PathBuf::from("safe/member"),
+            TarMemberViolation::MissingSymlinkTarget,
+        ),
+        (
             "nul-symlink",
             pax_override_tar("linkpath", "safe\0suffix", EntryType::Symlink, Some("safe")),
             PathBuf::from("safe/member"),

--- a/firecrab-api/src/oci/tar_tests.rs
+++ b/firecrab-api/src/oci/tar_tests.rs
@@ -1,0 +1,645 @@
+use super::*;
+
+use std::io::Cursor;
+
+use tar::{Builder, EntryType, Header};
+use tempfile::{TempDir, tempdir};
+
+fn header(entry_type: EntryType, size: u64) -> Header {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header
+}
+
+fn append_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+    data: &[u8],
+) {
+    let mut header = header(entry_type, data.len() as u64);
+    if let Some(target) = target {
+        header
+            .set_link_name_literal(target.as_bytes())
+            .expect("set fixture link target");
+    }
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
+    builder.into_inner().expect("finish fixture tar")
+}
+
+fn one_entry_tar(path: &str, entry_type: EntryType, target: Option<&str>, data: &[u8]) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, path, entry_type, target, data);
+    finish(builder)
+}
+
+fn raw_path_tar(path: &str) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_raw_entry(&mut builder, path, EntryType::Regular, &[]);
+    finish(builder)
+}
+
+fn append_raw_path(builder: &mut Builder<Vec<u8>>, path: &str) {
+    append_raw_entry(builder, path, EntryType::Regular, &[]);
+}
+
+fn append_raw_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    data: &[u8],
+) {
+    let mut raw_header = header(entry_type, data.len() as u64);
+    let name = &mut raw_header.as_old_mut().name;
+    assert!(path.len() < name.len(), "fixture path fits the raw header");
+    name[..path.len()].copy_from_slice(path.as_bytes());
+    raw_header.set_cksum();
+    builder
+        .append(&raw_header, Cursor::new(data))
+        .expect("append raw fixture path");
+}
+
+fn pax_record(key: &str, value: &str) -> Vec<u8> {
+    let value = format!(" {key}={value}\n");
+    let mut length = value.len() + 1;
+    loop {
+        let actual = length.to_string().len() + value.len();
+        if actual == length {
+            return format!("{length}{value}").into_bytes();
+        }
+        length = actual;
+    }
+}
+
+fn append_pax_metadata(builder: &mut Builder<Vec<u8>>, bytes: &[u8]) {
+    append_entry(
+        builder,
+        "PaxHeaders.X/member",
+        EntryType::XHeader,
+        None,
+        bytes,
+    );
+}
+
+fn pax_override_tar(
+    key: &str,
+    value: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_pax_metadata(&mut builder, &pax_record(key, value));
+    append_entry(&mut builder, "safe/member", entry_type, target, &[]);
+    finish(builder)
+}
+
+fn gnu_override_tar(
+    extension_type: EntryType,
+    value: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    let mut metadata = value.as_bytes().to_vec();
+    metadata.push(0);
+    append_entry(
+        &mut builder,
+        "././@LongLink",
+        extension_type,
+        None,
+        &metadata,
+    );
+    append_entry(&mut builder, "safe/member", entry_type, target, &[]);
+    finish(builder)
+}
+
+fn gnu_and_pax_linkpath_tar(gnu_target: &str, pax_target: &str) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    let mut metadata = gnu_target.as_bytes().to_vec();
+    metadata.push(0);
+    append_entry(
+        &mut builder,
+        "././@LongLink",
+        EntryType::GNULongLink,
+        None,
+        &metadata,
+    );
+    append_pax_metadata(&mut builder, &pax_record("linkpath", pax_target));
+    append_entry(
+        &mut builder,
+        "safe/member",
+        EntryType::Symlink,
+        Some("header-safe"),
+        &[],
+    );
+    finish(builder)
+}
+
+fn oversized_metadata_tar() -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    let metadata = vec![b'a'; (TAR_METADATA_MAX_BYTES + 1) as usize];
+    append_pax_metadata(&mut builder, &metadata);
+    finish(builder)
+}
+
+fn extended_sparse_tar() -> Vec<u8> {
+    let mut header = header(EntryType::GNUSparse, 0);
+    header.set_path("var/sparse").expect("set sparse path");
+    header
+        .as_gnu_mut()
+        .expect("fixture uses a GNU header")
+        .set_is_extended(true);
+    header.set_cksum();
+    let mut builder = Builder::new(Vec::new());
+    builder
+        .append(&header, Cursor::new(Vec::<u8>::new()))
+        .expect("append sparse header");
+    finish(builder)
+}
+
+fn pax_records_tar(records: &[(&str, &str)], entry_type: EntryType) -> Vec<u8> {
+    let mut metadata = Vec::new();
+    for (key, value) in records {
+        metadata.extend(pax_record(key, value));
+    }
+    let mut builder = Builder::new(Vec::new());
+    append_pax_metadata(&mut builder, &metadata);
+    append_entry(&mut builder, "safe/member", entry_type, None, &[]);
+    finish(builder)
+}
+
+fn global_pax_tar(key: &str, value: &str) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "GlobalHead.0",
+        EntryType::XGlobalHeader,
+        None,
+        &pax_record(key, value),
+    );
+    append_entry(&mut builder, "safe/member", EntryType::Regular, None, &[]);
+    finish(builder)
+}
+
+fn fixture_layer(directory: &TempDir, name: &str, bytes: &[u8]) -> DecompressedLayer {
+    let compressed_bytes = format!("compressed fixture {name}").into_bytes();
+    let compressed_digest = Sha256Digest::of_bytes(&compressed_bytes);
+    let compressed_path = directory.path().join(format!("{name}.blob"));
+    std::fs::write(&compressed_path, &compressed_bytes).expect("write compressed fixture");
+    let path = directory.path().join(format!("{name}.tar"));
+    std::fs::write(&path, bytes).expect("write tar fixture");
+    DecompressedLayer {
+        source: CachedBlob {
+            descriptor: Descriptor {
+                media_type: OCI_LAYER_MEDIA_TYPE.to_owned(),
+                digest: compressed_digest,
+                size: compressed_bytes.len() as u64,
+            },
+            path: compressed_path,
+        },
+        diff_id: Sha256Digest::of_bytes(bytes),
+        path,
+        size: bytes.len() as u64,
+    }
+}
+
+#[tokio::test]
+async fn regular_entries_links_and_whiteouts_pass_preflight_in_manifest_order() {
+    let mut first_builder = Builder::new(Vec::new());
+    append_raw_entry(
+        &mut first_builder,
+        "/tmp/GlobalHead.0",
+        EntryType::XGlobalHeader,
+        &pax_record("mtime", "1.0"),
+    );
+    append_entry(&mut first_builder, "etc/", EntryType::Directory, None, &[]);
+    append_entry(
+        &mut first_builder,
+        "bin/busybox",
+        EntryType::Regular,
+        None,
+        b"binary",
+    );
+    append_entry(
+        &mut first_builder,
+        "bin/sh",
+        EntryType::Symlink,
+        Some("/bin/busybox"),
+        &[],
+    );
+    append_entry(
+        &mut first_builder,
+        "usr/bin/tool",
+        EntryType::Symlink,
+        Some("../../bin/busybox"),
+        &[],
+    );
+    append_entry(
+        &mut first_builder,
+        "bin/busybox-copy",
+        EntryType::Link,
+        Some("bin/busybox"),
+        &[],
+    );
+    append_entry(
+        &mut first_builder,
+        "etc/.wh.removed",
+        EntryType::Regular,
+        None,
+        &[],
+    );
+    append_entry(
+        &mut first_builder,
+        "var/lib/data/.wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+    );
+    let first_tar = finish(first_builder);
+    let second_tar = one_entry_tar("./usr/share/message", EntryType::Regular, None, b"hello");
+    let directory = tempdir().expect("create fixture directory");
+    let first = fixture_layer(&directory, "first", &first_tar);
+    let second = fixture_layer(&directory, "second", &second_tar);
+
+    let validated =
+        validate_decompressed_layers(vec![first.clone(), second.clone(), first.clone()])
+            .await
+            .expect("validate ordinary OCI layer members");
+
+    assert_eq!(validated.len(), 3);
+    assert_eq!(validated[0].source(), &first.source);
+    assert_eq!(validated[1].diff_id(), &second.diff_id);
+    assert_eq!(validated[2].path(), first.path.as_path());
+    assert_eq!(validated[2].size(), first.size);
+}
+
+#[tokio::test]
+async fn traversal_absolute_and_pax_overridden_paths_are_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut late_traversal_builder = Builder::new(Vec::new());
+    append_entry(
+        &mut late_traversal_builder,
+        "safe/first",
+        EntryType::Regular,
+        None,
+        b"safe",
+    );
+    append_raw_path(&mut late_traversal_builder, "../../late-escape");
+    let late_traversal = finish(late_traversal_builder);
+    let fixtures = [
+        (
+            "parent",
+            raw_path_tar("../escape"),
+            PathBuf::from("../escape"),
+        ),
+        (
+            "nested-parent",
+            raw_path_tar("etc/../../escape"),
+            PathBuf::from("etc/../../escape"),
+        ),
+        (
+            "absolute",
+            raw_path_tar("/absolute/path"),
+            PathBuf::from("/absolute/path"),
+        ),
+        (
+            "pax-parent",
+            pax_override_tar("path", "../pax-escape", EntryType::Regular, None),
+            PathBuf::from("../pax-escape"),
+        ),
+        (
+            "gnu-parent",
+            gnu_override_tar(
+                EntryType::GNULongName,
+                "../../gnu-escape",
+                EntryType::Regular,
+                None,
+            ),
+            PathBuf::from("../../gnu-escape"),
+        ),
+        (
+            "late-parent",
+            late_traversal,
+            PathBuf::from("../../late-escape"),
+        ),
+    ];
+
+    for (name, bytes, expected_path) in fixtures {
+        let layer = fixture_layer(&directory, name, &bytes);
+        let expected_digest = layer.source.descriptor.digest.clone();
+        let error = validate_decompressed_layers(vec![layer])
+            .await
+            .expect_err("unsafe member path must fail preflight");
+        assert!(matches!(
+            error,
+            ResolveError::UnsafeTarMember {
+                compressed_digest,
+                path,
+                reason: TarMemberViolation::Path,
+            } if compressed_digest == expected_digest && path == expected_path
+        ));
+    }
+
+    let safe = fixture_layer(
+        &directory,
+        "safe-layer",
+        &one_entry_tar("safe/first", EntryType::Regular, None, b"safe"),
+    );
+    let unsafe_layer = fixture_layer(
+        &directory,
+        "unsafe-second-layer",
+        &raw_path_tar("../../second-layer-escape"),
+    );
+    let expected_digest = unsafe_layer.source.descriptor.digest.clone();
+    let error = validate_decompressed_layers(vec![safe, unsafe_layer])
+        .await
+        .expect_err("a later unsafe layer must fail the complete image preflight");
+    assert!(matches!(
+        error,
+        ResolveError::UnsafeTarMember { compressed_digest, path, .. }
+            if compressed_digest == expected_digest && path == Path::new("../../second-layer-escape")
+    ));
+}
+
+#[tokio::test]
+async fn parser_differential_pax_overrides_are_explicitly_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+    for (name, bytes, expected_key) in [
+        (
+            "local-size",
+            pax_override_tar("size", "512", EntryType::Regular, None),
+            "size",
+        ),
+        (
+            "global-path",
+            global_pax_tar("path", "../../global-escape"),
+            "path",
+        ),
+        (
+            "global-linkpath",
+            global_pax_tar("linkpath", "../../global-link"),
+            "linkpath",
+        ),
+        ("global-size", global_pax_tar("size", "512"), "size"),
+    ] {
+        let layer = fixture_layer(&directory, name, &bytes);
+        let error = validate_decompressed_layers(vec![layer])
+            .await
+            .expect_err("ambiguous PAX parser override must fail preflight");
+        assert!(matches!(
+            error,
+            ResolveError::UnsafeTarMember {
+                reason: TarMemberViolation::UnsupportedPaxAttribute { key },
+                ..
+            } if key == expected_key
+        ));
+    }
+}
+
+#[tokio::test]
+async fn device_and_other_special_nodes_are_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+    for (name, entry_type, expected_reason) in [
+        ("character", EntryType::Char, TarMemberViolation::DeviceNode),
+        ("block", EntryType::Block, TarMemberViolation::DeviceNode),
+        (
+            "fifo",
+            EntryType::Fifo,
+            TarMemberViolation::UnsupportedEntryType { entry_type: b'6' },
+        ),
+        (
+            "unknown",
+            EntryType::new(b'9'),
+            TarMemberViolation::UnsupportedEntryType { entry_type: b'9' },
+        ),
+    ] {
+        let bytes = one_entry_tar("dev/unsafe", entry_type, None, &[]);
+        let layer = fixture_layer(&directory, name, &bytes);
+        let error = validate_decompressed_layers(vec![layer])
+            .await
+            .expect_err("special filesystem node must fail preflight");
+        assert!(matches!(
+            error,
+            ResolveError::UnsafeTarMember { path, reason, .. }
+                if path == Path::new("dev/unsafe") && reason == expected_reason
+        ));
+    }
+
+    let sparse = fixture_layer(&directory, "sparse", &extended_sparse_tar());
+    let error = validate_decompressed_layers(vec![sparse])
+        .await
+        .expect_err("GNU sparse parsing must be rejected in the raw preflight");
+    assert!(matches!(
+        error,
+        ResolveError::UnsafeTarMember {
+            path,
+            reason: TarMemberViolation::UnsupportedEntryType { entry_type: b'S' },
+            ..
+        } if path == Path::new("var/sparse")
+    ));
+
+    let sparse_pax = pax_override_tar("GNU.sparse.name", "../../outside", EntryType::Regular, None);
+    let sparse_pax = fixture_layer(&directory, "sparse-pax", &sparse_pax);
+    let error = validate_decompressed_layers(vec![sparse_pax])
+        .await
+        .expect_err("GNU sparse PAX metadata must be rejected");
+    assert!(matches!(
+        error,
+        ResolveError::UnsafeTarMember {
+            reason: TarMemberViolation::UnsupportedPaxAttribute { key },
+            ..
+        } if key == "GNU.sparse.name"
+    ));
+}
+
+#[tokio::test]
+async fn invalid_link_targets_are_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+    let fixtures = [
+        (
+            "missing",
+            one_entry_tar("usr/bin/hard", EntryType::Link, None, &[]),
+            PathBuf::from("usr/bin/hard"),
+            TarMemberViolation::MissingHardlinkTarget,
+        ),
+        (
+            "missing-symlink",
+            one_entry_tar("usr/bin/symlink", EntryType::Symlink, None, &[]),
+            PathBuf::from("usr/bin/symlink"),
+            TarMemberViolation::MissingSymlinkTarget,
+        ),
+        (
+            "nul-symlink",
+            pax_override_tar("linkpath", "safe\0suffix", EntryType::Symlink, Some("safe")),
+            PathBuf::from("safe/member"),
+            TarMemberViolation::InvalidSymlinkTarget,
+        ),
+        (
+            "gnu-pax-nul-symlink",
+            gnu_and_pax_linkpath_tar("gnu-safe", "safe\0suffix"),
+            PathBuf::from("safe/member"),
+            TarMemberViolation::InvalidSymlinkTarget,
+        ),
+        (
+            "parent",
+            one_entry_tar("usr/bin/hard", EntryType::Link, Some("../outside"), &[]),
+            PathBuf::from("usr/bin/hard"),
+            TarMemberViolation::HardlinkTarget {
+                target: PathBuf::from("../outside"),
+            },
+        ),
+        (
+            "absolute",
+            one_entry_tar("usr/bin/hard", EntryType::Link, Some("/etc/shadow"), &[]),
+            PathBuf::from("usr/bin/hard"),
+            TarMemberViolation::HardlinkTarget {
+                target: PathBuf::from("/etc/shadow"),
+            },
+        ),
+        (
+            "pax-linkpath",
+            pax_override_tar(
+                "linkpath",
+                "../../outside",
+                EntryType::Link,
+                Some("safe/target"),
+            ),
+            PathBuf::from("safe/member"),
+            TarMemberViolation::HardlinkTarget {
+                target: PathBuf::from("../../outside"),
+            },
+        ),
+        (
+            "gnu-longlink",
+            gnu_override_tar(
+                EntryType::GNULongLink,
+                "../../gnu-outside",
+                EntryType::Link,
+                Some("safe/target"),
+            ),
+            PathBuf::from("safe/member"),
+            TarMemberViolation::HardlinkTarget {
+                target: PathBuf::from("../../gnu-outside"),
+            },
+        ),
+    ];
+
+    for (name, bytes, expected_path, expected_reason) in fixtures {
+        let layer = fixture_layer(&directory, name, &bytes);
+        let error = validate_decompressed_layers(vec![layer])
+            .await
+            .expect_err("unsafe hard link must fail preflight");
+        match error {
+            ResolveError::UnsafeTarMember { path, reason, .. } => {
+                assert_eq!(path, expected_path);
+                assert_eq!(reason, expected_reason);
+            }
+            other => panic!("unexpected hard link error: {other}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn malformed_pax_checksum_and_truncated_payload_are_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+
+    let mut malformed_pax_builder = Builder::new(Vec::new());
+    append_pax_metadata(&mut malformed_pax_builder, b"99 path=../escape\n");
+    append_entry(
+        &mut malformed_pax_builder,
+        "safe/member",
+        EntryType::Regular,
+        None,
+        &[],
+    );
+    let malformed_pax = finish(malformed_pax_builder);
+
+    let mut bad_checksum = one_entry_tar("file", EntryType::Regular, None, b"data");
+    bad_checksum[0] ^= 1;
+
+    let mut truncated = one_entry_tar("file", EntryType::Regular, None, b"payload");
+    truncated.truncate(512 + 3);
+
+    let mut missing_terminator = one_entry_tar("file", EntryType::Regular, None, b"payload");
+    missing_terminator.truncate(1024);
+
+    let mut concatenated = one_entry_tar("safe", EntryType::Regular, None, &[]);
+    concatenated.extend(raw_path_tar("../../hidden-after-zero"));
+
+    let duplicate_path = pax_records_tar(
+        &[("path", "safe/member"), ("path", "../../last-wins")],
+        EntryType::Regular,
+    );
+    for (name, bytes) in [
+        ("pax", malformed_pax),
+        ("checksum", bad_checksum),
+        ("truncated", truncated),
+        ("missing-terminator", missing_terminator),
+        ("concatenated", concatenated),
+        ("duplicate-path", duplicate_path),
+    ] {
+        let layer = fixture_layer(&directory, name, &bytes);
+        let expected_digest = layer.source.descriptor.digest.clone();
+        let error = validate_decompressed_layers(vec![layer])
+            .await
+            .expect_err("malformed tar must fail preflight");
+        assert!(matches!(
+            error,
+            ResolveError::MalformedLayerArchive { compressed_digest, .. }
+                if compressed_digest == expected_digest
+        ));
+    }
+
+    let oversized = fixture_layer(&directory, "oversized-metadata", &oversized_metadata_tar());
+    let error = validate_decompressed_layers(vec![oversized])
+        .await
+        .expect_err("oversized metadata must fail before the parser buffers it");
+    assert!(matches!(
+        error,
+        ResolveError::MalformedLayerArchive { message, .. }
+            if message.contains("exceeding")
+    ));
+}
+
+#[tokio::test]
+async fn rejected_member_keeps_verified_blob_and_layer_cache_bytes() {
+    let directory = tempdir().expect("create fixture directory");
+    let bytes = raw_path_tar("../../outside");
+    let layer = fixture_layer(&directory, "retained", &bytes);
+    let compressed_before = std::fs::read(&layer.source.path).expect("read compressed fixture");
+    let tar_before = std::fs::read(&layer.path).expect("read layer fixture");
+    let compressed_path = layer.source.path.clone();
+    let tar_path = layer.path.clone();
+
+    validate_decompressed_layers(vec![layer])
+        .await
+        .expect_err("unsafe tar must fail preflight");
+
+    assert_eq!(
+        std::fs::read(compressed_path).expect("compressed cache remains"),
+        compressed_before
+    );
+    assert_eq!(
+        std::fs::read(tar_path).expect("layer cache remains"),
+        tar_before
+    );
+    for entry in std::fs::read_dir(directory.path()).expect("read fixture directory") {
+        let name = entry
+            .expect("read fixture entry")
+            .file_name()
+            .to_string_lossy()
+            .into_owned();
+        assert!(!name.ends_with(".partial"), "unexpected partial {name}");
+    }
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -53,9 +53,28 @@ is limited to 64 GiB per layer by default; change it with
 `FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`. At most two layer decoders run
 process-wide, and each zstd decoder has a 128 MiB window limit.
 
-Tar member validation, extraction, whiteout handling, and layer merging remain
-separate import stages. Inspect does not run decompression or fill either OCI
-cache.
+## Layer safety preflight
+
+Before extraction, the internal pipeline scans every decompressed tar using
+GNU long-name/link metadata and PAX overrides. Member names must be non-empty
+relative paths without parent components. Character and block devices are
+rejected, as are unsupported special entries. Links must name a target;
+hard-link targets are archive-root-relative and cannot be absolute or contain
+parent components. Regular whiteout files remain valid for the later merge
+stage.
+
+Malformed headers, repeated PAX path/link records, sparse extensions,
+missing end records, and truncated member bodies stop the import before any
+filesystem tree is created. PAX `size` overrides and global PAX path/link/size
+overrides are rejected to avoid different tar parsers disagreeing about member
+boundaries or destinations. Each GNU or PAX metadata entry is limited to 1
+MiB. Rejection does not delete the already verified compressed blob or
+decompressed tar: both remain valid content-addressed cache entries.
+
+Extraction, whiteout handling, and layer merging remain separate import
+stages. Symbolic links are kept as metadata here; extraction must remain rooted
+without following one while creating later members. Inspect does not run
+decompression or validation, and does not fill either OCI cache.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Validate decompressed OCI layer tar archives before extraction.
- Reject unsafe paths, device nodes, hardlink escapes, and malformed GNU/PAX metadata.
- Preserve verified cache entries when validation fails.

## Testing

- Workspace tests, Clippy, rustdoc, formatting, and documentation checks passed.

Related to #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added pre-extraction validation for OCI tar layers to block unsafe paths, links, device files, unsupported entries, malformed archives, and excessive metadata.
  * Prevents filesystem changes when validation fails.
* **Reliability**
  * Preserves verified cached layers after validation errors.
  * Maintains layer order and supports safe handling of links and whiteouts.
* **Documentation**
  * Documented OCI layer validation, extraction, and failure-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->