### PR TITLE
feat(oci): inject a guest runtime into merged OCI layers

### DIFF
--- a/firecrab-api/src/guest_agent.rs
+++ b/firecrab-api/src/guest_agent.rs
@@ -28,7 +28,7 @@ pub(crate) const SERVICE_NAME: &str = "firecrab-guest-agent.service";
 
 /// Reports guest OS CPU % and memory used (MemTotal − MemAvailable) on the
 /// serial console every few seconds for the host to parse (`FIRECRAB_USAGE`).
-const AGENT_SCRIPT: &str = r#"#!/bin/sh
+pub(crate) const AGENT_SCRIPT: &str = r#"#!/bin/sh
 # Firecrab Metrics Agent (console transport v1).
 # Guest OS metrics only — not host Firecracker process RSS.
 # Avoid `set -e`: a single awk/test failure must not kill the reporter loop.

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -745,6 +745,31 @@ pub enum ResolveError {
         /// Rule the program failed.
         reason: ToolboxViolation,
     },
+    /// A guest path could not be resolved safely inside the merged tree.
+    #[error("guest path {path} cannot be provisioned: {reason}")]
+    GuestPathUnusable {
+        /// Absolute guest path being provisioned.
+        path: String,
+        /// Rule the merged tree's shape broke.
+        reason: GuestPathViolation,
+    },
+    /// A filesystem operation failed while injecting the guest runtime.
+    #[error("OCI guest injection {operation} failed at {path}: {source}")]
+    GuestInjectionIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Tree or cache path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
+    /// The caller stopped waiting before the guest runtime was complete.
+    #[error("OCI guest injection was cancelled before provisioning {path}")]
+    GuestInjectionCancelled {
+        /// Merged tree that was left unprovisioned.
+        path: PathBuf,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1735,6 +1760,11 @@ mod merge;
 #[cfg(test)]
 mod merge_tests;
 
+mod provision;
+
+#[cfg(test)]
+mod provision_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2148,6 +2178,32 @@ impl MergedRootfs {
     }
 }
 
+/// A merged tree that has been given a bootable Firecrab guest runtime.
+///
+/// Deliberately distinct from [`MergedRootfs`] so the later ext4 stage can
+/// require proof that a PID 1, a DHCP client, the readiness sentinel, and the
+/// metrics agent are present before it builds something meant to boot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvisionedRootfs {
+    path: PathBuf,
+    toolbox: Sha256Digest,
+}
+
+impl ProvisionedRootfs {
+    /// Path to the provisioned staging tree.
+    ///
+    /// Injection edits the merged tree in place, so this is the same path
+    /// [`MergedRootfs::path`] reported.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Digest of the toolbox program installed as the guest's PID 1.
+    pub fn toolbox_digest(&self) -> &Sha256Digest {
+        &self.toolbox
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2325,6 +2381,27 @@ pub enum ToolboxViolation {
     MalformedProgramHeaders,
 }
 
+/// Why a guest path in a merged tree cannot be written safely.
+///
+/// Ancestor symbolic links are followed rather than refused: usr-merged images
+/// ship `/sbin` as a link to `usr/sbin`, so refusing them would reject Ubuntu,
+/// Debian, and Fedora outright. Resolution is clamped to the tree instead.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum GuestPathViolation {
+    /// A path component required as a directory is another filesystem type.
+    #[error("ancestor {ancestor:?} is not a directory")]
+    NonDirectoryAncestor {
+        /// Tree-relative path of the conflicting ancestor.
+        ancestor: PathBuf,
+    },
+    /// Following the image's symbolic links never reached a real directory.
+    #[error("resolving it followed more than {limit} symbolic links")]
+    SymlinkLoop {
+        /// Traversal budget the tree exhausted.
+        limit: usize,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct LayerWorkKey {
     compressed_digest: Sha256Digest,
@@ -2469,6 +2546,20 @@ pub async fn provision_toolbox(
     options: &GuestRuntimeOptions<'_>,
 ) -> Result<ToolboxProgram, ResolveError> {
     busybox::ensure_toolbox(options).await
+}
+
+/// Installs a bootable Firecrab guest runtime into a merged OCI tree.
+///
+/// A container tree has no PID 1, no DHCP client, and nothing that reports
+/// readiness, so it cannot boot as a MicroVM. This stage adds an init, a
+/// DHCP client, the readiness sentinel, and the metrics agent, editing the
+/// merged tree in place. The merged handle is consumed because injection is
+/// not repeatable, and a failure restores exactly the paths it touched.
+pub async fn provision_merged_rootfs(
+    rootfs: MergedRootfs,
+    options: &GuestRuntimeOptions<'_>,
+) -> Result<ProvisionedRootfs, ResolveError> {
+    provision::provision_merged_rootfs(rootfs, options).await
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -728,6 +728,23 @@ pub enum ResolveError {
         /// Caller-selected final staging tree path.
         path: PathBuf,
     },
+    /// The pinned guest toolbox image does not carry the program the guest
+    /// runtime is built from.
+    #[error("pinned guest toolbox {reference} has no {member} member")]
+    ToolboxMissing {
+        /// Reference the toolbox was pulled from.
+        reference: String,
+        /// Archive path expected to hold the program.
+        member: &'static str,
+    },
+    /// The lifted toolbox program cannot serve as a guest init.
+    #[error("guest toolbox program at {path} is unusable: {reason}")]
+    ToolboxUnusable {
+        /// Host path of the rejected program.
+        path: PathBuf,
+        /// Rule the program failed.
+        reason: ToolboxViolation,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1702,6 +1719,11 @@ fn cache_io(operation: &'static str, path: PathBuf, source: io::Error) -> Resolv
     }
 }
 
+mod busybox;
+
+#[cfg(test)]
+mod busybox_tests;
+
 #[cfg(test)]
 mod cache_tests;
 
@@ -2126,6 +2148,48 @@ impl MergedRootfs {
     }
 }
 
+/// A verified static program cached on the host to become a guest's init.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolboxProgram {
+    path: PathBuf,
+    digest: Sha256Digest,
+    size: u64,
+}
+
+impl ToolboxProgram {
+    /// Host path of the cached, verified program.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// SHA-256 of the program bytes, recorded as guest provenance.
+    pub fn digest(&self) -> &Sha256Digest {
+        &self.digest
+    }
+
+    /// Program size in bytes.
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+}
+
+/// Host-side inputs the guest runtime stage cannot derive from a merged tree.
+///
+/// The toolbox program is pulled through the same verified pipeline as the
+/// image being imported, so it needs the same two caches. Grouping them means a
+/// later ext4 or registration stage adds a field instead of an argument.
+#[derive(Debug, Clone, Copy)]
+pub struct GuestRuntimeOptions<'a> {
+    /// Image root whose `.oci/` subtree backs every cache below.
+    pub image_root: &'a Path,
+    /// Verified raw blob cache the toolbox pull may fill.
+    pub blobs: &'a BlobCache,
+    /// Verified uncompressed-layer cache the toolbox pull may fill.
+    pub layers: &'a LayerCache,
+    /// Architecture the merged tree targets; the toolbox ELF must match it.
+    pub architecture: Architecture,
+}
+
 /// Why an otherwise valid layer tar entry is unsafe for later extraction.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum TarMemberViolation {
@@ -2213,6 +2277,52 @@ pub enum TarMemberViolation {
         /// Attribute name supplied by the archive.
         key: String,
     },
+}
+
+/// Why a toolbox program cannot serve as an imported guest's init.
+///
+/// The host never runs the program to find out. Every rule below is decided
+/// from the bytes on disk, because executing an unverified registry payload to
+/// test it would be the exact thing this stage exists to avoid.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ToolboxViolation {
+    /// Only a plain file can be copied into a guest tree.
+    #[error("the member is not a regular file")]
+    NotRegularFile,
+    /// An empty file would leave the guest without a PID 1.
+    #[error("the program is empty")]
+    Empty,
+    /// A mirrored override must not copy an unbounded file into every rootfs.
+    #[error("the program is {size} bytes, over the {limit}-byte limit")]
+    TooLarge {
+        /// Observed program size.
+        size: u64,
+        /// Configured ceiling.
+        limit: u64,
+    },
+    /// Firecracker boots 64-bit little-endian guests only.
+    #[error("the program is not a 64-bit little-endian ELF image")]
+    NotElf,
+    /// A program built for another machine cannot be this guest's PID 1.
+    #[error("the program targets ELF machine {actual}, but this host needs {expected}")]
+    ForeignArchitecture {
+        /// ELF machine this host requires.
+        expected: u16,
+        /// ELF machine the program declares.
+        actual: u16,
+    },
+    /// Shared objects and relocatable files are not programs.
+    #[error("the ELF image is not an executable")]
+    NotExecutable,
+    /// A merged container tree has no dynamic loader to satisfy the request.
+    #[error("the program needs the dynamic loader {interpreter:?}; only a static program can boot")]
+    DynamicallyLinked {
+        /// Interpreter path recorded in the `PT_INTERP` segment.
+        interpreter: String,
+    },
+    /// The program header table did not fit inside the file it describes.
+    #[error("the ELF program header table is malformed")]
+    MalformedProgramHeaders,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -2347,6 +2457,18 @@ pub async fn merge_validated_layers(
     destination: &Path,
 ) -> Result<MergedRootfs, ResolveError> {
     merge::merge_validated_layers(layers, destination).await
+}
+
+/// Pulls (or reuses) the pinned toolbox image and returns its static program.
+///
+/// The program is fetched through the same verified pipeline as any other
+/// image and cached under the image root, so only the first import on a host
+/// contacts the registry. Operators can point
+/// `FIRECRAB_OCI_TOOLBOX_IMAGE` at a mirror.
+pub async fn provision_toolbox(
+    options: &GuestRuntimeOptions<'_>,
+) -> Result<ToolboxProgram, ResolveError> {
+    busybox::ensure_toolbox(options).await
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci/busybox.rs
+++ b/firecrab-api/src/oci/busybox.rs
@@ -1,0 +1,453 @@
+//! Supplies the static program an imported container tree boots as PID 1.
+//!
+//! A container image carries an application, not an operating system: no init,
+//! no shell in a distroless tree, and never a DHCP client. The missing pieces
+//! come from a busybox image pulled through the very pipeline that imports the
+//! user's image, so no second downloader, digest verifier, or cache exists to
+//! keep correct. Only the first import on a host reaches the registry; the
+//! lifted program is cached under the image root afterwards.
+
+use super::*;
+
+use std::fs::{File, OpenOptions};
+use std::os::unix::fs::OpenOptionsExt as _;
+
+/// Repository the guest init, shell, and DHCP client come from.
+///
+/// Pinned to an image *index* digest rather than a per-architecture manifest:
+/// the index digest covers both children, so one immutable constant pins amd64
+/// and arm64 at once and [`ImageIndex::select`] still picks the right one. A
+/// tag here would let a registry repoint PID 1 under a running deployment.
+///
+/// `uclibc` is the statically linked variant. A merged container tree has no
+/// dynamic loader, so a glibc build would exec straight into a panic.
+const TOOLBOX_IMAGE: &str =
+    "busybox@sha256:8d7b1636e974e0adfd8d945955fca609304f0a56c18799dfd032d6e661382d84";
+/// Operator override for air-gapped hosts, private mirrors, and rate limits.
+const TOOLBOX_IMAGE_ENV: &str = "FIRECRAB_OCI_TOOLBOX_IMAGE";
+/// Operator override naming a static program already on this host.
+const TOOLBOX_PATH_ENV: &str = "FIRECRAB_OCI_TOOLBOX_PATH";
+/// Archive path the static program is lifted from.
+const TOOLBOX_MEMBER: &str = "bin/busybox";
+/// Ceiling on the lifted program, so a mirrored override cannot copy an
+/// unbounded file into every imported rootfs.
+const TOOLBOX_MAX_BYTES: u64 = 32 * 1024 * 1024;
+/// Applet names the injected guest scripts invoke.
+///
+/// busybox stores its applet table as NUL-separated names in the binary, so
+/// their absence is detectable without running anything. A trimmed build is
+/// reported and still used: refusing on a false positive would break every
+/// boot, while a genuinely missing applet surfaces as a readiness failure.
+const REQUIRED_APPLETS: &[&str] = &["sh", "ip", "udhcpc", "awk", "mount", "sleep", "cut"];
+
+/// ELF magic every candidate program must start with.
+const ELF_MAGIC: &[u8; 4] = b"\x7fELF";
+/// `EI_CLASS` value for a 64-bit image.
+const ELFCLASS64: u8 = 2;
+/// `EI_DATA` value for a little-endian image.
+const ELFDATA2LSB: u8 = 1;
+/// `e_type` for a fixed-position executable.
+const ET_EXEC: u16 = 2;
+/// `e_type` for a position-independent executable or shared object.
+const ET_DYN: u16 = 3;
+/// `e_machine` for 64-bit x86.
+const EM_X86_64: u16 = 62;
+/// `e_machine` for 64-bit ARM.
+const EM_AARCH64: u16 = 183;
+/// Program header type naming a dynamic loader.
+const PT_INTERP: u32 = 3;
+/// Size of the 64-bit ELF header.
+const ELF64_HEADER_BYTES: usize = 64;
+/// Size of one 64-bit program header entry.
+const ELF64_PROGRAM_HEADER_BYTES: u16 = 56;
+/// Refuse absurd program header counts before allocating for them.
+const ELF64_MAX_PROGRAM_HEADERS: u16 = 128;
+/// Longest interpreter path reported back in a rejection.
+const ELF64_MAX_INTERPRETER_BYTES: u64 = 4096;
+
+/// Acquires the toolbox program, pulling it only when the cache cannot serve it.
+pub(super) async fn ensure_toolbox(
+    options: &GuestRuntimeOptions<'_>,
+) -> Result<ToolboxProgram, ResolveError> {
+    if let Some(path) = configured_toolbox_override() {
+        return inspect_toolbox(&path, options.architecture).await;
+    }
+
+    let reference = ImageReference::parse(configured_toolbox_image().as_str())
+        .map_err(|error| ResolveError::Malformed(error.to_string()))?;
+    ensure_toolbox_from(options, &reference).await
+}
+
+/// Acquires the toolbox from one explicit reference.
+///
+/// Split out so tests can point at a local registry without mutating the
+/// process environment, which `ensure_toolbox` reads and parallel tests share.
+pub(super) async fn ensure_toolbox_from(
+    options: &GuestRuntimeOptions<'_>,
+    reference: &ImageReference,
+) -> Result<ToolboxProgram, ResolveError> {
+    let cached = toolbox_cache_path(options, reference);
+    if let Some(parent) = cached.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|source| cache_io("create toolbox cache", parent.to_owned(), source))?;
+    }
+    let lock = cache_path_lock(
+        cached.parent().unwrap_or(options.image_root),
+        Path::new(TOOLBOX_MEMBER),
+    )
+    .await?;
+    let _guard = lock.lock().await;
+
+    if let Ok(program) = inspect_toolbox(&cached, options.architecture).await {
+        return Ok(program);
+    }
+    // A cache entry that fails verification is stale or corrupt, never trusted.
+    let _ = tokio::fs::remove_file(&cached).await;
+    pull_toolbox(options, reference, &cached).await?;
+    inspect_toolbox(&cached, options.architecture).await
+}
+
+/// Reads the operator's program override, if one is set.
+pub(super) fn configured_toolbox_override() -> Option<PathBuf> {
+    let value = std::env::var(TOOLBOX_PATH_ENV).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
+
+/// Reads the toolbox reference, falling back to the pinned digest.
+///
+/// An override may carry a tag: a private mirror is trusted operator input.
+/// The built-in default never does.
+pub(super) fn configured_toolbox_image() -> String {
+    match std::env::var(TOOLBOX_IMAGE_ENV) {
+        Ok(value) if !value.trim().is_empty() => value.trim().to_owned(),
+        Ok(_) | Err(std::env::VarError::NotPresent) => TOOLBOX_IMAGE.to_owned(),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                variable = TOOLBOX_IMAGE_ENV,
+                "non-Unicode OCI toolbox image; using the pinned default"
+            );
+            TOOLBOX_IMAGE.to_owned()
+        }
+    }
+}
+
+/// Cache path for one reference and architecture.
+///
+/// The name is derived only from constants and the override, so a warm host
+/// finds its program without resolving anything over the network.
+fn toolbox_cache_path(options: &GuestRuntimeOptions<'_>, reference: &ImageReference) -> PathBuf {
+    let canonical = format!(
+        "{}/{}@{}",
+        reference.registry,
+        reference.repository,
+        reference.version.as_str()
+    );
+    let key = Sha256Digest::of_bytes(canonical.as_bytes());
+    options
+        .image_root
+        .join(".oci/toolbox")
+        .join(key.encoded())
+        .join(oci_platform(options.architecture))
+        .join("busybox")
+}
+
+/// Pulls the pinned image and lifts its program into the cache.
+async fn pull_toolbox(
+    options: &GuestRuntimeOptions<'_>,
+    reference: &ImageReference,
+    destination: &Path,
+) -> Result<(), ResolveError> {
+    let insecure = is_loopback_registry(&reference.registry);
+    let blobs = cache_image_blobs(reference, options.architecture, insecure, options.blobs).await?;
+    let layers = decompress_cached_layers(&blobs, options.layers).await?;
+    let layers = validate_decompressed_layers(layers).await?;
+
+    let parent = destination
+        .parent()
+        .expect("toolbox cache paths are built with a parent");
+    let scratch = parent.join(format!(".merge-{}", Uuid::new_v4()));
+    let merged = merge_validated_layers(&layers, &scratch).await?;
+    let mut cleanup = ScratchTree::new(scratch);
+    let member = merged.path().join(TOOLBOX_MEMBER);
+    let result = publish_toolbox(&member, destination, reference);
+    cleanup.remove();
+    result
+}
+
+/// Copies a lifted program to its cache path without ever publishing a partial.
+fn publish_toolbox(
+    member: &Path,
+    destination: &Path,
+    reference: &ImageReference,
+) -> Result<(), ResolveError> {
+    match std::fs::symlink_metadata(member) {
+        Ok(metadata) if metadata.file_type().is_file() => {}
+        Ok(_) => {
+            return Err(ResolveError::ToolboxUnusable {
+                path: member.to_owned(),
+                reason: ToolboxViolation::NotRegularFile,
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(ResolveError::ToolboxMissing {
+                reference: format!(
+                    "{}/{}@{}",
+                    reference.registry,
+                    reference.repository,
+                    reference.version.as_str()
+                ),
+                member: TOOLBOX_MEMBER,
+            });
+        }
+        Err(source) => {
+            return Err(cache_io(
+                "inspect toolbox member",
+                member.to_owned(),
+                source,
+            ));
+        }
+    }
+
+    let partial = destination.with_extension(format!("{}.partial", Uuid::new_v4()));
+    let mut source = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(member)
+        .map_err(|source| cache_io("open toolbox member", member.to_owned(), source))?;
+    let mut target = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o755)
+        .custom_flags(libc::O_CLOEXEC)
+        .open(&partial)
+        .map_err(|source| cache_io("stage toolbox program", partial.clone(), source))?;
+    let copy = io::copy(&mut source, &mut target)
+        .and_then(|_| target.sync_all())
+        .map_err(|source| cache_io("write toolbox program", partial.clone(), source));
+    if let Err(error) = copy {
+        let _ = std::fs::remove_file(&partial);
+        return Err(error);
+    }
+    std::fs::rename(&partial, destination).map_err(|source| {
+        let _ = std::fs::remove_file(&partial);
+        cache_io("publish toolbox program", destination.to_owned(), source)
+    })
+}
+
+/// Verifies a cached or operator-supplied program and describes it.
+pub(super) async fn inspect_toolbox(
+    path: &Path,
+    architecture: Architecture,
+) -> Result<ToolboxProgram, ResolveError> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || inspect_toolbox_blocking(&path, architecture))
+        .await
+        .map_err(|error| {
+            cache_io(
+                "join toolbox worker",
+                PathBuf::from("toolbox"),
+                io::Error::other(error),
+            )
+        })?
+}
+
+/// Blocking half of [`inspect_toolbox`].
+fn inspect_toolbox_blocking(
+    path: &Path,
+    architecture: Architecture,
+) -> Result<ToolboxProgram, ResolveError> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| cache_io("open toolbox program", path.to_owned(), source))?;
+    let metadata = file
+        .metadata()
+        .map_err(|source| cache_io("inspect toolbox program", path.to_owned(), source))?;
+    if !metadata.file_type().is_file() {
+        return Err(unusable(path, ToolboxViolation::NotRegularFile));
+    }
+    let size = metadata.len();
+    if size == 0 {
+        return Err(unusable(path, ToolboxViolation::Empty));
+    }
+    if size > TOOLBOX_MAX_BYTES {
+        return Err(unusable(
+            path,
+            ToolboxViolation::TooLarge {
+                size,
+                limit: TOOLBOX_MAX_BYTES,
+            },
+        ));
+    }
+    verify_static_elf(&mut file, path, architecture)?;
+
+    let mut bytes = Vec::with_capacity(size as usize);
+    file.seek(io::SeekFrom::Start(0))
+        .and_then(|_| file.read_to_end(&mut bytes))
+        .map_err(|source| cache_io("read toolbox program", path.to_owned(), source))?;
+    report_missing_applets(&bytes, path);
+
+    Ok(ToolboxProgram {
+        path: path.to_owned(),
+        digest: Sha256Digest::of_bytes(&bytes),
+        size,
+    })
+}
+
+/// Wraps a rejection reason with the program it applies to.
+fn unusable(path: &Path, reason: ToolboxViolation) -> ResolveError {
+    ResolveError::ToolboxUnusable {
+        path: path.to_owned(),
+        reason,
+    }
+}
+
+/// Proves a program is a static 64-bit executable for this architecture.
+///
+/// The host never executes the program to find out. `PT_INTERP` is the only
+/// on-disk marker separating a static build from a dynamic one, and a dynamic
+/// build would exec into a panic inside a tree that has no loader.
+fn verify_static_elf(
+    file: &mut File,
+    path: &Path,
+    architecture: Architecture,
+) -> Result<(), ResolveError> {
+    let mut header = [0_u8; ELF64_HEADER_BYTES];
+    file.seek(io::SeekFrom::Start(0))
+        .and_then(|_| file.read_exact(&mut header))
+        .map_err(|_| unusable(path, ToolboxViolation::NotElf))?;
+    if &header[..4] != ELF_MAGIC || header[4] != ELFCLASS64 || header[5] != ELFDATA2LSB {
+        return Err(unusable(path, ToolboxViolation::NotElf));
+    }
+    let e_type = u16::from_le_bytes([header[16], header[17]]);
+    if e_type != ET_EXEC && e_type != ET_DYN {
+        return Err(unusable(path, ToolboxViolation::NotExecutable));
+    }
+    let e_machine = u16::from_le_bytes([header[18], header[19]]);
+    let expected = match architecture {
+        Architecture::X86_64 => EM_X86_64,
+        Architecture::Aarch64 => EM_AARCH64,
+    };
+    if e_machine != expected {
+        return Err(unusable(
+            path,
+            ToolboxViolation::ForeignArchitecture {
+                expected,
+                actual: e_machine,
+            },
+        ));
+    }
+
+    let e_phoff = u64::from_le_bytes(header[32..40].try_into().expect("8 bytes"));
+    let e_phentsize = u16::from_le_bytes([header[54], header[55]]);
+    let e_phnum = u16::from_le_bytes([header[56], header[57]]);
+    if e_phnum == 0
+        || e_phnum > ELF64_MAX_PROGRAM_HEADERS
+        || e_phentsize != ELF64_PROGRAM_HEADER_BYTES
+    {
+        return Err(unusable(path, ToolboxViolation::MalformedProgramHeaders));
+    }
+    let mut table = vec![0_u8; usize::from(e_phnum) * usize::from(e_phentsize)];
+    file.seek(io::SeekFrom::Start(e_phoff))
+        .and_then(|_| file.read_exact(&mut table))
+        .map_err(|_| unusable(path, ToolboxViolation::MalformedProgramHeaders))?;
+
+    for entry in table.chunks_exact(usize::from(e_phentsize)) {
+        if u32::from_le_bytes(entry[..4].try_into().expect("4 bytes")) != PT_INTERP {
+            continue;
+        }
+        let p_offset = u64::from_le_bytes(entry[8..16].try_into().expect("8 bytes"));
+        let p_filesz = u64::from_le_bytes(entry[32..40].try_into().expect("8 bytes"));
+        let interpreter = read_interpreter(file, p_offset, p_filesz).unwrap_or_default();
+        return Err(unusable(
+            path,
+            ToolboxViolation::DynamicallyLinked { interpreter },
+        ));
+    }
+    Ok(())
+}
+
+/// Reads the interpreter path so a rejection can name it.
+fn read_interpreter(file: &mut File, offset: u64, length: u64) -> Option<String> {
+    if length == 0 || length > ELF64_MAX_INTERPRETER_BYTES {
+        return None;
+    }
+    let mut bytes = vec![0_u8; length as usize];
+    file.seek(io::SeekFrom::Start(offset)).ok()?;
+    file.read_exact(&mut bytes).ok()?;
+    let end = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    Some(String::from_utf8_lossy(&bytes[..end]).into_owned())
+}
+
+/// Warns when the applet table does not mention an applet the guest needs.
+///
+/// A trimmed build is used anyway: refusing on a false positive would break
+/// every boot, while a genuinely absent applet fails the readiness sentinel
+/// with a message an operator can act on.
+fn report_missing_applets(bytes: &[u8], path: &Path) {
+    let missing: Vec<&str> = REQUIRED_APPLETS
+        .iter()
+        .copied()
+        .filter(|applet| !contains_applet(bytes, applet))
+        .collect();
+    if !missing.is_empty() {
+        tracing::warn!(
+            path = %path.display(),
+            missing = ?missing,
+            "guest toolbox may be missing applets the injected runtime calls"
+        );
+    }
+}
+
+/// Whether the program mentions an applet as a NUL-delimited name.
+fn contains_applet(bytes: &[u8], applet: &str) -> bool {
+    let needle: Vec<u8> = std::iter::once(0)
+        .chain(applet.bytes())
+        .chain(std::iter::once(0))
+        .collect();
+    bytes.windows(needle.len()).any(|window| window == needle)
+}
+
+/// Removes the scratch merge tree a toolbox pull built.
+struct ScratchTree {
+    /// Tree to remove.
+    path: PathBuf,
+    /// Cleared once the tree has been removed.
+    armed: bool,
+}
+
+impl ScratchTree {
+    /// Arms cleanup for a freshly merged scratch tree.
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// Removes the tree now, reporting nothing: the caller's error wins.
+    fn remove(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.armed = false;
+        if let Err(error) = std::fs::remove_dir_all(&self.path)
+            && error.kind() != io::ErrorKind::NotFound
+        {
+            tracing::warn!(
+                error = %error,
+                path = %self.path.display(),
+                "failed to remove the OCI toolbox scratch tree"
+            );
+        }
+    }
+}
+
+impl Drop for ScratchTree {
+    fn drop(&mut self) {
+        self.remove();
+    }
+}

--- a/firecrab-api/src/oci/busybox_tests.rs
+++ b/firecrab-api/src/oci/busybox_tests.rs
@@ -1,0 +1,571 @@
+use super::*;
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_compression::tokio::bufread::GzipEncoder;
+use axum::body::Body;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{Response, StatusCode, header::CONTENT_TYPE};
+use axum::routing::get;
+use tar::{Builder, EntryType, Header};
+use tempfile::{TempDir, tempdir};
+use tokio::task::JoinHandle;
+
+/// `e_machine` for the architecture that is not this host's.
+const FOREIGN_MACHINE: u16 = 0x00f3;
+
+fn header(entry_type: EntryType, size: u64, mode: u32) -> Header {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header
+}
+
+fn append_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+    data: &[u8],
+    mode: u32,
+) {
+    let mut header = header(entry_type, data.len() as u64, mode);
+    if let Some(target) = target {
+        header
+            .set_link_name_literal(target.as_bytes())
+            .expect("set fixture link target");
+    }
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
+    builder.into_inner().expect("finish fixture tar")
+}
+
+/// Builds a 64-bit little-endian ELF image with the given program headers.
+///
+/// Real busybox is 1 MiB of machine code; every rule this stage enforces lives
+/// in the header, so a hand-built one exercises the verifier exactly.
+fn elf(machine: u16, e_type: u16, program_headers: &[[u8; 56]], trailer: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0_u8; 64];
+    bytes[..4].copy_from_slice(b"\x7fELF");
+    bytes[4] = 2; // ELFCLASS64
+    bytes[5] = 1; // ELFDATA2LSB
+    bytes[6] = 1; // EI_VERSION
+    bytes[16..18].copy_from_slice(&e_type.to_le_bytes());
+    bytes[18..20].copy_from_slice(&machine.to_le_bytes());
+    bytes[32..40].copy_from_slice(&64_u64.to_le_bytes()); // e_phoff
+    bytes[52..54].copy_from_slice(&64_u16.to_le_bytes()); // e_ehsize
+    bytes[54..56].copy_from_slice(&56_u16.to_le_bytes()); // e_phentsize
+    bytes[56..58].copy_from_slice(&(program_headers.len() as u16).to_le_bytes());
+    for entry in program_headers {
+        bytes.extend_from_slice(entry);
+    }
+    bytes.extend_from_slice(trailer);
+    bytes
+}
+
+/// One program header entry.
+fn program_header(p_type: u32, p_offset: u64, p_filesz: u64) -> [u8; 56] {
+    let mut entry = [0_u8; 56];
+    entry[..4].copy_from_slice(&p_type.to_le_bytes());
+    entry[8..16].copy_from_slice(&p_offset.to_le_bytes());
+    entry[32..40].copy_from_slice(&p_filesz.to_le_bytes());
+    entry
+}
+
+/// A static program for this host, carrying the applet names the guest calls.
+fn static_program() -> Vec<u8> {
+    let mut applets = vec![0_u8];
+    for applet in ["sh", "ip", "udhcpc", "awk", "mount", "sleep", "cut"] {
+        applets.extend_from_slice(applet.as_bytes());
+        applets.push(0);
+    }
+    let machine = match Architecture::HOST {
+        Architecture::X86_64 => 62,
+        Architecture::Aarch64 => 183,
+    };
+    elf(machine, 2, &[program_header(1, 0, 0)], &applets)
+}
+
+/// Writes a program to disk and verifies it the way the pull path would.
+async fn toolbox(directory: &TempDir, name: &str, bytes: &[u8]) -> ToolboxProgram {
+    let path = directory.path().join(name);
+    std::fs::write(&path, bytes).expect("write toolbox fixture");
+    busybox::inspect_toolbox(&path, Architecture::HOST)
+        .await
+        .expect("verify toolbox fixture")
+}
+
+/// Rejection reason for a program that should not pass verification.
+async fn refuse_toolbox(directory: &TempDir, name: &str, bytes: &[u8]) -> ToolboxViolation {
+    let path = directory.path().join(name);
+    std::fs::write(&path, bytes).expect("write toolbox fixture");
+    match busybox::inspect_toolbox(&path, Architecture::HOST).await {
+        Err(ResolveError::ToolboxUnusable { reason, .. }) => reason,
+        other => panic!("expected a toolbox rejection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn a_dynamically_linked_toolbox_program_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let interpreter = b"/lib64/ld-linux-x86-64.so.2\0";
+    let machine = match Architecture::HOST {
+        Architecture::X86_64 => 62,
+        Architecture::Aarch64 => 183,
+    };
+    let program = elf(
+        machine,
+        2,
+        &[program_header(3, 120, interpreter.len() as u64)],
+        interpreter,
+    );
+
+    // A merged container tree has no loader, so this would exec into a panic.
+    assert!(matches!(
+        refuse_toolbox(&directory, "dynamic", &program).await,
+        ToolboxViolation::DynamicallyLinked { interpreter }
+            if interpreter == "/lib64/ld-linux-x86-64.so.2"
+    ));
+}
+
+#[tokio::test]
+async fn a_toolbox_program_for_another_machine_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let program = elf(FOREIGN_MACHINE, 2, &[program_header(1, 0, 0)], &[]);
+    assert!(matches!(
+        refuse_toolbox(&directory, "foreign", &program).await,
+        ToolboxViolation::ForeignArchitecture { actual, .. } if actual == FOREIGN_MACHINE
+    ));
+}
+
+#[tokio::test]
+async fn programs_that_are_not_static_executables_are_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let machine = match Architecture::HOST {
+        Architecture::X86_64 => 62,
+        Architecture::Aarch64 => 183,
+    };
+
+    assert!(matches!(
+        refuse_toolbox(&directory, "text", b"#!/bin/sh\necho hello\n").await,
+        ToolboxViolation::NotElf
+    ));
+    assert!(matches!(
+        refuse_toolbox(&directory, "empty", b"").await,
+        ToolboxViolation::Empty
+    ));
+    // ET_REL: an object file, not something the kernel can exec.
+    assert!(matches!(
+        refuse_toolbox(&directory, "relocatable", &elf(machine, 1, &[], &[])).await,
+        ToolboxViolation::NotExecutable
+    ));
+    // A header table that claims more entries than the file can hold.
+    let mut truncated = elf(machine, 2, &[program_header(1, 0, 0)], &[]);
+    truncated[56..58].copy_from_slice(&64_u16.to_le_bytes());
+    assert!(matches!(
+        refuse_toolbox(&directory, "truncated", &truncated).await,
+        ToolboxViolation::MalformedProgramHeaders
+    ));
+    // No program headers at all leaves nothing to prove staticness with.
+    assert!(matches!(
+        refuse_toolbox(&directory, "headerless", &elf(machine, 2, &[], &[])).await,
+        ToolboxViolation::MalformedProgramHeaders
+    ));
+}
+
+#[tokio::test]
+async fn an_oversized_toolbox_program_is_refused_before_it_is_copied() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut program = static_program();
+    program.resize(33 * 1024 * 1024, 0);
+    assert!(matches!(
+        refuse_toolbox(&directory, "huge", &program).await,
+        ToolboxViolation::TooLarge { limit, .. } if limit == 32 * 1024 * 1024
+    ));
+}
+
+#[tokio::test]
+async fn a_toolbox_directory_is_refused_rather_than_copied() {
+    let directory = tempdir().expect("create fixture directory");
+    let path = directory.path().join("a-directory");
+    std::fs::create_dir(&path).expect("create fixture directory entry");
+    assert!(matches!(
+        busybox::inspect_toolbox(&path, Architecture::HOST).await,
+        Err(ResolveError::ToolboxUnusable {
+            reason: ToolboxViolation::NotRegularFile,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn toolbox_refusals_render_operator_readable_messages() {
+    let rendered = [
+        ResolveError::ToolboxMissing {
+            reference: "registry/busybox@sha256:0".to_owned(),
+            member: "bin/busybox",
+        },
+        ResolveError::ToolboxUnusable {
+            path: PathBuf::from("/images/.oci/toolbox/busybox"),
+            reason: ToolboxViolation::NotElf,
+        },
+    ]
+    .map(|error| error.to_string());
+
+    assert!(rendered[0].contains("bin/busybox"));
+    assert!(rendered[1].contains("not a 64-bit little-endian ELF"));
+}
+
+// ---------------------------------------------------------------------------
+// Toolbox acquisition against a local registry. Nothing here reaches Docker Hub.
+// ---------------------------------------------------------------------------
+
+const TOOLBOX_REPOSITORY: &str = "firecrab/toolbox";
+
+#[derive(Clone)]
+struct ToolboxRegistry {
+    manifest: Arc<Vec<u8>>,
+    blobs: Arc<BTreeMap<String, Arc<Vec<u8>>>>,
+    requests: Arc<AtomicUsize>,
+}
+
+struct TestRegistry {
+    registry: String,
+    state: ToolboxRegistry,
+    task: JoinHandle<()>,
+}
+
+impl Drop for TestRegistry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl TestRegistry {
+    /// Serves a one-layer image whose tar holds `member` at `bin/busybox`.
+    async fn start(member: Option<&[u8]>) -> Self {
+        let mut builder = Builder::new(Vec::new());
+        append_entry(&mut builder, "bin/", EntryType::Directory, None, &[], 0o755);
+        match member {
+            Some(bytes) => append_entry(
+                &mut builder,
+                "bin/busybox",
+                EntryType::Regular,
+                None,
+                bytes,
+                0o755,
+            ),
+            None => append_entry(
+                &mut builder,
+                "bin/other",
+                EntryType::Regular,
+                None,
+                b"not the program",
+                0o755,
+            ),
+        }
+        Self::start_from(finish(builder)).await
+    }
+
+    /// Serves a one-layer image from an explicit tar.
+    async fn start_from(tar: Vec<u8>) -> Self {
+        let diff_id = Sha256Digest::of_bytes(&tar);
+        let compressed = {
+            let input = tokio::io::BufReader::new(tar.as_slice());
+            let mut encoder = GzipEncoder::new(input);
+            let mut output = Vec::new();
+            encoder
+                .read_to_end(&mut output)
+                .await
+                .expect("gzip fixture layer");
+            output
+        };
+        // The manifest digest covers the compressed blob while the config's
+        // diff_id covers the tar, so the two are deliberately different here.
+        let layer_digest = Sha256Digest::of_bytes(&compressed);
+        let config = serde_json::to_vec(&serde_json::json!({
+            "architecture": "amd64",
+            "os": "linux",
+            "rootfs": { "type": "layers", "diff_ids": [diff_id.to_string()] },
+        }))
+        .expect("serialize toolbox config");
+        let config_digest = Sha256Digest::of_bytes(&config);
+        let manifest = serde_json::to_vec(&serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+            "config": {
+                "mediaType": OCI_CONFIG_MEDIA_TYPE,
+                "digest": config_digest.to_string(),
+                "size": config.len(),
+            },
+            "layers": [{
+                "mediaType": OCI_LAYER_GZIP_MEDIA_TYPE,
+                "digest": layer_digest.to_string(),
+                "size": compressed.len(),
+            }],
+        }))
+        .expect("serialize toolbox manifest");
+
+        let state = ToolboxRegistry {
+            manifest: Arc::new(manifest),
+            blobs: Arc::new(BTreeMap::from([
+                (config_digest.to_string(), Arc::new(config)),
+                (layer_digest.to_string(), Arc::new(compressed)),
+            ])),
+            requests: Arc::new(AtomicUsize::new(0)),
+        };
+        let app = axum::Router::new()
+            .route(
+                "/v2/firecrab/toolbox/manifests/{selector}",
+                get(serve_manifest),
+            )
+            .route("/v2/firecrab/toolbox/blobs/{digest}", get(serve_blob))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind toolbox registry");
+        let registry = listener
+            .local_addr()
+            .expect("toolbox registry address")
+            .to_string();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve toolbox registry");
+        });
+        Self {
+            registry,
+            state,
+            task,
+        }
+    }
+
+    fn reference(&self) -> ImageReference {
+        ImageReference::parse(&format!("{}/{TOOLBOX_REPOSITORY}:latest", self.registry))
+            .expect("parse toolbox reference")
+    }
+
+    fn requests(&self) -> usize {
+        self.state.requests.load(Ordering::SeqCst)
+    }
+}
+
+async fn serve_manifest(
+    State(state): State<ToolboxRegistry>,
+    AxumPath(_selector): AxumPath<String>,
+) -> Response<Body> {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, OCI_MANIFEST_MEDIA_TYPE)
+        .body(Body::from(state.manifest.to_vec()))
+        .expect("build manifest response")
+}
+
+async fn serve_blob(
+    State(state): State<ToolboxRegistry>,
+    AxumPath(digest): AxumPath<String>,
+) -> Response<Body> {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+    match state.blobs.get(&digest) {
+        Some(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::from(bytes.to_vec()))
+            .expect("build blob response"),
+        None => Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .expect("build missing blob response"),
+    }
+}
+
+fn options<'a>(
+    image_root: &'a Path,
+    blobs: &'a BlobCache,
+    layers: &'a LayerCache,
+) -> GuestRuntimeOptions<'a> {
+    GuestRuntimeOptions {
+        image_root,
+        blobs,
+        layers,
+        architecture: Architecture::HOST,
+    }
+}
+
+#[tokio::test]
+async fn a_pulled_toolbox_is_cached_and_never_requested_twice() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let blobs = BlobCache::new(image_root);
+    let layers = LayerCache::new(image_root);
+    let options = options(image_root, &blobs, &layers);
+    let program = static_program();
+    let registry = TestRegistry::start(Some(&program)).await;
+
+    let first = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect("pull the toolbox");
+    assert_eq!(std::fs::read(first.path()).unwrap(), program);
+    assert_eq!(first.size(), program.len() as u64);
+    let pulled = registry.requests();
+    assert!(pulled > 0, "the first call reaches the registry");
+
+    let second = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect("reuse the cached toolbox");
+    assert_eq!(second, first);
+    // Only the first import on a host may contact the registry; this is what
+    // keeps an anonymous pull limit from bounding how many images can be
+    // imported.
+    assert_eq!(registry.requests(), pulled);
+    // No scratch merge tree survives the pull.
+    let toolbox_root = image_root.join(".oci/toolbox");
+    assert!(
+        !scratch_trees_remain(&toolbox_root),
+        "no scratch trees left"
+    );
+}
+
+/// Whether any `.merge-*` scratch tree survived a toolbox pull.
+fn scratch_trees_remain(root: &Path) -> bool {
+    let mut pending = vec![root.to_owned()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path
+                    .file_name()
+                    .is_some_and(|name| name.to_string_lossy().starts_with(".merge-"))
+                {
+                    return true;
+                }
+                pending.push(path);
+            }
+        }
+    }
+    false
+}
+
+#[tokio::test]
+async fn a_toolbox_image_without_the_program_member_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let blobs = BlobCache::new(image_root);
+    let layers = LayerCache::new(image_root);
+    let options = options(image_root, &blobs, &layers);
+    let registry = TestRegistry::start(None).await;
+
+    let error = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect_err("an image without bin/busybox cannot supply an init");
+    assert!(matches!(
+        error,
+        ResolveError::ToolboxMissing { member, .. } if member == "bin/busybox"
+    ));
+    assert!(!scratch_trees_remain(&image_root.join(".oci/toolbox")));
+}
+
+#[tokio::test]
+async fn a_corrupt_cached_toolbox_is_rebuilt_instead_of_trusted() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let blobs = BlobCache::new(image_root);
+    let layers = LayerCache::new(image_root);
+    let options = options(image_root, &blobs, &layers);
+    let program = static_program();
+    let registry = TestRegistry::start(Some(&program)).await;
+
+    let first = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect("pull the toolbox");
+    std::fs::write(first.path(), b"not an ELF image at all").expect("corrupt the cache entry");
+
+    let rebuilt = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect("a corrupt entry is re-pulled, not trusted by path");
+    assert_eq!(rebuilt, first);
+    assert_eq!(std::fs::read(rebuilt.path()).unwrap(), program);
+}
+
+#[tokio::test]
+async fn the_built_in_toolbox_reference_can_never_be_repointed() {
+    // No override is set in this process, so this is the pinned default.
+    assert!(busybox::configured_toolbox_override().is_none());
+    let reference = ImageReference::parse(&busybox::configured_toolbox_image())
+        .expect("the built-in toolbox reference parses");
+    // A tag would let a registry swap PID 1 under a running deployment.
+    assert!(
+        reference.version.is_immutable(),
+        "the built-in toolbox must be pinned by digest, not by tag"
+    );
+    assert_eq!(reference.repository, "library/busybox");
+}
+
+#[tokio::test]
+async fn a_toolbox_member_that_is_not_a_regular_file_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let blobs = BlobCache::new(image_root);
+    let layers = LayerCache::new(image_root);
+    let options = options(image_root, &blobs, &layers);
+
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "bin/", EntryType::Directory, None, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "bin/real",
+        EntryType::Regular,
+        None,
+        b"elsewhere",
+        0o755,
+    );
+    // A symlink here would make the copy read through whatever it names.
+    append_entry(
+        &mut builder,
+        "bin/busybox",
+        EntryType::Symlink,
+        Some("real"),
+        &[],
+        0o777,
+    );
+    let registry = TestRegistry::start_from(finish(builder)).await;
+
+    let error = busybox::ensure_toolbox_from(&options, &registry.reference())
+        .await
+        .expect_err("a symlinked member must not be copied");
+    assert!(matches!(
+        error,
+        ResolveError::ToolboxUnusable {
+            reason: ToolboxViolation::NotRegularFile,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn a_toolbox_missing_applet_names_is_reported_but_still_used() {
+    let directory = tempdir().expect("create fixture directory");
+    let machine = match Architecture::HOST {
+        Architecture::X86_64 => 62,
+        Architecture::Aarch64 => 183,
+    };
+    // No applet table at all. Refusing on this would break every boot the
+    // moment the scan produced a false positive, so it only warns.
+    let trimmed = elf(machine, 2, &[program_header(1, 0, 0)], &[]);
+    let program = toolbox(&directory, "trimmed", &trimmed).await;
+    assert_eq!(program.size(), trimmed.len() as u64);
+}

--- a/firecrab-api/src/oci/provision.rs
+++ b/firecrab-api/src/oci/provision.rs
@@ -1,0 +1,641 @@
+//! Gives a merged container tree the guest runtime a MicroVM needs to boot.
+//!
+//! A container rootfs fails three ways at once: the kernel finds no `/sbin/init`
+//! and panics, nothing asks for a DHCP lease so the guest never gets an address,
+//! and nothing prints the readiness sentinel the host waits 180 seconds for.
+//! Firecrab's existing guest features cannot fill the gap — they install only
+//! when systemd or OpenRC is already present and no-op otherwise, which is
+//! exactly the container case.
+//!
+//! So this stage injects an init, a DHCP client, the readiness sentinel, and the
+//! metrics agent, all from one static program. The image's own userland is left
+//! alone: its entrypoint becomes an ordinary service under the injected init in
+//! a later stage, never PID 1.
+
+use super::*;
+
+use std::fs::{self, OpenOptions};
+use std::io::Write as _;
+use std::os::unix::fs::{DirBuilderExt as _, OpenOptionsExt as _, PermissionsExt as _};
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Guest path the kernel execs when the command line carries no `init=`.
+///
+/// Owning this path is what lets an imported image boot on the stock
+/// `root=/dev/vda rw` command line every template already uses.
+const GUEST_INIT: &str = "/sbin/init";
+/// Guest path of the injected toolbox program.
+const GUEST_TOOLBOX: &str = "/sbin/firecrab-busybox";
+/// busybox init reads its job table from here.
+const GUEST_INITTAB: &str = "/etc/inittab";
+/// Boot script run once, before anything else the guest does.
+const GUEST_BOOT_SCRIPT: &str = "/etc/firecrab/rc.boot";
+/// Lease hook busybox `udhcpc` calls to apply an address.
+const GUEST_DHCP_SCRIPT: &str = "/etc/firecrab/dhcp.script";
+/// Directory a later stage drops the image's translated entrypoint into.
+const GUEST_SERVICES: &str = "/etc/firecrab/services.d";
+/// Mount points a container tree may not carry.
+///
+/// `/dev` matters most: `CONFIG_DEVTMPFS_MOUNT=y` mounts it, but only onto a
+/// directory that exists. Without it there is no `/dev/console` and the guest
+/// boots dark, with no sentinel and no way to see why.
+const GUEST_MOUNT_POINTS: &[(&str, u32)] = &[
+    ("/proc", 0o755),
+    ("/sys", 0o755),
+    ("/dev", 0o755),
+    ("/run", 0o755),
+    ("/tmp", 0o1777),
+];
+
+/// Traversal budget when following an image's ancestor symbolic links.
+const SYMLINK_HOP_LIMIT: usize = 40;
+/// Injection is running and may still be cancelled.
+const INJECT_ACTIVE: u8 = 0;
+/// The caller stopped waiting before injection finished.
+const INJECT_CANCELLED: u8 = 1;
+/// Injection completed; the state no longer changes.
+const INJECT_FINISHED: u8 = 2;
+
+/// Shared cancellation state consulted between injection steps.
+struct InjectControl {
+    /// Current phase, shared with the caller's cancellation guard.
+    state: std::sync::Arc<AtomicU8>,
+    /// Tree reported by cancellation errors.
+    tree: PathBuf,
+}
+
+impl InjectControl {
+    /// Fails once the caller stopped waiting, so a long injection stops early.
+    fn check(&self) -> Result<(), ResolveError> {
+        if self.state.load(Ordering::Acquire) == INJECT_ACTIVE {
+            Ok(())
+        } else {
+            Err(ResolveError::GuestInjectionCancelled {
+                path: self.tree.clone(),
+            })
+        }
+    }
+
+    /// Records that injection finished and the tree is the caller's again.
+    fn finish(&self) {
+        self.state.store(INJECT_FINISHED, Ordering::Release);
+    }
+}
+
+/// Marks an abandoned injection cancelled when the caller's future is dropped.
+struct CancelInjectionOnDrop {
+    /// Shared phase, flipped to cancelled while still armed.
+    state: std::sync::Arc<AtomicU8>,
+    /// Cleared once the blocking worker has returned.
+    armed: bool,
+}
+
+impl Drop for CancelInjectionOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.state.compare_exchange(
+                INJECT_ACTIVE,
+                INJECT_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
+    }
+}
+
+/// Runs the blocking injection on the pool and cancels it if the caller leaves.
+pub(super) async fn provision_merged_rootfs(
+    rootfs: MergedRootfs,
+    options: &GuestRuntimeOptions<'_>,
+) -> Result<ProvisionedRootfs, ResolveError> {
+    let toolbox = busybox::ensure_toolbox(options).await?;
+    inject_with_toolbox(rootfs, &toolbox).await
+}
+
+/// Injects one already-verified toolbox program into a merged tree.
+///
+/// Split from acquisition so the injection rules can be tested without a
+/// registry, and so a caller that already holds a program never re-verifies it.
+pub(super) async fn inject_with_toolbox(
+    rootfs: MergedRootfs,
+    toolbox: &ToolboxProgram,
+) -> Result<ProvisionedRootfs, ResolveError> {
+    let tree = rootfs.path().to_owned();
+    let state = std::sync::Arc::new(AtomicU8::new(INJECT_ACTIVE));
+    let control = InjectControl {
+        state: state.clone(),
+        tree: tree.clone(),
+    };
+    let mut cancel_on_drop = CancelInjectionOnDrop { state, armed: true };
+    let worker_toolbox = toolbox.clone();
+    let result =
+        tokio::task::spawn_blocking(move || inject_blocking(&tree, &worker_toolbox, &control))
+            .await
+            .map_err(|error| {
+                injection_io(
+                    "join worker",
+                    rootfs.path().to_owned(),
+                    io::Error::other(error),
+                )
+            });
+    cancel_on_drop.armed = false;
+    result??;
+
+    Ok(ProvisionedRootfs {
+        path: rootfs.path().to_owned(),
+        toolbox: toolbox.digest().clone(),
+    })
+}
+
+/// Writes the guest runtime, unwinding exactly what it touched on failure.
+fn inject_blocking(
+    tree: &Path,
+    toolbox: &ToolboxProgram,
+    control: &InjectControl,
+) -> Result<(), ResolveError> {
+    let mut unwind = InjectedPaths::default();
+    let result = (|| {
+        control.check()?;
+        for (mount_point, mode) in GUEST_MOUNT_POINTS {
+            ensure_guest_directory(tree, mount_point, *mode, &mut unwind)?;
+        }
+        control.check()?;
+        ensure_guest_directory(tree, GUEST_SERVICES, 0o755, &mut unwind)?;
+
+        control.check()?;
+        install_program(tree, GUEST_TOOLBOX, toolbox.path(), &mut unwind)?;
+        install_symlink(tree, GUEST_INIT, "firecrab-busybox", &mut unwind)?;
+
+        control.check()?;
+        install_file(
+            tree,
+            GUEST_INITTAB,
+            inittab().as_bytes(),
+            0o644,
+            &mut unwind,
+        )?;
+        install_file(
+            tree,
+            GUEST_BOOT_SCRIPT,
+            boot_script().as_bytes(),
+            0o755,
+            &mut unwind,
+        )?;
+        install_file(
+            tree,
+            GUEST_DHCP_SCRIPT,
+            DHCP_SCRIPT.as_bytes(),
+            0o755,
+            &mut unwind,
+        )?;
+
+        control.check()?;
+        install_file(
+            tree,
+            crate::guest_agent::BIN_PATH,
+            crate::guest_agent::AGENT_SCRIPT.as_bytes(),
+            0o755,
+            &mut unwind,
+        )
+    })();
+
+    match result {
+        Ok(()) => {
+            control.finish();
+            unwind.keep();
+            Ok(())
+        }
+        Err(error) => {
+            unwind.restore();
+            Err(error)
+        }
+    }
+}
+
+/// Every path this stage created or replaced, so a failure can undo it.
+///
+/// The merged tree belongs to the caller and is expensive to rebuild, so a
+/// failed injection leaves it exactly as it was rather than deleting it. The
+/// path set is small and known, which keeps the unwind bounded.
+#[derive(Default)]
+struct InjectedPaths {
+    /// Host paths created by this stage, newest first when unwound.
+    created: Vec<PathBuf>,
+    /// Paths moved aside as `(backup, original)` so they can be moved back.
+    displaced: Vec<(PathBuf, PathBuf)>,
+    /// Set once injection succeeded and nothing should be undone.
+    kept: bool,
+}
+
+impl InjectedPaths {
+    /// Records a path this stage brought into existence.
+    fn created(&mut self, path: PathBuf) {
+        self.created.push(path);
+    }
+
+    /// Records an image path moved aside to make room.
+    fn displaced(&mut self, backup: PathBuf, original: PathBuf) {
+        self.displaced.push((backup, original));
+    }
+
+    /// Keeps everything: injection succeeded.
+    fn keep(&mut self) {
+        self.kept = true;
+    }
+
+    /// Removes what this stage added and puts back what it moved aside.
+    fn restore(&mut self) {
+        if self.kept {
+            return;
+        }
+        for path in self.created.drain(..).rev() {
+            let removed = match fs::symlink_metadata(&path) {
+                Ok(metadata) if metadata.file_type().is_dir() => fs::remove_dir(&path),
+                Ok(_) => fs::remove_file(&path),
+                Err(_) => Ok(()),
+            };
+            if let Err(error) = removed
+                && error.kind() != io::ErrorKind::NotFound
+            {
+                tracing::warn!(
+                    error = %error,
+                    path = %path.display(),
+                    "failed to unwind an injected guest path"
+                );
+            }
+        }
+        for (backup, original) in self.displaced.drain(..).rev() {
+            if let Err(error) = fs::rename(&backup, &original) {
+                tracing::warn!(
+                    error = %error,
+                    path = %original.display(),
+                    "failed to restore a displaced image path"
+                );
+            }
+        }
+    }
+}
+
+impl Drop for InjectedPaths {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+/// Resolves a guest path's parent inside the tree, creating what is missing.
+///
+/// Ancestor symbolic links are **followed**, not refused: usr-merged images
+/// ship `/sbin` as a link to `usr/sbin`, so refusing them would reject Ubuntu,
+/// Debian, and Fedora outright. Following is made safe by clamping — an
+/// absolute target re-roots at the tree and `..` stops at the tree root — so
+/// resolution provably cannot leave the tree no matter what the image planted.
+///
+/// The final component is deliberately not resolved. Callers replace it without
+/// following it, so an image's `/sbin/init` pointing at systemd loses the link
+/// rather than overwriting systemd itself.
+fn resolve_guest_parent(
+    tree: &Path,
+    guest_path: &str,
+    unwind: &mut InjectedPaths,
+) -> Result<PathBuf, ResolveError> {
+    let relative = guest_path.trim_start_matches('/');
+    let (parent, _) = relative.rsplit_once('/').unwrap_or(("", relative));
+    let mut pending: Vec<String> = parent
+        .split('/')
+        .filter(|component| !component.is_empty() && *component != ".")
+        .map(str::to_owned)
+        .collect();
+    pending.reverse();
+
+    let mut resolved = PathBuf::new();
+    let mut hops = 0_usize;
+    while let Some(component) = pending.pop() {
+        if component == ".." {
+            resolved.pop();
+            continue;
+        }
+        let candidate = resolved.join(&component);
+        let absolute = tree.join(&candidate);
+        match fs::symlink_metadata(&absolute) {
+            Ok(metadata) if metadata.file_type().is_dir() => resolved = candidate,
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                hops += 1;
+                if hops > SYMLINK_HOP_LIMIT {
+                    return Err(guest_path_unusable(
+                        guest_path,
+                        GuestPathViolation::SymlinkLoop {
+                            limit: SYMLINK_HOP_LIMIT,
+                        },
+                    ));
+                }
+                let target = fs::read_link(&absolute).map_err(|source| {
+                    injection_io("read ancestor link", absolute.clone(), source)
+                })?;
+                if target.is_absolute() {
+                    resolved = PathBuf::new();
+                }
+                let mut spliced: Vec<String> = target
+                    .components()
+                    .filter_map(|component| match component {
+                        std::path::Component::Normal(part) => {
+                            Some(part.to_string_lossy().into_owned())
+                        }
+                        std::path::Component::ParentDir => Some("..".to_owned()),
+                        _ => None,
+                    })
+                    .collect();
+                spliced.reverse();
+                pending.extend(spliced);
+            }
+            Ok(_) => {
+                return Err(guest_path_unusable(
+                    guest_path,
+                    GuestPathViolation::NonDirectoryAncestor {
+                        ancestor: candidate,
+                    },
+                ));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                create_directory(&absolute, 0o755)?;
+                unwind.created(absolute);
+                resolved = candidate;
+            }
+            Err(source) => {
+                return Err(injection_io("inspect ancestor", absolute, source));
+            }
+        }
+    }
+    Ok(tree.join(resolved))
+}
+
+/// Creates one directory with an exact mode.
+///
+/// The mode is restated after creation because `DirBuilder` masks it with the
+/// service's umask, which would quietly drop `/tmp`'s sticky bit.
+fn create_directory(path: &Path, mode: u32) -> Result<(), ResolveError> {
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(mode);
+    builder
+        .create(path)
+        .map_err(|source| injection_io("create guest directory", path.to_owned(), source))?;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .map_err(|source| injection_io("set guest directory mode", path.to_owned(), source))
+}
+
+/// Creates a guest directory, leaving an existing one alone.
+fn ensure_guest_directory(
+    tree: &Path,
+    guest_path: &str,
+    mode: u32,
+    unwind: &mut InjectedPaths,
+) -> Result<(), ResolveError> {
+    let parent = resolve_guest_parent(tree, guest_path, unwind)?;
+    let name = guest_path.rsplit('/').next().unwrap_or_default();
+    let destination = parent.join(name);
+    match fs::symlink_metadata(&destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => Ok(()),
+        Ok(_) => Err(guest_path_unusable(
+            guest_path,
+            GuestPathViolation::NonDirectoryAncestor {
+                ancestor: PathBuf::from(guest_path.trim_start_matches('/')),
+            },
+        )),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            create_directory(&destination, mode)?;
+            unwind.created(destination);
+            Ok(())
+        }
+        Err(source) => Err(injection_io("inspect guest directory", destination, source)),
+    }
+}
+
+/// Clears whatever the image left at a final component, recording the move.
+///
+/// The existing entry is never followed. A regular file or symlink is moved
+/// aside so a failed injection can restore it; a directory is refused, because
+/// silently deleting an image's directory tree is not this stage's call.
+fn displace_existing(
+    destination: &Path,
+    guest_path: &str,
+    unwind: &mut InjectedPaths,
+) -> Result<(), ResolveError> {
+    match fs::symlink_metadata(destination) {
+        Ok(metadata) if metadata.file_type().is_dir() => Err(guest_path_unusable(
+            guest_path,
+            GuestPathViolation::NonDirectoryAncestor {
+                ancestor: PathBuf::from(guest_path.trim_start_matches('/')),
+            },
+        )),
+        Ok(_) => {
+            let backup = destination.with_extension(format!("firecrab-{}", Uuid::new_v4()));
+            fs::rename(destination, &backup).map_err(|source| {
+                injection_io("displace image path", destination.to_owned(), source)
+            })?;
+            unwind.displaced(backup, destination.to_owned());
+            Ok(())
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(injection_io(
+            "inspect guest path",
+            destination.to_owned(),
+            source,
+        )),
+    }
+}
+
+/// Writes one guest file, replacing whatever the image left in its place.
+fn install_file(
+    tree: &Path,
+    guest_path: &str,
+    contents: &[u8],
+    mode: u32,
+    unwind: &mut InjectedPaths,
+) -> Result<(), ResolveError> {
+    let parent = resolve_guest_parent(tree, guest_path, unwind)?;
+    let name = guest_path.rsplit('/').next().unwrap_or_default();
+    let destination = parent.join(name);
+    displace_existing(&destination, guest_path, unwind)?;
+    // `create_new` with `O_NOFOLLOW` closes the window between the displace
+    // above and this create: a symlink planted in between cannot be followed.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(mode)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(&destination)
+        .map_err(|source| injection_io("create guest file", destination.clone(), source))?;
+    unwind.created(destination.clone());
+    file.write_all(contents)
+        .map_err(|source| injection_io("write guest file", destination.clone(), source))?;
+    // `OpenOptions::mode` is masked by the service's umask; restate it so an
+    // injected script is executable regardless of how the service was started.
+    fs::set_permissions(&destination, fs::Permissions::from_mode(mode))
+        .map_err(|source| injection_io("set guest file mode", destination, source))
+}
+
+/// Copies the toolbox program into the tree as an executable.
+fn install_program(
+    tree: &Path,
+    guest_path: &str,
+    source_path: &Path,
+    unwind: &mut InjectedPaths,
+) -> Result<(), ResolveError> {
+    let contents = fs::read(source_path)
+        .map_err(|source| injection_io("read toolbox program", source_path.to_owned(), source))?;
+    install_file(tree, guest_path, &contents, 0o755, unwind)
+}
+
+/// Links one guest path at another, replacing what the image left there.
+fn install_symlink(
+    tree: &Path,
+    guest_path: &str,
+    target: &str,
+    unwind: &mut InjectedPaths,
+) -> Result<(), ResolveError> {
+    let parent = resolve_guest_parent(tree, guest_path, unwind)?;
+    let name = guest_path.rsplit('/').next().unwrap_or_default();
+    let destination = parent.join(name);
+    displace_existing(&destination, guest_path, unwind)?;
+    std::os::unix::fs::symlink(target, &destination)
+        .map_err(|source| injection_io("create guest symlink", destination.clone(), source))?;
+    unwind.created(destination);
+    Ok(())
+}
+
+/// Wraps a filesystem failure with the injection step that hit it.
+fn injection_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
+    ResolveError::GuestInjectionIo {
+        operation,
+        path,
+        source,
+    }
+}
+
+/// Wraps a rejection reason with the guest path it applies to.
+fn guest_path_unusable(guest_path: &str, reason: GuestPathViolation) -> ResolveError {
+    ResolveError::GuestPathUnusable {
+        path: guest_path.to_owned(),
+        reason,
+    }
+}
+
+/// busybox init's job table.
+///
+/// Commands stay free of shell metacharacters on purpose: busybox init routes
+/// any command containing them through `/bin/sh -c`, which a distroless image
+/// does not have.
+fn inittab() -> String {
+    format!(
+        "# Firecrab guest runtime for an imported OCI image (public-docs/oci.md).\n\
+         ::sysinit:{GUEST_TOOLBOX} sh {GUEST_BOOT_SCRIPT}\n\
+         ::respawn:-{GUEST_TOOLBOX} sh\n\
+         ::ctrlaltdel:{GUEST_TOOLBOX} poweroff -f\n\
+         ::shutdown:{GUEST_TOOLBOX} sync\n\
+         ::restart:{GUEST_INIT}\n"
+    )
+}
+
+/// Everything between the kernel handing off and the host seeing a sentinel.
+fn boot_script() -> String {
+    format!(
+        r#"#!{GUEST_TOOLBOX} sh
+# Firecrab guest runtime for an imported OCI image (public-docs/oci.md).
+# Avoid `set -e`: one failed mount must not leave the host waiting out the full
+# readiness timeout for a sentinel that will now never be printed.
+BB={GUEST_TOOLBOX}
+
+$BB mount -t proc -o nosuid,nodev,noexec proc /proc 2>/dev/null
+$BB mount -t sysfs -o nosuid,nodev,noexec sysfs /sys 2>/dev/null
+$BB mount -t devtmpfs devtmpfs /dev 2>/dev/null
+$BB mount -t tmpfs -o nosuid,nodev,mode=755 tmpfs /run 2>/dev/null
+
+# Metrics first, so the dashboard has samples even when the network fails.
+$BB setsid $BB sh {agent} >/dev/null 2>&1 &
+
+$BB ip link set lo up 2>/dev/null
+# A bare udhcpc on an administratively down link never sends a single packet and
+# hangs forever, so the link comes up first, always.
+if ! $BB ip link set eth0 up 2>/dev/null; then
+  echo "FIRECRAB_NETWORK_FAILED no-ipv4-address" >/dev/console
+  exit 0
+fi
+
+$BB udhcpc -i eth0 -n -q -t 8 -T 2 -s {dhcp} >/dev/console 2>&1
+
+ipv4=""
+tries=0
+while [ "$tries" -lt 15 ]; do
+  ipv4=$($BB ip -4 -o addr show eth0 2>/dev/null | $BB awk '{{print $4; exit}}' | $BB cut -d/ -f1)
+  [ -n "$ipv4" ] && break
+  tries=$((tries + 1))
+  $BB sleep 1
+done
+
+if [ -z "$ipv4" ]; then
+  echo "FIRECRAB_NETWORK_FAILED no-ipv4-address" >/dev/console
+  exit 0
+fi
+
+dns_ok=0
+tries=0
+while [ "$tries" -lt 15 ]; do
+  if $BB nslookup example.com >/dev/null 2>&1; then
+    dns_ok=1
+    break
+  fi
+  tries=$((tries + 1))
+  $BB sleep 1
+done
+
+if [ "$dns_ok" -ne 1 ]; then
+  echo "FIRECRAB_NETWORK_FAILED dns-unreachable" >/dev/console
+  exit 0
+fi
+
+echo "FIRECRAB_NETWORK_READY $ipv4" >/dev/console
+
+# A later import stage translates the image entrypoint into a program here.
+for service in {services}/*; do
+  [ -x "$service" ] || continue
+  $BB setsid "$service" >/dev/console 2>&1 &
+done
+exit 0
+"#,
+        agent = crate::guest_agent::BIN_PATH,
+        dhcp = GUEST_DHCP_SCRIPT,
+        services = GUEST_SERVICES,
+    )
+}
+
+/// busybox `udhcpc` lease hook.
+///
+/// The lease arrives in the environment, not in arguments. `mask` is a prefix
+/// length in busybox, unlike the dotted `subnet` beside it.
+const DHCP_SCRIPT: &str = r#"#!/sbin/firecrab-busybox sh
+# Firecrab guest DHCP hook for an imported OCI image (public-docs/oci.md).
+BB=/sbin/firecrab-busybox
+
+case "$1" in
+  deconfig)
+    $BB ip addr flush dev "$interface" 2>/dev/null
+    $BB ip link set "$interface" up 2>/dev/null
+    ;;
+  bound|renew)
+    $BB ip addr flush dev "$interface" 2>/dev/null
+    $BB ip addr add "$ip/${mask:-24}" dev "$interface" 2>/dev/null
+    $BB ip link set "$interface" up 2>/dev/null
+    for gateway in $router; do
+      $BB ip route add default via "$gateway" dev "$interface" 2>/dev/null
+      break
+    done
+    # Some images symlink resolv.conf at a resolver stub they never ship, so
+    # the link target never appears. Replace the link with a real file.
+    [ -L /etc/resolv.conf ] && $BB rm -f /etc/resolv.conf
+    : >/etc/resolv.conf
+    for server in $dns; do
+      printf 'nameserver %s\n' "$server" >>/etc/resolv.conf
+    done
+    ;;
+esac
+exit 0
+"#;

--- a/firecrab-api/src/oci/provision_tests.rs
+++ b/firecrab-api/src/oci/provision_tests.rs
@@ -1,0 +1,617 @@
+use super::*;
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::os::unix::fs::PermissionsExt as _;
+
+use tar::{Builder, EntryType, Header};
+use tempfile::{TempDir, tempdir};
+
+fn header(entry_type: EntryType, size: u64, mode: u32) -> Header {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(size);
+    header
+}
+
+fn append_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    target: Option<&str>,
+    data: &[u8],
+    mode: u32,
+) {
+    let mut header = header(entry_type, data.len() as u64, mode);
+    if let Some(target) = target {
+        header
+            .set_link_name_literal(target.as_bytes())
+            .expect("set fixture link target");
+    }
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+fn finish(builder: Builder<Vec<u8>>) -> Vec<u8> {
+    builder.into_inner().expect("finish fixture tar")
+}
+
+fn layer(directory: &TempDir, name: &str, bytes: &[u8]) -> DecompressedLayer {
+    let compressed_bytes = format!("compressed provision fixture {name}").into_bytes();
+    let compressed_digest = Sha256Digest::of_bytes(&compressed_bytes);
+    let compressed_path = directory.path().join(format!("{name}.blob"));
+    std::fs::write(&compressed_path, &compressed_bytes).expect("write compressed fixture");
+    let path = directory.path().join(format!("{name}.tar"));
+    std::fs::write(&path, bytes).expect("write tar fixture");
+    DecompressedLayer {
+        source: CachedBlob {
+            descriptor: Descriptor {
+                media_type: OCI_LAYER_MEDIA_TYPE.to_owned(),
+                digest: compressed_digest,
+                size: compressed_bytes.len() as u64,
+            },
+            path: compressed_path,
+        },
+        diff_id: Sha256Digest::of_bytes(bytes),
+        path,
+        size: bytes.len() as u64,
+    }
+}
+
+/// Merges one fixture layer and returns the published tree.
+async fn merged(directory: &TempDir, name: &str, tar: &[u8]) -> MergedRootfs {
+    let layers = validate_decompressed_layers(vec![layer(directory, name, tar)])
+        .await
+        .expect("validate provision fixture");
+    let destination = directory.path().join(format!("{name}-rootfs"));
+    merge_validated_layers(&layers, &destination)
+        .await
+        .expect("merge provision fixture")
+}
+
+/// Builds a 64-bit little-endian ELF image with the given program headers.
+///
+/// Real busybox is 1 MiB of machine code; every rule this stage enforces lives
+/// in the header, so a hand-built one exercises the verifier exactly.
+fn elf(machine: u16, e_type: u16, program_headers: &[[u8; 56]], trailer: &[u8]) -> Vec<u8> {
+    let mut bytes = vec![0_u8; 64];
+    bytes[..4].copy_from_slice(b"\x7fELF");
+    bytes[4] = 2; // ELFCLASS64
+    bytes[5] = 1; // ELFDATA2LSB
+    bytes[6] = 1; // EI_VERSION
+    bytes[16..18].copy_from_slice(&e_type.to_le_bytes());
+    bytes[18..20].copy_from_slice(&machine.to_le_bytes());
+    bytes[32..40].copy_from_slice(&64_u64.to_le_bytes()); // e_phoff
+    bytes[52..54].copy_from_slice(&64_u16.to_le_bytes()); // e_ehsize
+    bytes[54..56].copy_from_slice(&56_u16.to_le_bytes()); // e_phentsize
+    bytes[56..58].copy_from_slice(&(program_headers.len() as u16).to_le_bytes());
+    for entry in program_headers {
+        bytes.extend_from_slice(entry);
+    }
+    bytes.extend_from_slice(trailer);
+    bytes
+}
+
+/// One program header entry.
+fn program_header(p_type: u32, p_offset: u64, p_filesz: u64) -> [u8; 56] {
+    let mut entry = [0_u8; 56];
+    entry[..4].copy_from_slice(&p_type.to_le_bytes());
+    entry[8..16].copy_from_slice(&p_offset.to_le_bytes());
+    entry[32..40].copy_from_slice(&p_filesz.to_le_bytes());
+    entry
+}
+
+/// A static program for this host, carrying the applet names the guest calls.
+fn static_program() -> Vec<u8> {
+    let mut applets = vec![0_u8];
+    for applet in ["sh", "ip", "udhcpc", "awk", "mount", "sleep", "cut"] {
+        applets.extend_from_slice(applet.as_bytes());
+        applets.push(0);
+    }
+    let machine = match Architecture::HOST {
+        Architecture::X86_64 => 62,
+        Architecture::Aarch64 => 183,
+    };
+    elf(machine, 2, &[program_header(1, 0, 0)], &applets)
+}
+
+/// Writes a program to disk and verifies it the way the pull path would.
+async fn toolbox(directory: &TempDir, name: &str, bytes: &[u8]) -> ToolboxProgram {
+    let path = directory.path().join(name);
+    std::fs::write(&path, bytes).expect("write toolbox fixture");
+    busybox::inspect_toolbox(&path, Architecture::HOST)
+        .await
+        .expect("verify toolbox fixture")
+}
+
+/// Records every path in a tree with its type, mode, and contents.
+fn snapshot(root: &Path) -> BTreeMap<PathBuf, String> {
+    let mut entries = BTreeMap::new();
+    let mut pending = vec![root.to_owned()];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(&directory).expect("read snapshot directory") {
+            let entry = entry.expect("read snapshot entry");
+            let path = entry.path();
+            let metadata = std::fs::symlink_metadata(&path).expect("stat snapshot entry");
+            let relative = path
+                .strip_prefix(root)
+                .expect("snapshot is rooted")
+                .to_owned();
+            let kind = if metadata.file_type().is_symlink() {
+                format!(
+                    "symlink:{}",
+                    std::fs::read_link(&path)
+                        .expect("read snapshot link")
+                        .display()
+                )
+            } else if metadata.is_dir() {
+                pending.push(path.clone());
+                format!("dir:{:o}", metadata.permissions().mode() & 0o7777)
+            } else {
+                format!(
+                    "file:{:o}:{}",
+                    metadata.permissions().mode() & 0o7777,
+                    Sha256Digest::of_bytes(&std::fs::read(&path).expect("read snapshot file"))
+                )
+            };
+            entries.insert(relative, kind);
+        }
+    }
+    entries
+}
+
+fn read_guest(tree: &Path, guest_path: &str) -> Vec<u8> {
+    std::fs::read(tree.join(guest_path.trim_start_matches('/')))
+        .unwrap_or_else(|error| panic!("read {guest_path}: {error}"))
+}
+
+fn guest_mode(tree: &Path, guest_path: &str) -> u32 {
+    std::fs::metadata(tree.join(guest_path.trim_start_matches('/')))
+        .unwrap_or_else(|error| panic!("stat {guest_path}: {error}"))
+        .permissions()
+        .mode()
+        & 0o7777
+}
+
+/// A minimal container tree: an application and nothing an init needs.
+fn application_layer() -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "app/", EntryType::Directory, None, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "app/server",
+        EntryType::Regular,
+        None,
+        b"binary",
+        0o755,
+    );
+    finish(builder)
+}
+
+#[tokio::test]
+async fn injecting_a_guest_installs_an_init_the_stock_kernel_command_line_finds() {
+    let directory = tempdir().expect("create fixture directory");
+    let program = static_program();
+    let toolbox = toolbox(&directory, "busybox", &program).await;
+    let merged = merged(&directory, "plain", &application_layer()).await;
+    let tree = merged.path().to_owned();
+
+    let provisioned = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject a guest runtime");
+
+    assert_eq!(provisioned.path(), tree);
+    assert_eq!(provisioned.toolbox_digest(), toolbox.digest());
+    // The kernel execs /sbin/init when the command line carries no init=.
+    assert_eq!(
+        std::fs::read_link(tree.join("sbin/init")).expect("read /sbin/init"),
+        Path::new("firecrab-busybox")
+    );
+    assert_eq!(read_guest(&tree, "/sbin/firecrab-busybox"), program);
+    assert_eq!(guest_mode(&tree, "/sbin/firecrab-busybox"), 0o755);
+    assert_eq!(guest_mode(&tree, "/etc/firecrab/rc.boot"), 0o755);
+    assert_eq!(guest_mode(&tree, "/etc/inittab"), 0o644);
+
+    let inittab = String::from_utf8(read_guest(&tree, "/etc/inittab")).expect("inittab is text");
+    assert!(inittab.contains("::sysinit:/sbin/firecrab-busybox sh /etc/firecrab/rc.boot"));
+
+    // The host fails the VM start unless one of these reaches the console.
+    let boot = String::from_utf8(read_guest(&tree, "/etc/firecrab/rc.boot")).expect("script");
+    assert!(boot.contains("FIRECRAB_NETWORK_READY $ipv4"));
+    assert!(boot.contains("FIRECRAB_NETWORK_FAILED no-ipv4-address"));
+    assert!(boot.contains("FIRECRAB_NETWORK_FAILED dns-unreachable"));
+
+    // One source of truth for the FIRECRAB_USAGE format the host parses.
+    assert_eq!(
+        read_guest(&tree, crate::guest_agent::BIN_PATH),
+        crate::guest_agent::AGENT_SCRIPT.as_bytes()
+    );
+
+    for mount_point in ["proc", "sys", "dev", "run", "tmp"] {
+        assert!(
+            tree.join(mount_point).is_dir(),
+            "{mount_point} is a directory"
+        );
+    }
+    assert_eq!(guest_mode(&tree, "/tmp"), 0o1777);
+    assert!(tree.join("etc/firecrab/services.d").is_dir());
+    // The image's own files are left exactly as they were.
+    assert_eq!(read_guest(&tree, "/app/server"), b"binary");
+}
+
+#[tokio::test]
+async fn the_boot_script_brings_the_link_up_before_running_the_dhcp_client() {
+    let directory = tempdir().expect("create fixture directory");
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "order", &application_layer()).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject a guest runtime");
+
+    let boot = String::from_utf8(read_guest(&tree, "/etc/firecrab/rc.boot")).expect("script");
+    let link_up = boot
+        .find("ip link set eth0 up")
+        .expect("link is brought up");
+    let dhcp = boot.find("udhcpc -i eth0").expect("dhcp client runs");
+    // A bare udhcpc on a down link sends zero packets and hangs forever.
+    assert!(link_up < dhcp, "the link must come up before udhcpc");
+}
+
+#[tokio::test]
+async fn inittab_commands_avoid_the_metacharacters_busybox_init_reroutes() {
+    let directory = tempdir().expect("create fixture directory");
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "inittab", &application_layer()).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject a guest runtime");
+
+    let inittab = String::from_utf8(read_guest(&tree, "/etc/inittab")).expect("inittab is text");
+    for line in inittab.lines().filter(|line| !line.starts_with('#')) {
+        let command = line.splitn(4, ':').nth(3).unwrap_or_default();
+        // busybox init runs a command containing any of these through
+        // `/bin/sh -c`, which a distroless image does not ship.
+        assert!(
+            !command.contains([
+                '~', '`', '!', '$', '^', '&', '*', '(', ')', '=', '|', '\\', '{', '}', '[', ']',
+                ';', '"', '\'', '<', '>', '?'
+            ]),
+            "inittab command must not need a shell: {command:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn usr_merged_images_are_provisioned_through_their_symlinked_sbin() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "usr/", EntryType::Directory, None, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "usr/sbin/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    // Ubuntu, Debian 12+, and Fedora all ship this. Refusing it would reject
+    // the majority of real images outright.
+    append_entry(
+        &mut builder,
+        "sbin",
+        EntryType::Symlink,
+        Some("usr/sbin"),
+        &[],
+        0o777,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "usrmerge", &tar).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("a usr-merged image must be provisionable");
+
+    assert!(
+        std::fs::symlink_metadata(tree.join("sbin"))
+            .expect("stat sbin")
+            .file_type()
+            .is_symlink(),
+        "the image's own /sbin link is preserved"
+    );
+    assert!(tree.join("usr/sbin/firecrab-busybox").is_file());
+    assert_eq!(
+        std::fs::read_link(tree.join("usr/sbin/init")).expect("read init link"),
+        Path::new("firecrab-busybox")
+    );
+}
+
+#[tokio::test]
+async fn an_image_supplied_init_is_replaced_without_touching_its_target() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "lib/", EntryType::Directory, None, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "lib/systemd",
+        EntryType::Regular,
+        None,
+        b"systemd",
+        0o755,
+    );
+    append_entry(
+        &mut builder,
+        "sbin/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    append_entry(
+        &mut builder,
+        "sbin/init",
+        EntryType::Symlink,
+        Some("/lib/systemd"),
+        &[],
+        0o777,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "systemd", &tar).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject over an image-supplied init");
+
+    assert_eq!(
+        std::fs::read_link(tree.join("sbin/init")).expect("read init link"),
+        Path::new("firecrab-busybox")
+    );
+    // The final component is never followed, so the link was replaced rather
+    // than written through onto systemd's own program.
+    assert_eq!(read_guest(&tree, "/lib/systemd"), b"systemd");
+}
+
+#[tokio::test]
+async fn a_symlinked_ancestor_pointing_outside_the_tree_is_clamped_to_it() {
+    let directory = tempdir().expect("create fixture directory");
+    let outside = directory.path().join("outside");
+    std::fs::create_dir(&outside).expect("create outside directory");
+    std::fs::write(outside.join("inittab"), b"untouched").expect("write outside sentinel");
+
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "etc",
+        EntryType::Symlink,
+        Some(&outside.to_string_lossy()),
+        &[],
+        0o777,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "escape", &tar).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("an escaping ancestor is re-rooted, not refused");
+
+    // The absolute target was re-rooted at the tree, so the host file outside
+    // it never saw a write.
+    assert_eq!(
+        std::fs::read(outside.join("inittab")).unwrap(),
+        b"untouched"
+    );
+    let inside = tree.join(outside.strip_prefix("/").expect("absolute outside path"));
+    assert!(inside.join("inittab").is_file(), "the write landed in-tree");
+}
+
+#[tokio::test]
+async fn a_non_directory_ancestor_refuses_the_injection_and_restores_the_tree() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "etc",
+        EntryType::Regular,
+        None,
+        b"not a directory",
+        0o644,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "blocked", &tar).await;
+    let tree = merged.path().to_owned();
+    let before = snapshot(&tree);
+
+    let error = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect_err("a file where /etc belongs must fail the injection");
+    assert!(matches!(
+        error,
+        ResolveError::GuestPathUnusable {
+            reason: GuestPathViolation::NonDirectoryAncestor { .. },
+            ..
+        }
+    ));
+    // A failed injection is not allowed to damage the caller's merged tree.
+    assert_eq!(snapshot(&tree), before);
+}
+
+#[tokio::test]
+async fn a_symlink_cycle_is_refused_before_any_guest_file_is_written() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "etc",
+        EntryType::Symlink,
+        Some("etc2"),
+        &[],
+        0o777,
+    );
+    append_entry(
+        &mut builder,
+        "etc2",
+        EntryType::Symlink,
+        Some("etc"),
+        &[],
+        0o777,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "cycle", &tar).await;
+    let tree = merged.path().to_owned();
+    let before = snapshot(&tree);
+
+    let error = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect_err("a symlink cycle must fail the injection");
+    assert!(matches!(
+        error,
+        ResolveError::GuestPathUnusable {
+            reason: GuestPathViolation::SymlinkLoop { limit },
+            ..
+        } if limit == 40
+    ));
+    assert_eq!(snapshot(&tree), before);
+}
+
+#[tokio::test]
+async fn guest_injection_refusals_render_operator_readable_messages() {
+    let rendered = [
+        ResolveError::GuestPathUnusable {
+            path: "/sbin/init".to_owned(),
+            reason: GuestPathViolation::SymlinkLoop { limit: 40 },
+        },
+        ResolveError::GuestInjectionIo {
+            operation: "create guest file",
+            path: PathBuf::from("/trees/rootfs/etc/inittab"),
+            source: io::Error::other("disk is full"),
+        },
+        ResolveError::GuestInjectionCancelled {
+            path: PathBuf::from("/trees/rootfs"),
+        },
+    ]
+    .map(|error| error.to_string());
+
+    assert!(rendered[0].contains("40 symbolic links"));
+    assert!(rendered[1].contains("disk is full"));
+    assert!(rendered[2].contains("cancelled"));
+}
+
+#[tokio::test]
+async fn a_late_failure_restores_an_image_supplied_init() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(
+        &mut builder,
+        "sbin/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    append_entry(
+        &mut builder,
+        "sbin/init",
+        EntryType::Regular,
+        None,
+        b"the image's own init",
+        0o755,
+    );
+    append_entry(&mut builder, "usr/", EntryType::Directory, None, &[], 0o755);
+    // The metrics agent is installed last, so a blocked /usr/local fails the
+    // injection only after the init has already been displaced.
+    append_entry(
+        &mut builder,
+        "usr/local",
+        EntryType::Regular,
+        None,
+        b"not a directory",
+        0o644,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "late", &tar).await;
+    let tree = merged.path().to_owned();
+    let before = snapshot(&tree);
+
+    let error = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect_err("a blocked /usr/local must fail the injection");
+    assert!(matches!(
+        error,
+        ResolveError::GuestPathUnusable {
+            reason: GuestPathViolation::NonDirectoryAncestor { .. },
+            ..
+        }
+    ));
+    // Everything is put back, including the init that had been moved aside.
+    assert_eq!(snapshot(&tree), before);
+    assert_eq!(read_guest(&tree, "/sbin/init"), b"the image's own init");
+}
+
+#[tokio::test]
+async fn a_directory_occupying_a_guest_file_path_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "etc/", EntryType::Directory, None, &[], 0o755);
+    // Deleting an image's directory tree to make room is not this stage's call.
+    append_entry(
+        &mut builder,
+        "etc/inittab/",
+        EntryType::Directory,
+        None,
+        &[],
+        0o755,
+    );
+    let tar = finish(builder);
+
+    let toolbox = toolbox(&directory, "busybox", &static_program()).await;
+    let merged = merged(&directory, "dirpath", &tar).await;
+    let tree = merged.path().to_owned();
+    let before = snapshot(&tree);
+
+    let error = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect_err("a directory where /etc/inittab belongs must fail");
+    assert!(matches!(
+        error,
+        ResolveError::GuestPathUnusable {
+            reason: GuestPathViolation::NonDirectoryAncestor { .. },
+            ..
+        }
+    ));
+    assert_eq!(snapshot(&tree), before);
+}
+
+#[tokio::test]
+async fn a_provisioned_tree_records_the_program_it_will_boot() {
+    let directory = tempdir().expect("create fixture directory");
+    let program = static_program();
+    let toolbox = toolbox(&directory, "busybox", &program).await;
+
+    let merged = merged(&directory, "recorded", &application_layer()).await;
+    let provisioned = provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject a guest runtime");
+
+    assert_eq!(
+        provisioned.toolbox_digest(),
+        &Sha256Digest::of_bytes(&program)
+    );
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -113,6 +113,30 @@ when it no longer passes. Operators can name a mirror with
 `FIRECRAB_OCI_TOOLBOX_IMAGE` or an already-present program with
 `FIRECRAB_OCI_TOOLBOX_PATH`.
 
+## Guest activation
+
+Activation installs an init at `/sbin/init`, so the image boots on the same
+kernel command line every other template uses. It also installs a boot script
+that mounts `/proc`, `/sys`, `/dev` and `/run`, brings the interface up before
+asking for a lease, reports `FIRECRAB_NETWORK_READY` with the address it
+received or `FIRECRAB_NETWORK_FAILED` with a reason, and starts the metrics
+agent that reports guest CPU and memory. `/etc/firecrab/services.d` is created
+empty for the image's own entrypoint, which a later stage translates into an
+ordinary service under that init rather than PID 1.
+
+Images that place `/sbin` or `/etc` behind a symbolic link are activated
+through it, because most distribution images link `/sbin` at `/usr/sbin`.
+Resolution is clamped to the tree, so a link naming a host path is followed
+inside the tree and never out of it, and an entry already occupying a guest
+path is replaced without writing through it. A failed activation restores every
+path it touched and leaves the merged tree as it found it.
+
+Registry inspection, raw blob caching, decompression, safety validation, merge,
+and guest activation remain distinct import stages. `GET /api/oci/inspect` stops
+at metadata and fills no OCI cache; caching and decompression do not publish a
+merged tree; activation neither sizes nor writes an ext4 image, pairs no kernel,
+and registers nothing.
+
 ## Related
 
 - [Images](images.md)

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,7 +2,8 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-Importing one into a bootable rootfs is separate work and not available yet.
+Building the result into a registered `rootfs.ext4` is separate work and not
+available yet.
 
 ## Inspect
 
@@ -95,9 +96,22 @@ after every layer succeeds; the destination must not already exist. Failures
 attempt to remove the partial tree and always retain verified blob and
 decompressed-layer cache entries.
 
-Registry inspection, raw blob caching, decompression, safety validation, and
-merge remain distinct import stages. `GET /api/oci/inspect` stops at metadata
-and fills no OCI cache; caching and decompression do not publish a merged tree.
+## Guest toolbox
+
+A container image is an application, not an operating system: it has no PID 1,
+no DHCP client, and nothing that reports readiness. The internal pipeline
+supplies all three from one static program before a merged tree can become a
+bootable image.
+
+That program is taken from a digest-pinned busybox image, pulled through the
+same verified stages as the image being imported. It must be a 64-bit
+executable for this host with no dynamic loader recorded in it, because a
+merged container tree has no loader to satisfy. Only the first import on a host
+reaches the registry; the program is then cached at
+`<FIRECRAB_IMAGE_ROOT>/.oci/toolbox/`, re-verified on every reuse, and rebuilt
+when it no longer passes. Operators can name a mirror with
+`FIRECRAB_OCI_TOOLBOX_IMAGE` or an already-present program with
+`FIRECRAB_OCI_TOOLBOX_PATH`.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Inject an init, DHCP client, readiness sentinel, and metrics agent into a merged OCI tree.
- Supply all four from one static busybox program pulled through the existing verified pipeline.
- Publish nothing new: the stage edits the merged tree in place and restores it on failure.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace --locked`
- `cargo llvm-cov --workspace --locked --lcov --output-path lcov.info`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Related to #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCI guest-runtime provisioning for bootable root filesystems.
  * Added verified BusyBox toolbox acquisition, caching, architecture checks, and local overrides.
  * Added guest initialization, networking, metrics, service startup, and readiness reporting.
  * Added safe guest-path handling and rollback when provisioning fails.

* **Documentation**
  * Updated OCI documentation with toolbox, activation, verification, and rollback workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->