### PR TITLE
Merge OCI layers with whiteouts (#90)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ version = "0.1.0"
 dependencies = [
  "async-compression",
  "axum",
+ "filetime",
  "firecrab-api-types",
  "firecrab-helper-protocol",
  "futures-util",

--- a/firecrab-api/Cargo.toml
+++ b/firecrab-api/Cargo.toml
@@ -10,6 +10,7 @@ async-compression = { version = "0.4.43", features = ["gzip", "tokio", "zstd"] }
 axum = { version = "0.8.9", features = ["ws"] }
 firecrab-api-types = { path = "../firecrab-api-types" }
 firecrab-helper-protocol = { path = "../firecrab-helper-protocol" }
+filetime = "0.2.29"
 futures-util = "0.3"
 libc = "0.2.186"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -705,6 +705,29 @@ pub enum ResolveError {
         /// Safety rule rejected by the entry.
         reason: TarMemberViolation,
     },
+    /// A merge destination already exists and must not be replaced.
+    #[error("OCI layer merge destination already exists at {path}")]
+    MergeDestinationExists {
+        /// Caller-selected final staging tree path.
+        path: PathBuf,
+    },
+    /// A filesystem operation failed while constructing the merged tree.
+    #[error("OCI layer merge {operation} failed at {path}: {source}")]
+    MergeIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Staging or published path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The caller stopped waiting before the private tree could be published.
+    #[error("OCI layer merge was cancelled before publishing {path}")]
+    MergeCancelled {
+        /// Caller-selected final staging tree path.
+        path: PathBuf,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1685,6 +1708,11 @@ mod cache_tests;
 #[cfg(test)]
 mod tar_tests;
 
+mod merge;
+
+#[cfg(test)]
+mod merge_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2085,12 +2113,27 @@ impl ValidatedLayer {
     }
 }
 
+/// A fully merged OCI filesystem tree published after every layer succeeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergedRootfs {
+    path: PathBuf,
+}
+
+impl MergedRootfs {
+    /// Path to the merged staging tree.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
 /// Why an otherwise valid layer tar entry is unsafe for later extraction.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum TarMemberViolation {
-    /// The member name is empty, absolute, or contains a parent/root/prefix
-    /// component.
-    #[error("member path must be a non-empty relative path beneath the extraction root")]
+    /// The member name is empty, absolute, contains a parent/root/prefix
+    /// component, or names the archive root with a non-directory entry.
+    #[error(
+        "member path must be relative beneath the extraction root; only a directory may name the root itself"
+    )]
     Path,
     /// Character and block devices are never imported from an OCI layer.
     #[error("device nodes are not permitted")]
@@ -2111,6 +2154,51 @@ pub enum TarMemberViolation {
     /// A symbolic link target cannot be represented by filesystem APIs.
     #[error("symbolic link target contains a NUL byte")]
     InvalidSymlinkTarget,
+    /// Two tar entries resolve to the same normalized path.
+    #[error("layer contains a duplicate normalized path")]
+    DuplicatePath,
+    /// A non-directory entry also has entries beneath it in the same layer.
+    #[error("non-directory entry conflicts with descendant {descendant:?}")]
+    ConflictingPath {
+        /// Descendant that makes the final tree ambiguous.
+        descendant: PathBuf,
+    },
+    /// A whiteout marker has no valid sibling basename to remove.
+    #[error("whiteout marker has an invalid target basename")]
+    InvalidWhiteoutTarget,
+    /// Whiteout markers must be regular files.
+    #[error("whiteout marker must be a regular file")]
+    InvalidWhiteoutType,
+    /// Whiteout markers must have an empty payload.
+    #[error("whiteout marker must be empty, but declares {size} bytes")]
+    NonEmptyWhiteout {
+        /// Marker payload length.
+        size: u64,
+    },
+    /// Applying the current layer would traverse a symlink from an older one.
+    #[error("operation would traverse symlink ancestor {ancestor:?}")]
+    SymlinkAncestor {
+        /// Relative path of the unsafe ancestor.
+        ancestor: PathBuf,
+    },
+    /// A path component required as a directory is another filesystem type.
+    #[error("path ancestor {ancestor:?} is not a directory")]
+    NonDirectoryAncestor {
+        /// Relative path of the conflicting ancestor.
+        ancestor: PathBuf,
+    },
+    /// A hard-link target was not produced by a lower or current layer.
+    #[error("hard link target {target:?} does not exist")]
+    MissingMergedHardlinkTarget {
+        /// Archive-root-relative target.
+        target: PathBuf,
+    },
+    /// Hard links to directories are unsupported and unsafe.
+    #[error("hard link target {target:?} is a directory")]
+    DirectoryHardlinkTarget {
+        /// Archive-root-relative directory target.
+        target: PathBuf,
+    },
     /// Tar hard-link names are archive-root-relative and cannot leave that
     /// root.
     #[error("hard link target {target:?} is outside the archive root")]
@@ -2246,6 +2334,21 @@ pub async fn validate_decompressed_layers(
         .collect())
 }
 
+/// Applies validated OCI layers in manifest order to a new filesystem tree.
+///
+/// Each layer's whiteouts are applied before that layer's ordinary members,
+/// regardless of marker order in the tar. Work happens in a private sibling
+/// directory and becomes visible at `destination` only after every layer and
+/// final directory attribute succeeds. The destination must not already
+/// exist. Verified blob and decompressed-layer caches are never removed when
+/// merging fails.
+pub async fn merge_validated_layers(
+    layers: &[ValidatedLayer],
+    destination: &Path,
+) -> Result<MergedRootfs, ResolveError> {
+    merge::merge_validated_layers(layers, destination).await
+}
+
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {
     let path = layer.path.clone();
     let compressed_digest = layer.source.descriptor.digest.clone();
@@ -2262,8 +2365,16 @@ fn validate_layer_archive_blocking(
     path: &Path,
     compressed_digest: &Sha256Digest,
 ) -> Result<(), ResolveError> {
-    let file = std::fs::File::open(path)
+    let mut file = std::fs::File::open(path)
         .map_err(|error| cache_io("open layer tar", path.to_owned(), error))?;
+    validate_layer_archive_file(&mut file, path, compressed_digest)
+}
+
+fn validate_layer_archive_file(
+    file: &mut std::fs::File,
+    path: &Path,
+    compressed_digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
     let file_len = file
         .metadata()
         .map_err(|error| cache_io("inspect layer tar", path.to_owned(), error))?
@@ -2274,13 +2385,15 @@ fn validate_layer_archive_blocking(
             format!("archive length {file_len} is not a multiple of the 512-byte tar block size"),
         ));
     }
-    let mut archive = tar::Archive::new(file);
-    let raw_last_end = validate_raw_tar_metadata(&mut archive, file_len, compressed_digest)?;
-    let mut file = archive.into_inner();
-    validate_tar_terminator(&mut file, raw_last_end, file_len, compressed_digest)?;
     file.seek(io::SeekFrom::Start(0))
         .map_err(|error| cache_io("rewind layer tar", path.to_owned(), error))?;
-    let mut archive = tar::Archive::new(file);
+    let mut archive = tar::Archive::new(&mut *file);
+    let raw_last_end = validate_raw_tar_metadata(&mut archive, file_len, compressed_digest)?;
+    let file = archive.into_inner();
+    validate_tar_terminator(file, raw_last_end, file_len, compressed_digest)?;
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| cache_io("rewind layer tar", path.to_owned(), error))?;
+    let mut archive = tar::Archive::new(&mut *file);
     let entries = archive
         .entries()
         .map_err(|error| malformed_layer_archive(compressed_digest, error))?;
@@ -2330,7 +2443,7 @@ fn validate_layer_archive_blocking(
                 )
             })?
             .into_owned();
-        if !is_safe_layer_member_path(&member_path) {
+        if !is_safe_layer_entry_path(&member_path, entry_type) {
             return Err(unsafe_tar_member(
                 compressed_digest,
                 member_path,
@@ -2471,12 +2584,15 @@ fn validate_layer_archive_blocking(
             ));
         }
     }
-    let mut file = archive.into_inner();
-    validate_tar_terminator(&mut file, semantic_last_end, file_len, compressed_digest)
+    let file = archive.into_inner();
+    validate_tar_terminator(file, semantic_last_end, file_len, compressed_digest)?;
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| cache_io("rewind layer tar", path.to_owned(), error))?;
+    Ok(())
 }
 
-fn validate_raw_tar_metadata(
-    archive: &mut tar::Archive<std::fs::File>,
+fn validate_raw_tar_metadata<R: io::Read + io::Seek>(
+    archive: &mut tar::Archive<R>,
     file_len: u64,
     compressed_digest: &Sha256Digest,
 ) -> Result<u64, ResolveError> {
@@ -2541,7 +2657,7 @@ fn validate_raw_tar_metadata(
                 )
             })?
             .into_owned();
-        if !is_safe_layer_member_path(&member_path) {
+        if !is_safe_layer_entry_path(&member_path, entry_type) {
             return Err(unsafe_tar_member(
                 compressed_digest,
                 member_path,
@@ -2647,7 +2763,7 @@ fn validate_pax_metadata<R: io::Read>(
                         },
                     ));
                 }
-                if !is_safe_layer_member_bytes(value) {
+                if !is_safe_layer_member_bytes(value) && !is_layer_root_bytes(value) {
                     return Err(unsafe_tar_member(
                         compressed_digest,
                         PathBuf::from(String::from_utf8_lossy(value).into_owned()),
@@ -2779,6 +2895,14 @@ fn is_safe_layer_member_bytes(path: &[u8]) -> bool {
     has_name
 }
 
+fn is_layer_root_bytes(path: &[u8]) -> bool {
+    if path.is_empty() || path[0] == b'/' || path.contains(&0) {
+        return false;
+    }
+    path.split(|byte| *byte == b'/')
+        .all(|component| matches!(component, b"" | b"."))
+}
+
 fn is_safe_layer_member_path(path: &Path) -> bool {
     if path.as_os_str().is_empty()
         || path.as_os_str().as_encoded_bytes().contains(&0)
@@ -2797,6 +2921,21 @@ fn is_safe_layer_member_path(path: &Path) -> bool {
         }
     }
     has_name
+}
+
+fn is_layer_root_path(path: &Path) -> bool {
+    if path.as_os_str().is_empty()
+        || path.as_os_str().as_encoded_bytes().contains(&0)
+        || path.is_absolute()
+    {
+        return false;
+    }
+    path.components()
+        .all(|component| component == std::path::Component::CurDir)
+}
+
+fn is_safe_layer_entry_path(path: &Path, entry_type: tar::EntryType) -> bool {
+    is_safe_layer_member_path(path) || (entry_type.is_dir() && is_layer_root_path(path))
 }
 
 fn malformed_layer_archive(

--- a/firecrab-api/src/oci/merge.rs
+++ b/firecrab-api/src/oci/merge.rs
@@ -1,3 +1,11 @@
+//! Applies validated OCI layers to a private tree and publishes it atomically.
+//!
+//! Layers replay in manifest order, and each layer's whiteouts run before its
+//! own members regardless of where the markers sit in the tar. Directory modes
+//! and mtimes are stamped only after the last layer lands, so an earlier layer
+//! never wins over a later one. Nothing appears at the caller's destination
+//! until the finished tree is renamed into place.
+
 use super::*;
 
 use std::collections::{BTreeMap, HashSet};
@@ -7,22 +15,34 @@ use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
 use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _, PermissionsExt as _};
 use std::sync::atomic::{AtomicU8, Ordering};
 
+/// Basename prefix marking an OverlayFS whiteout entry.
 const WHITEOUT_PREFIX: &[u8] = b".wh.";
+/// Basename marking a directory whose lower-layer contents are hidden.
 const OPAQUE_WHITEOUT: &[u8] = b".wh..wh..opq";
-// The merge tree is host-visible and service-owned. Preserve ordinary and
-// sticky permissions, but never activate attacker-supplied set-ID bits on it.
+/// Permission bits the merged tree may keep from a layer.
+///
+/// The merge tree is host-visible and service-owned. Preserve ordinary and
+/// sticky permissions, but never activate attacker-supplied set-ID bits on it.
 const HOST_SAFE_MODE_MASK: u32 = 0o1777;
+/// The merge is running and may still be cancelled.
 const MERGE_ACTIVE: u8 = 0;
+/// The finished tree is being renamed into place and can no longer be cancelled.
 const MERGE_PUBLISHING: u8 = 1;
+/// The caller stopped waiting before publishing began.
 const MERGE_CANCELLED: u8 = 2;
+/// Publishing completed, so the state no longer changes.
 const MERGE_FINISHED: u8 = 3;
 
+/// Shared cancellation state consulted between merge steps.
 struct MergeControl {
+    /// Current merge phase, shared with the caller's cancellation guard.
     state: std::sync::Arc<AtomicU8>,
+    /// Destination reported by cancellation errors.
     destination: PathBuf,
 }
 
 impl MergeControl {
+    /// Fails once the caller stopped waiting, so long merges abandon early.
     fn check(&self) -> Result<(), ResolveError> {
         if self.state.load(Ordering::Acquire) == MERGE_ACTIVE {
             Ok(())
@@ -33,6 +53,7 @@ impl MergeControl {
         }
     }
 
+    /// Claims the right to publish, locking cancellation out from here on.
     fn begin_publish(&self) -> Result<(), ResolveError> {
         self.state
             .compare_exchange(
@@ -47,13 +68,17 @@ impl MergeControl {
             })
     }
 
+    /// Records that publishing finished and the tree is now the caller's.
     fn finish(&self) {
         self.state.store(MERGE_FINISHED, Ordering::Release);
     }
 }
 
+/// Marks an abandoned merge cancelled when the caller's future is dropped.
 struct CancelMergeOnDrop {
+    /// Shared merge phase, flipped to cancelled while still armed.
     state: std::sync::Arc<AtomicU8>,
+    /// Cleared once the blocking worker has returned.
     armed: bool,
 }
 
@@ -70,39 +95,61 @@ impl Drop for CancelMergeOnDrop {
     }
 }
 
+/// A deletion one layer records against the layers below it.
 #[derive(Debug)]
 enum Whiteout {
+    /// Remove this path and anything beneath it.
     Remove(PathBuf),
+    /// Hide every lower-layer child of this directory.
     Opaque(PathBuf),
 }
 
+/// Directory attributes stamped after every layer has been applied.
 #[derive(Debug, Clone)]
 struct DirectoryMetadata {
+    /// Tree-relative directory path.
     path: PathBuf,
+    /// Mode declared by the owning layer, masked before use.
     mode: u32,
+    /// Modification time declared by the owning layer.
     mtime: i64,
 }
 
+/// A hard link waiting for its target to appear in the merged tree.
 #[derive(Debug, Clone)]
 struct PlannedHardlink {
+    /// Tree-relative path of the link to create.
     path: PathBuf,
+    /// Archive-root-relative path the link points at.
     target: PathBuf,
 }
 
+/// What a planned path will become, used to reject ambiguous layers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PlannedEntryKind {
+    /// A whiteout marker, which is never materialized in the tree.
     Whiteout,
+    /// A directory, the only kind of entry allowed to hold descendants.
     Directory,
+    /// Any other entry, which may not hold descendants.
     Other,
 }
 
+/// Everything one layer needs applied outside plain tar extraction order.
 #[derive(Debug)]
 struct LayerPlan {
+    /// Deletions to apply before the layer's own members.
     whiteouts: Vec<Whiteout>,
+    /// Directories to create, shallowest first.
     directories: Vec<DirectoryMetadata>,
+    /// Hard links to resolve once the layer's files exist.
     hardlinks: Vec<PlannedHardlink>,
 }
 
+/// Runs the blocking merge on the pool and cancels it if the caller leaves.
+///
+/// Dropping the returned future between layers stops the worker before it
+/// publishes, so an abandoned request never leaves a destination behind.
 pub(super) async fn merge_validated_layers(
     layers: &[ValidatedLayer],
     destination: &Path,
@@ -125,6 +172,10 @@ pub(super) async fn merge_validated_layers(
     result?
 }
 
+/// Builds the merged tree in a private sibling directory, then publishes it.
+///
+/// The staging directory is removed on every exit path except a successful
+/// rename, which hands the tree to the caller.
 fn merge_layers_blocking(
     layers: &[ValidatedLayer],
     destination: &Path,
@@ -206,6 +257,7 @@ fn merge_layers_blocking(
     result
 }
 
+/// Applies one layer: whiteouts first, then directories, members, and links.
 fn apply_layer(
     layer: &ValidatedLayer,
     root: &Path,
@@ -253,6 +305,10 @@ fn apply_layer(
     apply_hardlinks(root, &plan.hardlinks, digest, directory_metadata, control)
 }
 
+/// Reopens a validated layer and rechecks its size, diff ID, and tar shape.
+///
+/// Validation ran against the path rather than this handle, so a cache entry
+/// swapped in between would otherwise reach extraction unchecked.
 fn open_verified_layer(layer: &ValidatedLayer) -> Result<File, ResolveError> {
     let descriptor = &layer.layer.source.descriptor;
     let path = &layer.layer.path;
@@ -303,6 +359,7 @@ fn open_verified_layer(layer: &ValidatedLayer) -> Result<File, ResolveError> {
     Ok(file)
 }
 
+/// Hashes an open file from its start and rewinds it, returning size and digest.
 fn hash_open_file(file: &mut File, path: &Path) -> Result<(u64, Sha256Digest), ResolveError> {
     file.seek(io::SeekFrom::Start(0))
         .map_err(|error| merge_io("rewind validated layer", path.to_owned(), error))?;
@@ -333,6 +390,11 @@ fn hash_open_file(file: &mut File, path: &Path) -> Result<(u64, Sha256Digest), R
     ))
 }
 
+/// Scans a layer once for whiteouts, directories, and hard links.
+///
+/// Duplicate normalized paths and non-directory entries with descendants are
+/// rejected here, because either would make the merged tree depend on the
+/// order in which entries happen to be extracted.
 fn plan_layer(
     file: &mut File,
     layer_path: &Path,
@@ -464,6 +526,7 @@ fn plan_layer(
     })
 }
 
+/// Decodes one entry path and normalizes it, rejecting anything unsafe.
 fn normalized_entry_path<R: io::Read>(
     entry: &tar::Entry<'_, R>,
     digest: &Sha256Digest,
@@ -479,10 +542,14 @@ fn normalized_entry_path<R: io::Read>(
         .ok_or_else(|| unsafe_tar_member(digest, path.into_owned(), TarMemberViolation::Path))
 }
 
+/// Normalizes a path that is not allowed to name the archive root itself.
 fn normalize_safe_path(path: &Path) -> Option<PathBuf> {
     normalize_layer_path(path, false)
 }
 
+/// Drops `.` components, returning `None` when the path is unsafe.
+///
+/// `allow_root` admits the archive root, which only directory entries may name.
 fn normalize_layer_path(path: &Path, allow_root: bool) -> Option<PathBuf> {
     if !(is_safe_layer_member_path(path) || allow_root && is_layer_root_path(path)) {
         return None;
@@ -496,6 +563,7 @@ fn normalize_layer_path(path: &Path, allow_root: bool) -> Option<PathBuf> {
     (allow_root || !normalized.as_os_str().is_empty()).then_some(normalized)
 }
 
+/// Recognizes `.wh.` markers and resolves which path each one deletes.
 fn classify_whiteout<R: io::Read>(
     entry: &tar::Entry<'_, R>,
     path: &Path,
@@ -538,6 +606,7 @@ fn classify_whiteout<R: io::Read>(
     Ok(Some(Whiteout::Remove(target)))
 }
 
+/// Rereads the layer and unpacks every member the plan did not already handle.
 fn extract_non_directory_entries(
     file: &mut File,
     layer_path: &Path,
@@ -602,6 +671,7 @@ fn extract_non_directory_entries(
     Ok(())
 }
 
+/// Creates a directory, replacing a non-directory left there by a lower layer.
 fn prepare_directory(
     root: &Path,
     path: &Path,
@@ -624,6 +694,10 @@ fn prepare_directory(
     }
 }
 
+/// Creates missing ancestors, refusing to follow a symlink from a lower layer.
+///
+/// Without this an earlier layer could point a directory name at an absolute
+/// path and steer a later layer's writes outside the merged tree.
 fn ensure_parent_directories(
     root: &Path,
     path: &Path,
@@ -668,6 +742,7 @@ fn ensure_parent_directories(
     Ok(())
 }
 
+/// Reports whether all existing ancestors are directories, creating none of them.
 fn existing_parent_is_safe(
     root: &Path,
     path: &Path,
@@ -710,6 +785,7 @@ fn existing_parent_is_safe(
     Ok(true)
 }
 
+/// Deletes what the layers below left at a whiteout marker's target.
 fn remove_merged_path(root: &Path, path: &Path, digest: &Sha256Digest) -> Result<(), ResolveError> {
     if !lower_parent_is_directory(root, path, digest)? {
         return Ok(());
@@ -725,6 +801,7 @@ fn remove_merged_path(root: &Path, path: &Path, digest: &Sha256Digest) -> Result
     }
 }
 
+/// Reports whether a whiteout target's ancestors all exist as directories.
 fn lower_parent_is_directory(
     root: &Path,
     path: &Path,
@@ -759,6 +836,7 @@ fn lower_parent_is_directory(
     Ok(true)
 }
 
+/// Removes whatever a lower layer left at a path the current layer claims.
 fn remove_existing_target(
     root: &Path,
     path: &Path,
@@ -778,6 +856,7 @@ fn remove_existing_target(
     }
 }
 
+/// Empties a directory named by an opaque whiteout, keeping the directory itself.
 fn clear_merged_directory(
     root: &Path,
     path: &Path,
@@ -814,6 +893,10 @@ fn clear_merged_directory(
     Ok(())
 }
 
+/// Links each planned hard link once its target exists in the merged tree.
+///
+/// A target may be created by a later entry of the same layer, so the list is
+/// retried until one full pass links nothing new.
 fn apply_hardlinks(
     root: &Path,
     hardlinks: &[PlannedHardlink],
@@ -880,6 +963,10 @@ fn apply_hardlinks(
     Ok(())
 }
 
+/// Stamps directory modes and mtimes deepest first, after all layers landed.
+///
+/// Writing children before their parents keeps a restrictive parent mode from
+/// blocking the writes beneath it.
 fn apply_directory_metadata(
     root: &Path,
     metadata: &BTreeMap<PathBuf, DirectoryMetadata>,
@@ -921,6 +1008,7 @@ fn apply_directory_metadata(
     Ok(())
 }
 
+/// Drops recorded attributes for a subtree that no longer exists.
 fn forget_directory_metadata(
     metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
     path: &Path,
@@ -931,6 +1019,7 @@ fn forget_directory_metadata(
     });
 }
 
+/// Creates one merged directory with a conservative mode until metadata lands.
 fn create_merged_directory(path: &Path) -> Result<(), ResolveError> {
     let mut builder = fs::DirBuilder::new();
     builder.mode(0o755);
@@ -939,10 +1028,12 @@ fn create_merged_directory(path: &Path) -> Result<(), ResolveError> {
         .map_err(|error| merge_io("create merged directory", path.to_owned(), error))
 }
 
+/// Counts path components, which orders directory work by depth.
 fn path_depth(path: &Path) -> usize {
     path.components().count()
 }
 
+/// Renames the finished tree into place without replacing an existing path.
 fn publish_tree(partial: &Path, destination: &Path) -> Result<(), ResolveError> {
     let source = CString::new(partial.as_os_str().as_bytes()).map_err(|error| {
         merge_io(
@@ -986,6 +1077,7 @@ fn publish_tree(partial: &Path, destination: &Path) -> Result<(), ResolveError> 
     ))
 }
 
+/// Wraps a filesystem failure with the merge operation that hit it.
 fn merge_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
     ResolveError::MergeIo {
         operation,
@@ -994,12 +1086,16 @@ fn merge_io(operation: &'static str, path: PathBuf, source: io::Error) -> Resolv
     }
 }
 
+/// Removes the private staging tree unless the merge published it.
 struct PartialTreeCleanup {
+    /// Staging tree root.
     path: PathBuf,
+    /// Set once the tree has been removed or handed to the caller.
     published: bool,
 }
 
 impl PartialTreeCleanup {
+    /// Arms cleanup for a freshly created staging tree.
     fn new(path: PathBuf) -> Self {
         Self {
             path,
@@ -1007,6 +1103,7 @@ impl PartialTreeCleanup {
         }
     }
 
+    /// Removes the staging tree now, reporting why it could not be removed.
     fn remove_now_if_needed(&mut self) -> Result<(), ResolveError> {
         if self.published {
             return Ok(());
@@ -1035,6 +1132,10 @@ impl Drop for PartialTreeCleanup {
     }
 }
 
+/// Restores owner access across the staging tree so cleanup can descend into it.
+///
+/// Layer modes may leave a directory unreadable even to its owner, which would
+/// otherwise strand the staging tree on disk.
 fn make_tree_owner_accessible(path: &Path) {
     let Ok(metadata) = fs::symlink_metadata(path) else {
         return;

--- a/firecrab-api/src/oci/merge.rs
+++ b/firecrab-api/src/oci/merge.rs
@@ -1,0 +1,1058 @@
+use super::*;
+
+use std::collections::{BTreeMap, HashSet};
+use std::ffi::{CString, OsString};
+use std::fs::{self, File, OpenOptions};
+use std::os::unix::ffi::{OsStrExt as _, OsStringExt as _};
+use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _, PermissionsExt as _};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+const WHITEOUT_PREFIX: &[u8] = b".wh.";
+const OPAQUE_WHITEOUT: &[u8] = b".wh..wh..opq";
+// The merge tree is host-visible and service-owned. Preserve ordinary and
+// sticky permissions, but never activate attacker-supplied set-ID bits on it.
+const HOST_SAFE_MODE_MASK: u32 = 0o1777;
+const MERGE_ACTIVE: u8 = 0;
+const MERGE_PUBLISHING: u8 = 1;
+const MERGE_CANCELLED: u8 = 2;
+const MERGE_FINISHED: u8 = 3;
+
+struct MergeControl {
+    state: std::sync::Arc<AtomicU8>,
+    destination: PathBuf,
+}
+
+impl MergeControl {
+    fn check(&self) -> Result<(), ResolveError> {
+        if self.state.load(Ordering::Acquire) == MERGE_ACTIVE {
+            Ok(())
+        } else {
+            Err(ResolveError::MergeCancelled {
+                path: self.destination.clone(),
+            })
+        }
+    }
+
+    fn begin_publish(&self) -> Result<(), ResolveError> {
+        self.state
+            .compare_exchange(
+                MERGE_ACTIVE,
+                MERGE_PUBLISHING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+            .map_err(|_| ResolveError::MergeCancelled {
+                path: self.destination.clone(),
+            })
+    }
+
+    fn finish(&self) {
+        self.state.store(MERGE_FINISHED, Ordering::Release);
+    }
+}
+
+struct CancelMergeOnDrop {
+    state: std::sync::Arc<AtomicU8>,
+    armed: bool,
+}
+
+impl Drop for CancelMergeOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.state.compare_exchange(
+                MERGE_ACTIVE,
+                MERGE_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Whiteout {
+    Remove(PathBuf),
+    Opaque(PathBuf),
+}
+
+#[derive(Debug, Clone)]
+struct DirectoryMetadata {
+    path: PathBuf,
+    mode: u32,
+    mtime: i64,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedHardlink {
+    path: PathBuf,
+    target: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlannedEntryKind {
+    Whiteout,
+    Directory,
+    Other,
+}
+
+#[derive(Debug)]
+struct LayerPlan {
+    whiteouts: Vec<Whiteout>,
+    directories: Vec<DirectoryMetadata>,
+    hardlinks: Vec<PlannedHardlink>,
+}
+
+pub(super) async fn merge_validated_layers(
+    layers: &[ValidatedLayer],
+    destination: &Path,
+) -> Result<MergedRootfs, ResolveError> {
+    let layers = layers.to_vec();
+    let destination = destination.to_owned();
+    let join_path = destination.clone();
+    let state = std::sync::Arc::new(AtomicU8::new(MERGE_ACTIVE));
+    let worker_control = MergeControl {
+        state: state.clone(),
+        destination: destination.clone(),
+    };
+    let mut cancel_on_drop = CancelMergeOnDrop { state, armed: true };
+    let result = tokio::task::spawn_blocking(move || {
+        merge_layers_blocking(&layers, &destination, &worker_control)
+    })
+    .await
+    .map_err(|error| merge_io("join worker", join_path, io::Error::other(error)));
+    cancel_on_drop.armed = false;
+    result?
+}
+
+fn merge_layers_blocking(
+    layers: &[ValidatedLayer],
+    destination: &Path,
+    control: &MergeControl,
+) -> Result<MergedRootfs, ResolveError> {
+    control.check()?;
+    let parent = destination.parent().ok_or_else(|| {
+        merge_io(
+            "resolve destination parent",
+            destination.to_owned(),
+            io::Error::new(io::ErrorKind::InvalidInput, "destination has no parent"),
+        )
+    })?;
+    if destination.file_name().is_none() {
+        return Err(merge_io(
+            "resolve destination name",
+            destination.to_owned(),
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "destination must name a directory below its parent",
+            ),
+        ));
+    }
+    fs::create_dir_all(parent)
+        .map_err(|error| merge_io("create destination parent", parent.to_owned(), error))?;
+    match fs::symlink_metadata(destination) {
+        Ok(_) => {
+            return Err(ResolveError::MergeDestinationExists {
+                path: destination.to_owned(),
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(merge_io(
+                "inspect destination",
+                destination.to_owned(),
+                error,
+            ));
+        }
+    }
+
+    let partial = parent.join(format!(".firecrab-oci-merge-{}.partial", Uuid::new_v4()));
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder
+        .create(&partial)
+        .map_err(|error| merge_io("create partial tree", partial.clone(), error))?;
+    let mut cleanup = PartialTreeCleanup::new(partial.clone());
+    let tree = partial.join("rootfs");
+    let mut tree_builder = fs::DirBuilder::new();
+    tree_builder.mode(0o700);
+    tree_builder
+        .create(&tree)
+        .map_err(|error| merge_io("create private root tree", tree.clone(), error))?;
+    let mut directory_metadata = BTreeMap::new();
+
+    let result = (|| {
+        for layer in layers {
+            control.check()?;
+            apply_layer(layer, &tree, &mut directory_metadata, control)?;
+        }
+        apply_directory_metadata(&tree, &directory_metadata, control)?;
+        control.begin_publish()?;
+        let publish_result = publish_tree(&tree, destination);
+        control.finish();
+        publish_result?;
+        Ok(MergedRootfs {
+            path: destination.to_owned(),
+        })
+    })();
+
+    if let Err(cleanup_error) = cleanup.remove_now_if_needed() {
+        tracing::warn!(
+            error = %cleanup_error,
+            path = %partial.display(),
+            "failed to remove partial OCI layer merge tree"
+        );
+    }
+    result
+}
+
+fn apply_layer(
+    layer: &ValidatedLayer,
+    root: &Path,
+    directory_metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
+    control: &MergeControl,
+) -> Result<(), ResolveError> {
+    let digest = &layer.layer.source.descriptor.digest;
+    let mut file = open_verified_layer(layer)?;
+    let plan = plan_layer(&mut file, &layer.layer.path, digest, control)?;
+
+    for whiteout in &plan.whiteouts {
+        control.check()?;
+        match whiteout {
+            Whiteout::Remove(path) => {
+                remove_merged_path(root, path, digest)?;
+                forget_directory_metadata(directory_metadata, path, true);
+            }
+            Whiteout::Opaque(path) => {
+                clear_merged_directory(root, path, digest)?;
+                forget_directory_metadata(directory_metadata, path, false);
+            }
+        }
+    }
+
+    let mut directories = plan.directories.clone();
+    directories.sort_by(|left, right| {
+        path_depth(&left.path)
+            .cmp(&path_depth(&right.path))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    for metadata in directories {
+        control.check()?;
+        prepare_directory(root, &metadata.path, digest, directory_metadata)?;
+        directory_metadata.insert(metadata.path.clone(), metadata);
+    }
+
+    extract_non_directory_entries(
+        &mut file,
+        &layer.layer.path,
+        root,
+        digest,
+        directory_metadata,
+        control,
+    )?;
+    apply_hardlinks(root, &plan.hardlinks, digest, directory_metadata, control)
+}
+
+fn open_verified_layer(layer: &ValidatedLayer) -> Result<File, ResolveError> {
+    let descriptor = &layer.layer.source.descriptor;
+    let path = &layer.layer.path;
+    let mut options = OpenOptions::new();
+    options
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    let mut file = options
+        .open(path)
+        .map_err(|error| merge_io("open validated layer", path.clone(), error))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| merge_io("inspect validated layer", path.clone(), error))?;
+    if !metadata.file_type().is_file() {
+        return Err(merge_io(
+            "inspect validated layer",
+            path.clone(),
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "layer cache entry is not a file",
+            ),
+        ));
+    }
+    if metadata.len() != layer.layer.size {
+        return Err(ResolveError::SizeMismatch {
+            subject: format!("decompressed OCI layer {}", descriptor.digest),
+            expected: layer.layer.size,
+            actual: metadata.len(),
+        });
+    }
+
+    let (size, actual) = hash_open_file(&mut file, path)?;
+    if size != layer.layer.size {
+        return Err(ResolveError::SizeMismatch {
+            subject: format!("decompressed OCI layer {}", descriptor.digest),
+            expected: layer.layer.size,
+            actual: size,
+        });
+    }
+    if actual != layer.layer.diff_id {
+        return Err(ResolveError::DiffIdMismatch {
+            compressed_digest: descriptor.digest.clone(),
+            expected: layer.layer.diff_id.clone(),
+            actual,
+        });
+    }
+    validate_layer_archive_file(&mut file, path, &descriptor.digest)?;
+    Ok(file)
+}
+
+fn hash_open_file(file: &mut File, path: &Path) -> Result<(u64, Sha256Digest), ResolveError> {
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| merge_io("rewind validated layer", path.to_owned(), error))?;
+    let mut hasher = Sha256::new();
+    let mut size = 0_u64;
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| merge_io("hash validated layer", path.to_owned(), error))?;
+        if read == 0 {
+            break;
+        }
+        size = size.checked_add(read as u64).ok_or_else(|| {
+            merge_io(
+                "hash validated layer",
+                path.to_owned(),
+                io::Error::other("layer byte count overflow"),
+            )
+        })?;
+        hasher.update(&buffer[..read]);
+    }
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| merge_io("rewind validated layer", path.to_owned(), error))?;
+    Ok((
+        size,
+        Sha256Digest(format!("sha256:{:x}", hasher.finalize())),
+    ))
+}
+
+fn plan_layer(
+    file: &mut File,
+    layer_path: &Path,
+    digest: &Sha256Digest,
+    control: &MergeControl,
+) -> Result<LayerPlan, ResolveError> {
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| merge_io("rewind layer for planning", layer_path.to_owned(), error))?;
+    let mut archive = tar::Archive::new(&mut *file);
+    let entries = archive
+        .entries()
+        .map_err(|error| malformed_layer_archive(digest, error))?;
+    let mut seen = HashSet::new();
+    let mut path_kinds = BTreeMap::new();
+    let mut whiteouts = Vec::new();
+    let mut directories = Vec::new();
+    let mut hardlinks = Vec::new();
+
+    for (index, entry) in entries.enumerate() {
+        control.check()?;
+        let entry = entry.map_err(|error| {
+            malformed_layer_archive(
+                digest,
+                format!("could not plan member {}: {error}", index + 1),
+            )
+        })?;
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_pax_global_extensions() {
+            continue;
+        }
+        let path = normalized_entry_path(&entry, digest, index + 1)?;
+        if !seen.insert(path.clone()) {
+            return Err(unsafe_tar_member(
+                digest,
+                path,
+                TarMemberViolation::DuplicatePath,
+            ));
+        }
+        if let Some(whiteout) = classify_whiteout(&entry, &path, digest)? {
+            path_kinds.insert(path.clone(), PlannedEntryKind::Whiteout);
+            whiteouts.push(whiteout);
+        } else if entry_type.is_dir() {
+            path_kinds.insert(path.clone(), PlannedEntryKind::Directory);
+            let mode = entry.header().mode().map_err(|error| {
+                malformed_layer_archive(
+                    digest,
+                    format!(
+                        "member {} has an invalid directory mode: {error}",
+                        index + 1
+                    ),
+                )
+            })?;
+            let mtime = entry.header().mtime().map_err(|error| {
+                malformed_layer_archive(
+                    digest,
+                    format!(
+                        "member {} has an invalid directory mtime: {error}",
+                        index + 1
+                    ),
+                )
+            })?;
+            let mtime = i64::try_from(mtime).map_err(|_| {
+                malformed_layer_archive(
+                    digest,
+                    format!("member {} directory mtime is out of range", index + 1),
+                )
+            })?;
+            directories.push(DirectoryMetadata { path, mode, mtime });
+        } else if entry_type.is_hard_link() {
+            path_kinds.insert(path.clone(), PlannedEntryKind::Other);
+            let target = entry
+                .link_name()
+                .map_err(|error| {
+                    malformed_layer_archive(
+                        digest,
+                        format!(
+                            "could not decode hard link target for member {}: {error}",
+                            index + 1
+                        ),
+                    )
+                })?
+                .map(|target| target.into_owned())
+                .ok_or_else(|| {
+                    unsafe_tar_member(
+                        digest,
+                        path.clone(),
+                        TarMemberViolation::MissingHardlinkTarget,
+                    )
+                })?;
+            let target = normalize_safe_path(&target).ok_or_else(|| {
+                unsafe_tar_member(
+                    digest,
+                    path.clone(),
+                    TarMemberViolation::HardlinkTarget { target },
+                )
+            })?;
+            hardlinks.push(PlannedHardlink { path, target });
+        } else {
+            path_kinds.insert(path, PlannedEntryKind::Other);
+        }
+    }
+
+    for path in path_kinds.keys() {
+        for ancestor in path.ancestors().skip(1) {
+            if ancestor.as_os_str().is_empty() {
+                break;
+            }
+            if path_kinds
+                .get(ancestor)
+                .is_some_and(|kind| *kind != PlannedEntryKind::Directory)
+            {
+                return Err(unsafe_tar_member(
+                    digest,
+                    ancestor.to_owned(),
+                    TarMemberViolation::ConflictingPath {
+                        descendant: path.clone(),
+                    },
+                ));
+            }
+        }
+    }
+
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| merge_io("rewind planned layer", layer_path.to_owned(), error))?;
+    Ok(LayerPlan {
+        whiteouts,
+        directories,
+        hardlinks,
+    })
+}
+
+fn normalized_entry_path<R: io::Read>(
+    entry: &tar::Entry<'_, R>,
+    digest: &Sha256Digest,
+    index: usize,
+) -> Result<PathBuf, ResolveError> {
+    let path = entry.path().map_err(|error| {
+        malformed_layer_archive(
+            digest,
+            format!("could not decode member {index} path while planning: {error}"),
+        )
+    })?;
+    normalize_layer_path(&path, entry.header().entry_type().is_dir())
+        .ok_or_else(|| unsafe_tar_member(digest, path.into_owned(), TarMemberViolation::Path))
+}
+
+fn normalize_safe_path(path: &Path) -> Option<PathBuf> {
+    normalize_layer_path(path, false)
+}
+
+fn normalize_layer_path(path: &Path, allow_root: bool) -> Option<PathBuf> {
+    if !(is_safe_layer_member_path(path) || allow_root && is_layer_root_path(path)) {
+        return None;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        if let std::path::Component::Normal(component) = component {
+            normalized.push(component);
+        }
+    }
+    (allow_root || !normalized.as_os_str().is_empty()).then_some(normalized)
+}
+
+fn classify_whiteout<R: io::Read>(
+    entry: &tar::Entry<'_, R>,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<Option<Whiteout>, ResolveError> {
+    let Some(basename) = path.file_name().map(|name| name.as_bytes()) else {
+        return Ok(None);
+    };
+    if !basename.starts_with(WHITEOUT_PREFIX) {
+        return Ok(None);
+    }
+    if !entry.header().entry_type().is_file() {
+        return Err(unsafe_tar_member(
+            digest,
+            path.to_owned(),
+            TarMemberViolation::InvalidWhiteoutType,
+        ));
+    }
+    if entry.size() != 0 {
+        return Err(unsafe_tar_member(
+            digest,
+            path.to_owned(),
+            TarMemberViolation::NonEmptyWhiteout { size: entry.size() },
+        ));
+    }
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+    if basename == OPAQUE_WHITEOUT {
+        return Ok(Some(Whiteout::Opaque(parent.to_owned())));
+    }
+    let target_name = &basename[WHITEOUT_PREFIX.len()..];
+    if target_name.is_empty() || matches!(target_name, b"." | b"..") {
+        return Err(unsafe_tar_member(
+            digest,
+            path.to_owned(),
+            TarMemberViolation::InvalidWhiteoutTarget,
+        ));
+    }
+    let mut target = parent.to_owned();
+    target.push(OsString::from_vec(target_name.to_vec()));
+    Ok(Some(Whiteout::Remove(target)))
+}
+
+fn extract_non_directory_entries(
+    file: &mut File,
+    layer_path: &Path,
+    root: &Path,
+    digest: &Sha256Digest,
+    directory_metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
+    control: &MergeControl,
+) -> Result<(), ResolveError> {
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(|error| merge_io("rewind layer for extraction", layer_path.to_owned(), error))?;
+    let mut archive = tar::Archive::new(&mut *file);
+    archive.set_preserve_permissions(false);
+    archive.set_preserve_ownerships(false);
+    archive.set_unpack_xattrs(false);
+    archive.set_overwrite(false);
+    let entries = archive
+        .entries()
+        .map_err(|error| malformed_layer_archive(digest, error))?;
+    for (index, entry) in entries.enumerate() {
+        control.check()?;
+        let mut entry = entry.map_err(|error| {
+            malformed_layer_archive(
+                digest,
+                format!("could not extract member {}: {error}", index + 1),
+            )
+        })?;
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_pax_global_extensions() {
+            continue;
+        }
+        let path = normalized_entry_path(&entry, digest, index + 1)?;
+        if classify_whiteout(&entry, &path, digest)?.is_some()
+            || entry_type.is_dir()
+            || entry_type.is_hard_link()
+        {
+            continue;
+        }
+        let mode = entry.header().mode().map_err(|error| {
+            malformed_layer_archive(
+                digest,
+                format!("member {} has an invalid mode: {error}", index + 1),
+            )
+        })?;
+        ensure_parent_directories(root, &path, digest)?;
+        remove_existing_target(root, &path, digest)?;
+        forget_directory_metadata(directory_metadata, &path, true);
+        let unpacked = entry
+            .unpack_in(root)
+            .map_err(|error| merge_io("extract member", path.clone(), error))?;
+        if !unpacked {
+            return Err(unsafe_tar_member(digest, path, TarMemberViolation::Path));
+        }
+        if entry_type.is_file() {
+            let destination = root.join(&path);
+            fs::set_permissions(
+                &destination,
+                fs::Permissions::from_mode(mode & HOST_SAFE_MODE_MASK),
+            )
+            .map_err(|error| merge_io("set merged file permissions", destination, error))?;
+        }
+    }
+    Ok(())
+}
+
+fn prepare_directory(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+    directory_metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
+) -> Result<(), ResolveError> {
+    ensure_parent_directories(root, path, digest)?;
+    let destination = root.join(path);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => {
+            remove_existing_target(root, path, digest)?;
+            forget_directory_metadata(directory_metadata, path, true);
+            create_merged_directory(&destination)
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            create_merged_directory(&destination)
+        }
+        Err(error) => Err(merge_io("inspect directory target", destination, error)),
+    }
+}
+
+fn ensure_parent_directories(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
+    let Some(parent) = path.parent() else {
+        return Ok(());
+    };
+    let mut relative = PathBuf::new();
+    for component in parent.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err(unsafe_tar_member(
+                digest,
+                path.to_owned(),
+                TarMemberViolation::Path,
+            ));
+        };
+        relative.push(component);
+        let candidate = root.join(&relative);
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(unsafe_tar_member(
+                    digest,
+                    path.to_owned(),
+                    TarMemberViolation::SymlinkAncestor { ancestor: relative },
+                ));
+            }
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => {
+                return Err(unsafe_tar_member(
+                    digest,
+                    path.to_owned(),
+                    TarMemberViolation::NonDirectoryAncestor { ancestor: relative },
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                create_merged_directory(&candidate)?;
+            }
+            Err(error) => return Err(merge_io("inspect path ancestor", candidate, error)),
+        }
+    }
+    Ok(())
+}
+
+fn existing_parent_is_safe(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<bool, ResolveError> {
+    let Some(parent) = path.parent() else {
+        return Ok(true);
+    };
+    let mut relative = PathBuf::new();
+    for component in parent.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err(unsafe_tar_member(
+                digest,
+                path.to_owned(),
+                TarMemberViolation::Path,
+            ));
+        };
+        relative.push(component);
+        let candidate = root.join(&relative);
+        match fs::symlink_metadata(&candidate) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(unsafe_tar_member(
+                    digest,
+                    path.to_owned(),
+                    TarMemberViolation::SymlinkAncestor { ancestor: relative },
+                ));
+            }
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => {
+                return Err(unsafe_tar_member(
+                    digest,
+                    path.to_owned(),
+                    TarMemberViolation::NonDirectoryAncestor { ancestor: relative },
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(merge_io("inspect path ancestor", candidate, error)),
+        }
+    }
+    Ok(true)
+}
+
+fn remove_merged_path(root: &Path, path: &Path, digest: &Sha256Digest) -> Result<(), ResolveError> {
+    if !lower_parent_is_directory(root, path, digest)? {
+        return Ok(());
+    }
+    let destination = root.join(path);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => fs::remove_dir_all(&destination)
+            .map_err(|error| merge_io("remove whiteout directory", destination, error)),
+        Ok(_) => fs::remove_file(&destination)
+            .map_err(|error| merge_io("remove whiteout path", destination, error)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(merge_io("inspect whiteout target", destination, error)),
+    }
+}
+
+fn lower_parent_is_directory(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<bool, ResolveError> {
+    let Some(parent) = path.parent() else {
+        return Ok(true);
+    };
+    let mut relative = PathBuf::new();
+    for component in parent.components() {
+        let std::path::Component::Normal(component) = component else {
+            return Err(unsafe_tar_member(
+                digest,
+                path.to_owned(),
+                TarMemberViolation::Path,
+            ));
+        };
+        relative.push(component);
+        match fs::symlink_metadata(root.join(&relative)) {
+            Ok(metadata) if metadata.file_type().is_dir() => {}
+            Ok(_) => return Ok(false),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(merge_io(
+                    "inspect whiteout ancestor",
+                    root.join(relative),
+                    error,
+                ));
+            }
+        }
+    }
+    Ok(true)
+}
+
+fn remove_existing_target(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
+    if !existing_parent_is_safe(root, path, digest)? {
+        return Ok(());
+    }
+    let destination = root.join(path);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => fs::remove_dir_all(&destination)
+            .map_err(|error| merge_io("remove merged directory", destination, error)),
+        Ok(_) => fs::remove_file(&destination)
+            .map_err(|error| merge_io("remove merged path", destination, error)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(merge_io("inspect merged path", destination, error)),
+    }
+}
+
+fn clear_merged_directory(
+    root: &Path,
+    path: &Path,
+    digest: &Sha256Digest,
+) -> Result<(), ResolveError> {
+    if !lower_parent_is_directory(root, path, digest)? {
+        return Ok(());
+    }
+    let directory = root.join(path);
+    let metadata = match fs::symlink_metadata(&directory) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(merge_io("inspect opaque directory", directory, error)),
+    };
+    if !metadata.file_type().is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(&directory)
+        .map_err(|error| merge_io("read opaque directory", directory.clone(), error))?
+    {
+        let entry =
+            entry.map_err(|error| merge_io("read opaque child", directory.clone(), error))?;
+        let child = entry.path();
+        let metadata = fs::symlink_metadata(&child)
+            .map_err(|error| merge_io("inspect opaque child", child.clone(), error))?;
+        if metadata.file_type().is_dir() {
+            fs::remove_dir_all(&child)
+                .map_err(|error| merge_io("remove opaque directory", child, error))?;
+        } else {
+            fs::remove_file(&child)
+                .map_err(|error| merge_io("remove opaque child", child, error))?;
+        }
+    }
+    Ok(())
+}
+
+fn apply_hardlinks(
+    root: &Path,
+    hardlinks: &[PlannedHardlink],
+    digest: &Sha256Digest,
+    directory_metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
+    control: &MergeControl,
+) -> Result<(), ResolveError> {
+    for hardlink in hardlinks {
+        control.check()?;
+        ensure_parent_directories(root, &hardlink.path, digest)?;
+        remove_existing_target(root, &hardlink.path, digest)?;
+        forget_directory_metadata(directory_metadata, &hardlink.path, true);
+    }
+
+    let mut pending = hardlinks.to_vec();
+    while !pending.is_empty() {
+        let mut unresolved = Vec::new();
+        let mut progressed = false;
+        for hardlink in pending {
+            control.check()?;
+            if !existing_parent_is_safe(root, &hardlink.target, digest)? {
+                unresolved.push(hardlink);
+                continue;
+            }
+            let source = root.join(&hardlink.target);
+            let metadata = match fs::symlink_metadata(&source) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    unresolved.push(hardlink);
+                    continue;
+                }
+                Err(error) => return Err(merge_io("inspect hard link target", source, error)),
+            };
+            if metadata.file_type().is_dir() {
+                return Err(unsafe_tar_member(
+                    digest,
+                    hardlink.path,
+                    TarMemberViolation::DirectoryHardlinkTarget {
+                        target: hardlink.target,
+                    },
+                ));
+            }
+            ensure_parent_directories(root, &hardlink.path, digest)?;
+            let destination = root.join(&hardlink.path);
+            fs::hard_link(&source, &destination)
+                .map_err(|error| merge_io("create hard link", destination, error))?;
+            progressed = true;
+        }
+        if !progressed {
+            let hardlink = unresolved
+                .into_iter()
+                .next()
+                .expect("a non-empty pending list leaves an unresolved link");
+            return Err(unsafe_tar_member(
+                digest,
+                hardlink.path,
+                TarMemberViolation::MissingMergedHardlinkTarget {
+                    target: hardlink.target,
+                },
+            ));
+        }
+        pending = unresolved;
+    }
+    Ok(())
+}
+
+fn apply_directory_metadata(
+    root: &Path,
+    metadata: &BTreeMap<PathBuf, DirectoryMetadata>,
+    control: &MergeControl,
+) -> Result<(), ResolveError> {
+    let has_root_metadata = metadata.contains_key(Path::new(""));
+    let mut metadata: Vec<&DirectoryMetadata> = metadata.values().collect();
+    metadata.sort_by(|left, right| {
+        path_depth(&right.path)
+            .cmp(&path_depth(&left.path))
+            .then_with(|| left.path.cmp(&right.path))
+    });
+    for metadata in metadata {
+        control.check()?;
+        let destination = root.join(&metadata.path);
+        let current = fs::symlink_metadata(&destination)
+            .map_err(|error| merge_io("inspect final directory", destination.clone(), error))?;
+        if !current.file_type().is_dir() {
+            return Err(merge_io(
+                "inspect final directory",
+                destination,
+                io::Error::new(io::ErrorKind::InvalidData, "directory entry was replaced"),
+            ));
+        }
+        fs::set_permissions(
+            &destination,
+            fs::Permissions::from_mode(metadata.mode & HOST_SAFE_MODE_MASK),
+        )
+        .map_err(|error| merge_io("set directory permissions", destination.clone(), error))?;
+        let mtime = filetime::FileTime::from_unix_time(metadata.mtime, 0);
+        filetime::set_file_mtime(&destination, mtime)
+            .map_err(|error| merge_io("set directory mtime", destination, error))?;
+    }
+    if !has_root_metadata {
+        control.check()?;
+        fs::set_permissions(root, fs::Permissions::from_mode(0o755))
+            .map_err(|error| merge_io("set default root permissions", root.to_owned(), error))?;
+    }
+    Ok(())
+}
+
+fn forget_directory_metadata(
+    metadata: &mut BTreeMap<PathBuf, DirectoryMetadata>,
+    path: &Path,
+    include_path: bool,
+) {
+    metadata.retain(|candidate, _| {
+        !(candidate.starts_with(path) && (include_path || candidate != path))
+    });
+}
+
+fn create_merged_directory(path: &Path) -> Result<(), ResolveError> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o755);
+    builder
+        .create(path)
+        .map_err(|error| merge_io("create merged directory", path.to_owned(), error))
+}
+
+fn path_depth(path: &Path) -> usize {
+    path.components().count()
+}
+
+fn publish_tree(partial: &Path, destination: &Path) -> Result<(), ResolveError> {
+    let source = CString::new(partial.as_os_str().as_bytes()).map_err(|error| {
+        merge_io(
+            "encode partial path",
+            partial.to_owned(),
+            io::Error::new(io::ErrorKind::InvalidInput, error),
+        )
+    })?;
+    let target = CString::new(destination.as_os_str().as_bytes()).map_err(|error| {
+        merge_io(
+            "encode destination path",
+            destination.to_owned(),
+            io::Error::new(io::ErrorKind::InvalidInput, error),
+        )
+    })?;
+    // libc does not expose renameat2 on every Linux libc (notably musl), but
+    // Firecrab's release architectures all provide the kernel syscall.
+    let result = unsafe {
+        libc::syscall(
+            libc::SYS_renameat2,
+            libc::AT_FDCWD,
+            source.as_ptr(),
+            libc::AT_FDCWD,
+            target.as_ptr(),
+            libc::RENAME_NOREPLACE,
+        )
+    };
+    if result == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.kind() == io::ErrorKind::AlreadyExists {
+        return Err(ResolveError::MergeDestinationExists {
+            path: destination.to_owned(),
+        });
+    }
+    Err(merge_io(
+        "publish partial tree",
+        destination.to_owned(),
+        error,
+    ))
+}
+
+fn merge_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
+    ResolveError::MergeIo {
+        operation,
+        path,
+        source,
+    }
+}
+
+struct PartialTreeCleanup {
+    path: PathBuf,
+    published: bool,
+}
+
+impl PartialTreeCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            published: false,
+        }
+    }
+
+    fn remove_now_if_needed(&mut self) -> Result<(), ResolveError> {
+        if self.published {
+            return Ok(());
+        }
+        make_tree_owner_accessible(&self.path);
+        match fs::remove_dir_all(&self.path) {
+            Ok(()) => {
+                self.published = true;
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                self.published = true;
+                Ok(())
+            }
+            Err(error) => Err(merge_io("remove partial tree", self.path.clone(), error)),
+        }
+    }
+}
+
+impl Drop for PartialTreeCleanup {
+    fn drop(&mut self) {
+        if !self.published {
+            make_tree_owner_accessible(&self.path);
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+fn make_tree_owner_accessible(path: &Path) {
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return;
+    };
+    if !metadata.file_type().is_dir() {
+        return;
+    }
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let child = entry.path();
+        if fs::symlink_metadata(&child)
+            .map(|metadata| metadata.file_type().is_dir())
+            .unwrap_or(false)
+        {
+            make_tree_owner_accessible(&child);
+        }
+    }
+}

--- a/firecrab-api/src/oci/merge_tests.rs
+++ b/firecrab-api/src/oci/merge_tests.rs
@@ -1,0 +1,910 @@
+use super::*;
+
+use std::io::Cursor;
+use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+use tar::{Builder, EntryType, Header};
+use tempfile::{TempDir, tempdir};
+
+fn header(entry_type: EntryType, size: u64, mode: u32) -> Header {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header
+}
+
+fn append_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+    data: &[u8],
+    mode: u32,
+) {
+    let mut header = header(entry_type, data.len() as u64, mode);
+    if let Some(target) = target {
+        header
+            .set_link_name_literal(target.as_bytes())
+            .expect("set fixture link target");
+    }
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+fn append_raw_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    data: &[u8],
+    mode: u32,
+) {
+    let mut header = header(entry_type, data.len() as u64, mode);
+    let name = &mut header.as_old_mut().name;
+    assert!(path.len() < name.len(), "fixture path fits raw tar header");
+    name[..path.len()].copy_from_slice(path.as_bytes());
+    header.set_cksum();
+    builder
+        .append(&header, Cursor::new(data))
+        .expect("append raw fixture tar entry");
+}
+
+fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
+    builder.into_inner().expect("finish fixture tar")
+}
+
+fn layer(directory: &TempDir, name: &str, bytes: &[u8]) -> DecompressedLayer {
+    let compressed_bytes = format!("compressed merge fixture {name}").into_bytes();
+    let compressed_digest = Sha256Digest::of_bytes(&compressed_bytes);
+    let compressed_path = directory.path().join(format!("{name}.blob"));
+    std::fs::write(&compressed_path, &compressed_bytes).expect("write compressed fixture");
+    let path = directory.path().join(format!("{name}.tar"));
+    std::fs::write(&path, bytes).expect("write tar fixture");
+    DecompressedLayer {
+        source: CachedBlob {
+            descriptor: Descriptor {
+                media_type: OCI_LAYER_MEDIA_TYPE.to_owned(),
+                digest: compressed_digest,
+                size: compressed_bytes.len() as u64,
+            },
+            path: compressed_path,
+        },
+        diff_id: Sha256Digest::of_bytes(bytes),
+        path,
+        size: bytes.len() as u64,
+    }
+}
+
+async fn validate(layers: Vec<DecompressedLayer>) -> Vec<ValidatedLayer> {
+    validate_decompressed_layers(layers)
+        .await
+        .expect("validate merge fixtures")
+}
+
+fn assert_no_partial_trees(parent: &Path) {
+    for entry in std::fs::read_dir(parent).expect("read merge parent") {
+        let name = entry
+            .expect("read merge parent entry")
+            .file_name()
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            !name.starts_with(".firecrab-oci-merge-") || !name.ends_with(".partial"),
+            "unexpected partial merge tree {name}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn layers_merge_in_manifest_order_and_replace_path_types() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut base = Builder::new(Vec::new());
+    append_raw_entry(&mut base, "./", EntryType::Directory, &[], 0o1750);
+    append_entry(&mut base, "etc/", EntryType::Directory, None, &[], 0o750);
+    append_entry(
+        &mut base,
+        "etc/version",
+        EntryType::Regular,
+        None,
+        b"base",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "etc/lower-kept",
+        EntryType::Regular,
+        None,
+        b"kept",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "file-to-dir",
+        EntryType::Regular,
+        None,
+        b"old file",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "dir-to-file/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    append_entry(
+        &mut base,
+        "dir-to-file/old",
+        EntryType::Regular,
+        None,
+        b"old child",
+        0o644,
+    );
+    append_entry(&mut base, "tmp/", EntryType::Directory, None, &[], 0o1777);
+    let base = finish(base);
+
+    let mut top = Builder::new(Vec::new());
+    append_entry(&mut top, "etc/", EntryType::Directory, None, &[], 0o700);
+    append_entry(
+        &mut top,
+        "etc/version",
+        EntryType::Regular,
+        None,
+        b"top",
+        0o600,
+    );
+    append_entry(
+        &mut top,
+        "file-to-dir/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o711,
+    );
+    append_entry(
+        &mut top,
+        "file-to-dir/new",
+        EntryType::Regular,
+        None,
+        b"new child",
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "dir-to-file",
+        EntryType::Regular,
+        None,
+        b"new file",
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "bin/copy",
+        EntryType::Link,
+        Some("bin/target"),
+        &[],
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "bin/target",
+        EntryType::Regular,
+        None,
+        b"binary",
+        0o4755,
+    );
+    append_entry(
+        &mut top,
+        "bin/current",
+        EntryType::Symlink,
+        Some("target"),
+        &[],
+        0o777,
+    );
+    append_entry(
+        &mut top,
+        "bin/chain-a",
+        EntryType::Link,
+        Some("bin/chain-b"),
+        &[],
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "bin/chain-b",
+        EntryType::Link,
+        Some("bin/target"),
+        &[],
+        0o644,
+    );
+    let top = finish(top);
+    let layers = validate(vec![
+        layer(&directory, "ordered-base", &base),
+        layer(&directory, "ordered-top", &top),
+    ])
+    .await;
+    let destination = directory.path().join("rootfs");
+
+    let merged = merge_validated_layers(&layers, &destination)
+        .await
+        .expect("merge ordered layers");
+
+    assert_eq!(merged.path(), destination);
+    assert_eq!(
+        std::fs::read(destination.join("etc/version")).unwrap(),
+        b"top"
+    );
+    assert_eq!(
+        std::fs::read(destination.join("file-to-dir/new")).unwrap(),
+        b"new child"
+    );
+    assert_eq!(
+        std::fs::read(destination.join("etc/lower-kept")).unwrap(),
+        b"kept"
+    );
+    assert_eq!(
+        std::fs::metadata(destination.join("etc"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777,
+        0o700
+    );
+    assert_eq!(
+        std::fs::read(destination.join("dir-to-file")).unwrap(),
+        b"new file"
+    );
+    assert!(!destination.join("dir-to-file/old").exists());
+    assert_eq!(
+        std::fs::read_link(destination.join("bin/current")).unwrap(),
+        Path::new("target")
+    );
+    let target = std::fs::metadata(destination.join("bin/target")).unwrap();
+    let copy = std::fs::metadata(destination.join("bin/copy")).unwrap();
+    assert_eq!(target.ino(), copy.ino());
+    assert_eq!(target.permissions().mode() & 0o7777, 0o755);
+    assert_eq!(
+        target.ino(),
+        std::fs::metadata(destination.join("bin/chain-a"))
+            .unwrap()
+            .ino()
+    );
+    assert_eq!(
+        std::fs::metadata(destination.join("file-to-dir"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777,
+        0o711
+    );
+    assert_eq!(
+        std::fs::metadata(&destination)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777,
+        0o1750
+    );
+    assert_eq!(std::fs::metadata(&destination).unwrap().mtime(), 0);
+    assert_eq!(
+        std::fs::metadata(destination.join("tmp"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777,
+        0o1777
+    );
+}
+
+#[tokio::test]
+async fn whiteouts_affect_only_lower_entries_and_are_never_materialized() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut base = Builder::new(Vec::new());
+    append_entry(
+        &mut base,
+        "etc/value",
+        EntryType::Regular,
+        None,
+        b"lower",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "var/gone/child",
+        EntryType::Regular,
+        None,
+        b"remove me",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "var/keep",
+        EntryType::Regular,
+        None,
+        b"keep me",
+        0o644,
+    );
+    let base = finish(base);
+
+    let mut top = Builder::new(Vec::new());
+    append_entry(
+        &mut top,
+        "etc/value",
+        EntryType::Regular,
+        None,
+        b"same-layer replacement",
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "etc/.wh.value",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut top,
+        "var/.wh.gone",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut top,
+        "var/.wh.missing",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    let top = finish(top);
+    let layers = validate(vec![
+        layer(&directory, "whiteout-base", &base),
+        layer(&directory, "whiteout-top", &top),
+    ])
+    .await;
+    let destination = directory.path().join("rootfs");
+
+    merge_validated_layers(&layers, &destination)
+        .await
+        .expect("apply explicit whiteouts");
+
+    assert_eq!(
+        std::fs::read(destination.join("etc/value")).unwrap(),
+        b"same-layer replacement"
+    );
+    assert!(!destination.join("var/gone").exists());
+    assert_eq!(
+        std::fs::read(destination.join("var/keep")).unwrap(),
+        b"keep me"
+    );
+    assert_eq!(
+        std::fs::metadata(&destination)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o7777,
+        0o755
+    );
+    assert!(!destination.join("etc/.wh.value").exists());
+    assert!(!destination.join("var/.wh.gone").exists());
+}
+
+#[tokio::test]
+async fn opaque_whiteouts_keep_current_layer_entries_regardless_of_tar_order() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut base = Builder::new(Vec::new());
+    append_entry(
+        &mut base,
+        "app/lower",
+        EntryType::Regular,
+        None,
+        b"lower",
+        0o644,
+    );
+    append_entry(
+        &mut base,
+        "app/nested/lower",
+        EntryType::Regular,
+        None,
+        b"nested lower",
+        0o644,
+    );
+    let base = finish(base);
+    let mut top = Builder::new(Vec::new());
+    append_entry(
+        &mut top,
+        "app/current",
+        EntryType::Regular,
+        None,
+        b"current",
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "app/nested/current",
+        EntryType::Regular,
+        None,
+        b"nested current",
+        0o644,
+    );
+    append_entry(
+        &mut top,
+        "app/.wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    let top = finish(top);
+    let layers = validate(vec![
+        layer(&directory, "opaque-base", &base),
+        layer(&directory, "opaque-top", &top),
+    ])
+    .await;
+    let destination = directory.path().join("rootfs");
+
+    merge_validated_layers(&layers, &destination)
+        .await
+        .expect("apply opaque whiteout");
+
+    assert!(!destination.join("app/lower").exists());
+    assert!(!destination.join("app/nested/lower").exists());
+    assert_eq!(
+        std::fs::read(destination.join("app/current")).unwrap(),
+        b"current"
+    );
+    assert_eq!(
+        std::fs::read(destination.join("app/nested/current")).unwrap(),
+        b"nested current"
+    );
+    assert!(!destination.join("app/.wh..wh..opq").exists());
+
+    let mut replacement_base = Builder::new(Vec::new());
+    append_entry(
+        &mut replacement_base,
+        "replace",
+        EntryType::Regular,
+        None,
+        b"lower file",
+        0o644,
+    );
+    let replacement_base = finish(replacement_base);
+    let mut replacement_top = Builder::new(Vec::new());
+    append_entry(
+        &mut replacement_top,
+        "replace/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    append_entry(
+        &mut replacement_top,
+        "replace/.wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut replacement_top,
+        "replace/current",
+        EntryType::Regular,
+        None,
+        b"current",
+        0o644,
+    );
+    let replacement_top = finish(replacement_top);
+    let replacement_layers = validate(vec![
+        layer(&directory, "opaque-file-base", &replacement_base),
+        layer(&directory, "opaque-file-top", &replacement_top),
+    ])
+    .await;
+    let replacement_destination = directory.path().join("replacement-rootfs");
+    merge_validated_layers(&replacement_layers, &replacement_destination)
+        .await
+        .expect("opaque directory may replace a lower non-directory");
+    assert_eq!(
+        std::fs::read(replacement_destination.join("replace/current")).unwrap(),
+        b"current"
+    );
+
+    let mut root_base = Builder::new(Vec::new());
+    append_entry(
+        &mut root_base,
+        "lower",
+        EntryType::Regular,
+        None,
+        b"lower",
+        0o644,
+    );
+    let root_base = finish(root_base);
+    let mut root_top = Builder::new(Vec::new());
+    append_entry(
+        &mut root_top,
+        "current",
+        EntryType::Regular,
+        None,
+        b"current",
+        0o644,
+    );
+    append_entry(
+        &mut root_top,
+        ".wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    let root_top = finish(root_top);
+    let root_layers = validate(vec![
+        layer(&directory, "opaque-root-base", &root_base),
+        layer(&directory, "opaque-root-top", &root_top),
+    ])
+    .await;
+    let root_destination = directory.path().join("opaque-rootfs");
+    merge_validated_layers(&root_layers, &root_destination)
+        .await
+        .expect("apply root opaque whiteout");
+    assert!(!root_destination.join("lower").exists());
+    assert_eq!(
+        std::fs::read(root_destination.join("current")).unwrap(),
+        b"current"
+    );
+}
+
+#[tokio::test]
+async fn invalid_whiteouts_and_ambiguous_paths_fail_without_publishing() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut invalid_type = Builder::new(Vec::new());
+    append_entry(
+        &mut invalid_type,
+        ".wh.victim",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    let mut nonempty = Builder::new(Vec::new());
+    append_entry(
+        &mut nonempty,
+        ".wh.victim",
+        EntryType::Regular,
+        None,
+        b"x",
+        0o000,
+    );
+    let mut duplicate = Builder::new(Vec::new());
+    append_entry(
+        &mut duplicate,
+        "duplicate",
+        EntryType::Regular,
+        None,
+        b"one",
+        0o644,
+    );
+    append_raw_entry(
+        &mut duplicate,
+        "./duplicate",
+        EntryType::Regular,
+        b"two",
+        0o644,
+    );
+    let mut conflict = Builder::new(Vec::new());
+    append_entry(
+        &mut conflict,
+        "parent",
+        EntryType::Regular,
+        None,
+        b"file",
+        0o644,
+    );
+    let mut marker_conflict = Builder::new(Vec::new());
+    append_entry(
+        &mut marker_conflict,
+        "parent/.wh.child",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut marker_conflict,
+        "parent/.wh.child/descendant",
+        EntryType::Regular,
+        None,
+        b"ambiguous",
+        0o644,
+    );
+    append_entry(
+        &mut conflict,
+        "parent/child",
+        EntryType::Regular,
+        None,
+        b"child",
+        0o644,
+    );
+    let mut missing_hardlink = Builder::new(Vec::new());
+    append_entry(
+        &mut missing_hardlink,
+        "hardlink",
+        EntryType::Link,
+        Some("missing"),
+        &[],
+        0o644,
+    );
+    let mut directory_hardlink = Builder::new(Vec::new());
+    append_entry(
+        &mut directory_hardlink,
+        "target/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    append_entry(
+        &mut directory_hardlink,
+        "hardlink",
+        EntryType::Link,
+        Some("target"),
+        &[],
+        0o644,
+    );
+
+    let fixtures = [
+        (
+            "empty-whiteout-target",
+            {
+                let mut builder = Builder::new(Vec::new());
+                append_entry(&mut builder, ".wh.", EntryType::Regular, None, &[], 0o000);
+                finish(builder)
+            },
+            TarMemberViolation::InvalidWhiteoutTarget,
+        ),
+        (
+            "dot-whiteout-target",
+            {
+                let mut builder = Builder::new(Vec::new());
+                append_entry(&mut builder, ".wh..", EntryType::Regular, None, &[], 0o000);
+                finish(builder)
+            },
+            TarMemberViolation::InvalidWhiteoutTarget,
+        ),
+        (
+            "dotdot-whiteout-target",
+            {
+                let mut builder = Builder::new(Vec::new());
+                append_entry(&mut builder, ".wh...", EntryType::Regular, None, &[], 0o000);
+                finish(builder)
+            },
+            TarMemberViolation::InvalidWhiteoutTarget,
+        ),
+        (
+            "whiteout-type",
+            finish(invalid_type),
+            TarMemberViolation::InvalidWhiteoutType,
+        ),
+        (
+            "whiteout-payload",
+            finish(nonempty),
+            TarMemberViolation::NonEmptyWhiteout { size: 1 },
+        ),
+        (
+            "duplicate-path",
+            finish(duplicate),
+            TarMemberViolation::DuplicatePath,
+        ),
+        (
+            "conflicting-path",
+            finish(conflict),
+            TarMemberViolation::ConflictingPath {
+                descendant: PathBuf::from("parent/child"),
+            },
+        ),
+        (
+            "marker-conflicting-path",
+            finish(marker_conflict),
+            TarMemberViolation::ConflictingPath {
+                descendant: PathBuf::from("parent/.wh.child/descendant"),
+            },
+        ),
+        (
+            "missing-hardlink",
+            finish(missing_hardlink),
+            TarMemberViolation::MissingMergedHardlinkTarget {
+                target: PathBuf::from("missing"),
+            },
+        ),
+        (
+            "directory-hardlink",
+            finish(directory_hardlink),
+            TarMemberViolation::DirectoryHardlinkTarget {
+                target: PathBuf::from("target"),
+            },
+        ),
+    ];
+
+    for (name, bytes, expected) in fixtures {
+        let layers = validate(vec![layer(&directory, name, &bytes)]).await;
+        let destination = directory.path().join(format!("{name}-rootfs"));
+        let error = merge_validated_layers(&layers, &destination)
+            .await
+            .expect_err("invalid merge layer must fail");
+        assert!(matches!(
+            error,
+            ResolveError::UnsafeTarMember { reason, .. } if reason == expected
+        ));
+        assert!(!destination.exists());
+        assert_no_partial_trees(directory.path());
+    }
+}
+
+#[tokio::test]
+async fn lower_symlink_ancestors_cannot_write_or_whiteout_outside_the_tree() {
+    let directory = tempdir().expect("create fixture directory");
+    let outside = directory.path().join("outside");
+    std::fs::create_dir(&outside).expect("create outside directory");
+    std::fs::write(outside.join("sentinel"), b"unchanged").expect("write outside sentinel");
+    let target = outside.to_string_lossy();
+    let mut base = Builder::new(Vec::new());
+    append_entry(
+        &mut base,
+        "escape",
+        EntryType::Symlink,
+        Some(&target),
+        &[],
+        0o777,
+    );
+    let base = finish(base);
+    let upper_fixtures = [
+        (
+            "write-through-symlink",
+            {
+                let mut builder = Builder::new(Vec::new());
+                append_entry(
+                    &mut builder,
+                    "escape/sentinel",
+                    EntryType::Regular,
+                    None,
+                    b"changed",
+                    0o644,
+                );
+                finish(builder)
+            },
+            false,
+        ),
+        (
+            "whiteout-through-symlink",
+            {
+                let mut builder = Builder::new(Vec::new());
+                append_entry(
+                    &mut builder,
+                    "escape/.wh.sentinel",
+                    EntryType::Regular,
+                    None,
+                    &[],
+                    0o000,
+                );
+                finish(builder)
+            },
+            true,
+        ),
+    ];
+
+    for (name, upper, succeeds_as_noop) in upper_fixtures {
+        let layers = validate(vec![
+            layer(&directory, &format!("{name}-base"), &base),
+            layer(&directory, &format!("{name}-top"), &upper),
+        ])
+        .await;
+        let destination = directory.path().join(format!("{name}-rootfs"));
+        let result = merge_validated_layers(&layers, &destination).await;
+        if succeeds_as_noop {
+            result.expect("a whiteout below a lower symlink is a lexical no-op");
+            assert_eq!(
+                std::fs::read_link(destination.join("escape")).unwrap(),
+                Path::new(target.as_ref())
+            );
+        } else {
+            let error = result.expect_err("ordinary writes must not traverse a lower symlink");
+            assert!(matches!(
+                error,
+                ResolveError::UnsafeTarMember {
+                    reason: TarMemberViolation::SymlinkAncestor { ancestor },
+                    ..
+                } if ancestor == Path::new("escape")
+            ));
+            assert!(!destination.exists());
+        }
+        assert_eq!(
+            std::fs::read(outside.join("sentinel")).unwrap(),
+            b"unchanged"
+        );
+        assert_no_partial_trees(directory.path());
+    }
+}
+
+#[tokio::test]
+async fn stale_validated_bytes_and_preexisting_destinations_are_not_published_over() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut first = Builder::new(Vec::new());
+    append_entry(
+        &mut first,
+        "value",
+        EntryType::Regular,
+        None,
+        b"first",
+        0o644,
+    );
+    let first = finish(first);
+    let mut replacement = Builder::new(Vec::new());
+    append_entry(
+        &mut replacement,
+        "value",
+        EntryType::Regular,
+        None,
+        b"other",
+        0o644,
+    );
+    let replacement = finish(replacement);
+    assert_eq!(first.len(), replacement.len());
+    let decompressed = layer(&directory, "stale", &first);
+    let layer_path = decompressed.path.clone();
+    let layers = validate(vec![decompressed]).await;
+    std::fs::write(&layer_path, &replacement).expect("replace validated tar bytes");
+    let destination = directory.path().join("stale-rootfs");
+
+    let error = merge_validated_layers(&layers, &destination)
+        .await
+        .expect_err("changed validated bytes must be rehashed");
+    assert!(matches!(error, ResolveError::DiffIdMismatch { .. }));
+    assert!(!destination.exists());
+    assert_no_partial_trees(directory.path());
+
+    let existing = directory.path().join("existing-rootfs");
+    std::fs::create_dir(&existing).expect("create existing destination");
+    std::fs::write(existing.join("sentinel"), b"unchanged").unwrap();
+    let error = merge_validated_layers(&[], &existing)
+        .await
+        .expect_err("existing destination must not be replaced");
+    assert!(matches!(error, ResolveError::MergeDestinationExists { path } if path == existing));
+    assert_eq!(
+        std::fs::read(existing.join("sentinel")).unwrap(),
+        b"unchanged"
+    );
+    assert_no_partial_trees(directory.path());
+}
+
+#[tokio::test]
+async fn only_directory_entries_may_name_the_archive_root() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_raw_entry(
+        &mut builder,
+        "./",
+        EntryType::Regular,
+        b"not a directory",
+        0o644,
+    );
+    let bytes = finish(builder);
+    let error = validate_decompressed_layers(vec![layer(&directory, "root-file", &bytes)])
+        .await
+        .expect_err("an archive-root regular file must fail preflight");
+
+    assert!(matches!(
+        error,
+        ResolveError::UnsafeTarMember {
+            path,
+            reason: TarMemberViolation::Path,
+            ..
+        } if path == Path::new(".")
+    ));
+}

--- a/firecrab-api/src/oci/merge_tests.rs
+++ b/firecrab-api/src/oci/merge_tests.rs
@@ -908,3 +908,285 @@ async fn only_directory_entries_may_name_the_archive_root() {
         } if path == Path::new(".")
     ));
 }
+
+#[tokio::test]
+async fn merge_destinations_must_name_a_directory_below_a_parent() {
+    let directory = tempdir().expect("create fixture directory");
+
+    let error = merge_validated_layers(&[], Path::new("/"))
+        .await
+        .expect_err("a destination without a parent must fail");
+    assert!(matches!(
+        error,
+        ResolveError::MergeIo { operation, path, .. }
+            if operation == "resolve destination parent" && path == Path::new("/")
+    ));
+
+    let unnamed = directory.path().join("..");
+    let error = merge_validated_layers(&[], &unnamed)
+        .await
+        .expect_err("a destination without a final component must fail");
+    assert!(matches!(
+        error,
+        ResolveError::MergeIo { operation, path, .. }
+            if operation == "resolve destination name" && path == unnamed
+    ));
+    assert_no_partial_trees(directory.path());
+}
+
+#[tokio::test]
+async fn hard_link_targets_must_resolve_inside_the_merged_tree() {
+    let directory = tempdir().expect("create fixture directory");
+    let outside = directory.path().join("hardlink-outside");
+    std::fs::create_dir(&outside).expect("create outside directory");
+    std::fs::write(outside.join("sentinel"), b"unchanged").expect("write outside sentinel");
+
+    let mut symlink_base = Builder::new(Vec::new());
+    append_entry(
+        &mut symlink_base,
+        "escape",
+        EntryType::Symlink,
+        Some(&outside.to_string_lossy()),
+        &[],
+        0o777,
+    );
+    let mut symlink_top = Builder::new(Vec::new());
+    append_entry(
+        &mut symlink_top,
+        "link",
+        EntryType::Link,
+        Some("escape/sentinel"),
+        &[],
+        0o644,
+    );
+
+    let mut file_base = Builder::new(Vec::new());
+    append_entry(
+        &mut file_base,
+        "blocker",
+        EntryType::Regular,
+        None,
+        b"file",
+        0o644,
+    );
+    let mut file_top = Builder::new(Vec::new());
+    append_entry(
+        &mut file_top,
+        "link",
+        EntryType::Link,
+        Some("blocker/inner"),
+        &[],
+        0o644,
+    );
+
+    let mut missing_parent = Builder::new(Vec::new());
+    append_entry(
+        &mut missing_parent,
+        "link",
+        EntryType::Link,
+        Some("absent/target"),
+        &[],
+        0o644,
+    );
+
+    let fixtures = [
+        (
+            "hardlink-symlink-ancestor",
+            Some(finish(symlink_base)),
+            finish(symlink_top),
+            TarMemberViolation::SymlinkAncestor {
+                ancestor: PathBuf::from("escape"),
+            },
+        ),
+        (
+            "hardlink-file-ancestor",
+            Some(finish(file_base)),
+            finish(file_top),
+            TarMemberViolation::NonDirectoryAncestor {
+                ancestor: PathBuf::from("blocker"),
+            },
+        ),
+        (
+            "hardlink-missing-parent",
+            None,
+            finish(missing_parent),
+            TarMemberViolation::MissingMergedHardlinkTarget {
+                target: PathBuf::from("absent/target"),
+            },
+        ),
+    ];
+
+    for (name, base, top, expected) in fixtures {
+        let mut decompressed = Vec::new();
+        if let Some(base) = &base {
+            decompressed.push(layer(&directory, &format!("{name}-base"), base));
+        }
+        decompressed.push(layer(&directory, &format!("{name}-top"), &top));
+        let layers = validate(decompressed).await;
+        let destination = directory.path().join(format!("{name}-rootfs"));
+        let error = merge_validated_layers(&layers, &destination)
+            .await
+            .expect_err("an unresolvable hard link target must fail");
+        assert!(matches!(
+            error,
+            ResolveError::UnsafeTarMember { reason, .. } if reason == expected
+        ));
+        assert!(!destination.exists());
+        assert_no_partial_trees(directory.path());
+    }
+
+    assert_eq!(
+        std::fs::read(outside.join("sentinel")).unwrap(),
+        b"unchanged"
+    );
+}
+
+#[tokio::test]
+async fn whiteouts_below_missing_directories_are_lexical_no_ops() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut base = Builder::new(Vec::new());
+    append_entry(
+        &mut base,
+        "present/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    let base = finish(base);
+    let mut removals = Builder::new(Vec::new());
+    append_entry(
+        &mut removals,
+        "absent/gone/.wh.victim",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut removals,
+        "absent/hidden/.wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    append_entry(
+        &mut removals,
+        "present/hidden/.wh..wh..opq",
+        EntryType::Regular,
+        None,
+        &[],
+        0o000,
+    );
+    let removals = finish(removals);
+
+    let layers = validate(vec![
+        layer(&directory, "whiteout-missing-base", &base),
+        layer(&directory, "whiteout-missing-top", &removals),
+    ])
+    .await;
+    let destination = directory.path().join("whiteout-missing-rootfs");
+    let merged = merge_validated_layers(&layers, &destination)
+        .await
+        .expect("whiteouts without a lower directory must not fail the merge");
+
+    assert_eq!(merged.path(), destination);
+    assert!(destination.join("present").is_dir());
+    assert!(!destination.join("absent").exists());
+    assert!(!destination.join("present/hidden").exists());
+    assert_no_partial_trees(directory.path());
+}
+
+#[tokio::test]
+async fn members_may_not_be_written_beneath_a_lower_layer_file() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut base = Builder::new(Vec::new());
+    append_entry(
+        &mut base,
+        "blocker",
+        EntryType::Regular,
+        None,
+        b"file",
+        0o644,
+    );
+    let base = finish(base);
+    let mut top = Builder::new(Vec::new());
+    append_entry(
+        &mut top,
+        "blocker/child",
+        EntryType::Regular,
+        None,
+        b"child",
+        0o644,
+    );
+    let top = finish(top);
+
+    let layers = validate(vec![
+        layer(&directory, "nondirectory-ancestor-base", &base),
+        layer(&directory, "nondirectory-ancestor-top", &top),
+    ])
+    .await;
+    let destination = directory.path().join("nondirectory-ancestor-rootfs");
+    let error = merge_validated_layers(&layers, &destination)
+        .await
+        .expect_err("a lower-layer file must not silently become a directory");
+
+    assert!(matches!(
+        error,
+        ResolveError::UnsafeTarMember {
+            reason: TarMemberViolation::NonDirectoryAncestor { ancestor },
+            ..
+        } if ancestor == Path::new("blocker")
+    ));
+    assert!(!destination.exists());
+    assert_no_partial_trees(directory.path());
+}
+
+#[tokio::test]
+async fn cache_entries_swapped_after_validation_are_rejected() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "value",
+        EntryType::Regular,
+        None,
+        b"first",
+        0o644,
+    );
+    let bytes = finish(builder);
+
+    let decompressed = layer(&directory, "swapped-directory", &bytes);
+    let layer_path = decompressed.path.clone();
+    let layers = validate(vec![decompressed]).await;
+    std::fs::remove_file(&layer_path).expect("remove validated tar");
+    std::fs::create_dir(&layer_path).expect("replace validated tar with a directory");
+    let destination = directory.path().join("swapped-directory-rootfs");
+    let error = merge_validated_layers(&layers, &destination)
+        .await
+        .expect_err("a cache entry that is no longer a file must fail");
+    assert!(matches!(
+        error,
+        ResolveError::MergeIo { operation, .. } if operation == "inspect validated layer"
+    ));
+    assert!(!destination.exists());
+    assert_no_partial_trees(directory.path());
+
+    let decompressed = layer(&directory, "swapped-size", &bytes);
+    let layer_path = decompressed.path.clone();
+    let declared_size = decompressed.size;
+    let layers = validate(vec![decompressed]).await;
+    std::fs::write(&layer_path, &bytes[..bytes.len() - 512]).expect("shrink validated tar");
+    let destination = directory.path().join("swapped-size-rootfs");
+    let error = merge_validated_layers(&layers, &destination)
+        .await
+        .expect_err("a resized cache entry must fail");
+    assert!(matches!(
+        error,
+        ResolveError::SizeMismatch { expected, actual, .. }
+            if expected == declared_size && actual == declared_size - 512
+    ));
+    assert!(!destination.exists());
+    assert_no_partial_trees(directory.path());
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -56,8 +56,9 @@ process-wide, and each zstd decoder has a 128 MiB window limit.
 ## Layer safety preflight
 
 Before extraction, the internal pipeline scans every decompressed tar using
-GNU long-name/link metadata and PAX overrides. Member names must be non-empty
-relative paths without parent components. Character and block devices are
+GNU long-name/link metadata and PAX overrides. Member names must be relative
+paths without parent components; only a directory may name the archive root
+as `.` or `./`. Character and block devices are
 rejected, as are unsupported special entries. Links must name a target;
 hard-link targets are archive-root-relative and cannot be absolute or contain
 parent components. Regular whiteout files remain valid for the later merge
@@ -71,10 +72,32 @@ boundaries or destinations. Each GNU or PAX metadata entry is limited to 1
 MiB. Rejection does not delete the already verified compressed blob or
 decompressed tar: both remain valid content-addressed cache entries.
 
-Extraction, whiteout handling, and layer merging remain separate import
-stages. Symbolic links are kept as metadata here; extraction must remain rooted
-without following one while creating later members. Inspect does not run
-decompression or validation, and does not fill either OCI cache.
+## Layer merge
+
+The internal merge stage consumes validated, uncompressed tar streams in
+manifest order. It reopens each stream without following a cache-path symlink,
+then rechecks its exact size, config `diff_id`, and archive safety before
+changing the filesystem tree.
+
+The host staging tree preserves ordinary and sticky permissions but remains
+owned by the unprivileged API service. It does not activate image-supplied
+set-ID bits or apply numeric ownership and extended attributes; those guest
+filesystem attributes belong to the later ext4 construction stage.
+
+For each layer, `.wh.<name>` removes the named sibling from lower layers and
+`.wh..wh..opq` removes lower-layer children from its directory. Whiteouts are
+applied before that layer's ordinary members regardless of archive order, so a
+same-layer replacement remains present and marker files never appear in the
+result.
+
+Merging builds a private sibling partial tree and atomically publishes it only
+after every layer succeeds; the destination must not already exist. Failures
+attempt to remove the partial tree and always retain verified blob and
+decompressed-layer cache entries.
+
+Registry inspection, raw blob caching, decompression, safety validation, and
+merge remain distinct import stages. `GET /api/oci/inspect` stops at metadata
+and fills no OCI cache; caching and decompression do not publish a merged tree.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Merge validated OCI layers in manifest order.
- Apply explicit and opaque whiteouts while blocking symlink traversal.
- Publish the completed rootfs tree atomically.

## Testing

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Related to #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure OCI layer merging with support for whiteouts, hard links, symlinks, permissions, and ownership.
  * Added atomic publication of merged root filesystems, preventing partial results after failures.
  * Added comprehensive validation for unsafe paths, conflicts, invalid links, and archive integrity.

* **Documentation**
  * Updated OCI documentation with layer safety, validation, merge behavior, and failure-handling details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->