### PR TITLE
feat(oci): size ext4 from the provisioned tree and refuse a full image

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -781,6 +781,52 @@ pub enum ResolveError {
         #[source]
         source: io::Error,
     },
+    /// The ext4 destination already exists and must not be replaced.
+    #[error("OCI ext4 destination already exists at {path}")]
+    Ext4DestinationExists {
+        /// Caller-selected final image path.
+        path: PathBuf,
+    },
+    /// `mkfs.ext4` or `tune2fs` ran but did not produce a usable image.
+    #[error("OCI ext4 image at {path} could not be built: {detail}")]
+    Ext4Build {
+        /// Image path being built.
+        path: PathBuf,
+        /// Tool diagnostic.
+        detail: String,
+    },
+    /// The packed image has less free space than the required headroom.
+    #[error(
+        "OCI ext4 image at {path} is full after packing ({free_bytes} bytes free of {size_bytes}; {required_bytes} required)"
+    )]
+    Ext4Full {
+        /// Image path that was rejected.
+        path: PathBuf,
+        /// Planned image length.
+        size_bytes: u64,
+        /// Free space reported after packing.
+        free_bytes: u64,
+        /// Headroom the image must keep.
+        required_bytes: u64,
+    },
+    /// The planned image exceeds the operator ceiling.
+    #[error(
+        "OCI ext4 image at {path} would be {size_bytes} bytes, exceeding the {limit}-byte limit"
+    )]
+    Ext4TooLarge {
+        /// Image path that was not written.
+        path: PathBuf,
+        /// Planned image length.
+        size_bytes: u64,
+        /// Configured maximum size.
+        limit: u64,
+    },
+    /// The caller stopped waiting before the ext4 image was published.
+    #[error("OCI ext4 write was cancelled before publishing {path}")]
+    Ext4Cancelled {
+        /// Destination that was left unpublished.
+        path: PathBuf,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -2220,6 +2266,43 @@ impl ProvisionedRootfs {
     }
 }
 
+/// A provisioned tree packed into a sized ext4 image that still has headroom.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciExt4Image {
+    path: PathBuf,
+    size_bytes: u64,
+    payload_bytes: u64,
+    free_bytes: u64,
+    toolbox: Sha256Digest,
+}
+
+impl OciExt4Image {
+    /// Host path of the published ext4 image.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Length of the image file in bytes.
+    pub fn size_bytes(&self) -> u64 {
+        self.size_bytes
+    }
+
+    /// Measured payload of the provisioned tree packed into the image.
+    pub fn payload_bytes(&self) -> u64 {
+        self.payload_bytes
+    }
+
+    /// Free space remaining after packing, from `tune2fs`.
+    pub fn free_bytes(&self) -> u64 {
+        self.free_bytes
+    }
+
+    /// Digest of the toolbox program the provisioned tree will boot.
+    pub fn toolbox_digest(&self) -> &Sha256Digest {
+        &self.toolbox
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2576,6 +2659,20 @@ pub async fn provision_merged_rootfs(
     options: &GuestRuntimeOptions<'_>,
 ) -> Result<ProvisionedRootfs, ResolveError> {
     provision::provision_merged_rootfs(rootfs, options).await
+}
+
+/// Packs a provisioned tree into a new ext4 image sized from that tree.
+///
+/// The image is large enough for the payload plus headroom. A result that
+/// lands full is deleted and returned as an error rather than registered
+/// later as a bootable template. The destination must not already exist.
+/// The source tree is left in place. This stage does not pair a kernel or
+/// register a template.
+pub async fn write_provisioned_ext4(
+    rootfs: &ProvisionedRootfs,
+    destination: &Path,
+) -> Result<OciExt4Image, ResolveError> {
+    ext4::write_provisioned_ext4(rootfs, destination).await
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -770,6 +770,17 @@ pub enum ResolveError {
         /// Merged tree that was left unprovisioned.
         path: PathBuf,
     },
+    /// A filesystem operation failed while sizing or writing the ext4 image.
+    #[error("OCI ext4 {operation} failed at {path}: {source}")]
+    Ext4Io {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Tree or image path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1764,6 +1775,11 @@ mod provision;
 
 #[cfg(test)]
 mod provision_tests;
+
+mod ext4;
+
+#[cfg(test)]
+mod ext4_tests;
 
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/firecrab-api/src/oci/ext4.rs
+++ b/firecrab-api/src/oci/ext4.rs
@@ -2,14 +2,29 @@
 
 use super::*;
 
+use std::fs::{self, OpenOptions};
 use std::os::unix::fs::MetadataExt as _;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 pub(super) const HEADROOM_BYTES: u64 = 32 * 1024 * 1024;
 pub(super) const MIN_IMAGE_BYTES: u64 = 8 * 1024 * 1024;
+/// Free space that must remain after `mkfs.ext4 -d`.
+///
+/// Smaller than [`HEADROOM_BYTES`] on purpose: that constant is a sizing
+/// allowance, and the formatter spends some of it on the journal and inode
+/// table. Requiring the full 32 MiB back would reject every image whose
+/// planned size is only slightly above 32 MiB. One mebibyte still means the
+/// filesystem is not full.
+pub(super) const MIN_FREE_AFTER_PACK: u64 = 1024 * 1024;
 const METADATA_NUMERATOR: u64 = 25;
 const METADATA_DENOMINATOR: u64 = 100;
 const ALIGN_BYTES: u64 = 1024 * 1024;
 pub(super) const DEFAULT_MAX_ROOTFS_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+const MAX_ROOTFS_BYTES_ENV: &str = "FIRECRAB_OCI_MAX_ROOTFS_BYTES";
+const WRITE_ACTIVE: u8 = 0;
+const WRITE_PUBLISHING: u8 = 1;
+const WRITE_CANCELLED: u8 = 2;
+const WRITE_FINISHED: u8 = 3;
 
 pub(super) fn plan_ext4_size(payload_bytes: u64) -> u64 {
     let metadata = payload_bytes.saturating_mul(METADATA_NUMERATOR) / METADATA_DENOMINATOR;
@@ -62,5 +77,304 @@ fn ext4_io(operation: &'static str, path: PathBuf, source: io::Error) -> Resolve
         operation,
         path,
         source,
+    }
+}
+
+/// Shared cancellation state consulted between ext4 write steps.
+struct Ext4Control {
+    /// Current phase, shared with the caller's cancellation guard.
+    state: std::sync::Arc<AtomicU8>,
+    /// Destination reported by cancellation errors.
+    destination: PathBuf,
+}
+
+impl Ext4Control {
+    /// Fails once the caller stopped waiting, so a long pack stops early.
+    fn check(&self) -> Result<(), ResolveError> {
+        if self.state.load(Ordering::Acquire) == WRITE_ACTIVE {
+            Ok(())
+        } else {
+            Err(ResolveError::Ext4Cancelled {
+                path: self.destination.clone(),
+            })
+        }
+    }
+
+    /// Claims the right to publish, locking cancellation out from here on.
+    fn begin_publish(&self) -> Result<(), ResolveError> {
+        self.state
+            .compare_exchange(
+                WRITE_ACTIVE,
+                WRITE_PUBLISHING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+            .map_err(|_| ResolveError::Ext4Cancelled {
+                path: self.destination.clone(),
+            })
+    }
+
+    /// Records that publishing finished and the image is the caller's.
+    fn finish(&self) {
+        self.state.store(WRITE_FINISHED, Ordering::Release);
+    }
+}
+
+/// Marks an abandoned write cancelled when the caller's future is dropped.
+struct CancelExt4OnDrop {
+    /// Shared phase, flipped to cancelled while still armed.
+    state: std::sync::Arc<AtomicU8>,
+    /// Cleared once the blocking worker has returned.
+    armed: bool,
+}
+
+impl Drop for CancelExt4OnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.state.compare_exchange(
+                WRITE_ACTIVE,
+                WRITE_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
+        }
+    }
+}
+
+pub(super) async fn write_provisioned_ext4(
+    rootfs: &ProvisionedRootfs,
+    destination: &Path,
+) -> Result<OciExt4Image, ResolveError> {
+    write_provisioned_ext4_with_limit(rootfs, destination, configured_max_rootfs_bytes()).await
+}
+
+pub(super) async fn write_provisioned_ext4_with_limit(
+    rootfs: &ProvisionedRootfs,
+    destination: &Path,
+    limit: u64,
+) -> Result<OciExt4Image, ResolveError> {
+    let payload = measure_tree_payload(rootfs.path())?;
+    let size = plan_ext4_size(payload);
+    if size > limit {
+        return Err(ResolveError::Ext4TooLarge {
+            path: destination.to_owned(),
+            size_bytes: size,
+            limit,
+        });
+    }
+    write_measured_ext4(rootfs, destination, size, payload).await
+}
+
+pub(super) async fn write_provisioned_ext4_with_size(
+    rootfs: &ProvisionedRootfs,
+    destination: &Path,
+    image_bytes: u64,
+) -> Result<OciExt4Image, ResolveError> {
+    let payload = measure_tree_payload(rootfs.path())?;
+    write_measured_ext4(rootfs, destination, image_bytes, payload).await
+}
+
+async fn write_measured_ext4(
+    rootfs: &ProvisionedRootfs,
+    destination: &Path,
+    image_bytes: u64,
+    payload_bytes: u64,
+) -> Result<OciExt4Image, ResolveError> {
+    match fs::symlink_metadata(destination) {
+        Ok(_) => {
+            return Err(ResolveError::Ext4DestinationExists {
+                path: destination.to_owned(),
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(ext4_io(
+                "inspect destination",
+                destination.to_owned(),
+                source,
+            ));
+        }
+    }
+
+    let state = std::sync::Arc::new(AtomicU8::new(WRITE_ACTIVE));
+    let control = Ext4Control {
+        state: state.clone(),
+        destination: destination.to_owned(),
+    };
+    let mut cancel_on_drop = CancelExt4OnDrop { state, armed: true };
+    let tree = rootfs.path().to_owned();
+    let dest = destination.to_owned();
+    let toolbox = rootfs.toolbox_digest().clone();
+    let result = tokio::task::spawn_blocking(move || {
+        write_blocking(&tree, &dest, image_bytes, payload_bytes, toolbox, &control)
+    })
+    .await
+    .map_err(|error| {
+        ext4_io(
+            "join worker",
+            destination.to_owned(),
+            io::Error::other(error),
+        )
+    });
+    cancel_on_drop.armed = false;
+    result?
+}
+
+fn write_blocking(
+    tree: &Path,
+    destination: &Path,
+    image_bytes: u64,
+    payload_bytes: u64,
+    toolbox: Sha256Digest,
+    control: &Ext4Control,
+) -> Result<OciExt4Image, ResolveError> {
+    control.check()?;
+    if let Some(parent) = destination.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent)
+            .map_err(|source| ext4_io("create destination parent", parent.to_owned(), source))?;
+    }
+
+    let parent = destination
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let partial = parent.join(format!(".firecrab-oci-ext4-{}.partial", Uuid::new_v4()));
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&partial)
+        .map_err(|source| ext4_io("create partial image", partial.clone(), source))?;
+    file.set_len(image_bytes)
+        .map_err(|source| ext4_io("size partial image", partial.clone(), source))?;
+    drop(file);
+    let mut cleanup = PartialCleanup::new(partial.clone());
+
+    control.check()?;
+    run_mkfs(tree, &partial, destination)?;
+    control.check()?;
+    let free_bytes = inspect_free_bytes(&partial, destination)?;
+    if free_bytes < MIN_FREE_AFTER_PACK {
+        return Err(ResolveError::Ext4Full {
+            path: destination.to_owned(),
+            size_bytes: image_bytes,
+            free_bytes,
+            required_bytes: MIN_FREE_AFTER_PACK,
+        });
+    }
+
+    control.begin_publish()?;
+    fs::rename(&partial, destination)
+        .map_err(|source| ext4_io("publish ext4 image", destination.to_owned(), source))?;
+    cleanup.published = true;
+    control.finish();
+    Ok(OciExt4Image {
+        path: destination.to_owned(),
+        size_bytes: image_bytes,
+        payload_bytes,
+        free_bytes,
+        toolbox,
+    })
+}
+
+fn run_mkfs(tree: &Path, image: &Path, destination: &Path) -> Result<(), ResolveError> {
+    let mut command = std::process::Command::new("mkfs.ext4");
+    command.args(["-F", "-q", "-m", "0", "-L", "rootfs"]);
+    command.args(orphan_file_args());
+    command.arg("-d").arg(tree).arg(image);
+    let output = command
+        .output()
+        .map_err(|source| ext4_io("run mkfs.ext4", image.to_owned(), source))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let mut detail = String::from_utf8_lossy(&output.stderr).into_owned();
+    if detail.trim().is_empty() {
+        detail = String::from_utf8_lossy(&output.stdout).into_owned();
+    }
+    if detail.trim().is_empty() {
+        detail = format!("mkfs.ext4 exited with status {}", output.status);
+    }
+    Err(ResolveError::Ext4Build {
+        path: destination.to_owned(),
+        detail: detail.trim().to_owned(),
+    })
+}
+
+fn inspect_free_bytes(image: &Path, destination: &Path) -> Result<u64, ResolveError> {
+    let output = std::process::Command::new("tune2fs")
+        .arg("-l")
+        .arg(image)
+        .output()
+        .map_err(|source| ext4_io("run tune2fs", image.to_owned(), source))?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        return Err(ResolveError::Ext4Build {
+            path: destination.to_owned(),
+            detail: format!("tune2fs failed: {}", detail.trim()),
+        });
+    }
+    parse_tune2fs_free_bytes(&String::from_utf8_lossy(&output.stdout)).ok_or_else(|| {
+        ResolveError::Ext4Build {
+            path: destination.to_owned(),
+            detail: "tune2fs did not report free space".to_owned(),
+        }
+    })
+}
+
+fn parse_tune2fs_free_bytes(text: &str) -> Option<u64> {
+    let mut block_size = None;
+    let mut free_blocks = None;
+    for line in text.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        match key.trim() {
+            "Block size" => block_size = value.trim().parse::<u64>().ok(),
+            "Free blocks" => free_blocks = value.trim().parse::<u64>().ok(),
+            _ => {}
+        }
+    }
+    Some(block_size? * free_blocks?)
+}
+
+fn orphan_file_args() -> Vec<&'static str> {
+    match std::fs::read_to_string("/etc/mke2fs.conf") {
+        Ok(text)
+            if text
+                .split_whitespace()
+                .any(|word| word.contains("orphan_file")) =>
+        {
+            vec!["-O", "^orphan_file"]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn configured_max_rootfs_bytes() -> u64 {
+    match std::env::var(MAX_ROOTFS_BYTES_ENV) {
+        Ok(value) => match value.trim().parse::<u64>() {
+            Ok(limit) if limit > 0 => limit,
+            _ => {
+                tracing::warn!(
+                    variable = MAX_ROOTFS_BYTES_ENV,
+                    value,
+                    default = DEFAULT_MAX_ROOTFS_BYTES,
+                    "invalid OCI ext4 image limit; using default"
+                );
+                DEFAULT_MAX_ROOTFS_BYTES
+            }
+        },
+        Err(std::env::VarError::NotPresent) => DEFAULT_MAX_ROOTFS_BYTES,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                variable = MAX_ROOTFS_BYTES_ENV,
+                default = DEFAULT_MAX_ROOTFS_BYTES,
+                "non-Unicode OCI ext4 image limit; using default"
+            );
+            DEFAULT_MAX_ROOTFS_BYTES
+        }
     }
 }

--- a/firecrab-api/src/oci/ext4.rs
+++ b/firecrab-api/src/oci/ext4.rs
@@ -1,0 +1,66 @@
+//! Sizes and writes an ext4 image from a provisioned OCI tree.
+
+use super::*;
+
+use std::os::unix::fs::MetadataExt as _;
+
+pub(super) const HEADROOM_BYTES: u64 = 32 * 1024 * 1024;
+pub(super) const MIN_IMAGE_BYTES: u64 = 8 * 1024 * 1024;
+const METADATA_NUMERATOR: u64 = 25;
+const METADATA_DENOMINATOR: u64 = 100;
+const ALIGN_BYTES: u64 = 1024 * 1024;
+pub(super) const DEFAULT_MAX_ROOTFS_BYTES: u64 = 32 * 1024 * 1024 * 1024;
+
+pub(super) fn plan_ext4_size(payload_bytes: u64) -> u64 {
+    let metadata = payload_bytes.saturating_mul(METADATA_NUMERATOR) / METADATA_DENOMINATOR;
+    let needed = payload_bytes
+        .saturating_add(metadata)
+        .saturating_add(HEADROOM_BYTES);
+    let aligned = needed
+        .saturating_add(ALIGN_BYTES - 1)
+        .saturating_div(ALIGN_BYTES)
+        .saturating_mul(ALIGN_BYTES);
+    aligned.max(MIN_IMAGE_BYTES)
+}
+
+pub(super) fn measure_tree_payload(tree: &Path) -> Result<u64, ResolveError> {
+    let mut total = 0_u64;
+    let mut seen_inodes = std::collections::HashSet::new();
+    let mut pending = vec![tree.to_owned()];
+    while let Some(path) = pending.pop() {
+        let entries = std::fs::read_dir(&path)
+            .map_err(|source| ext4_io("read tree", path.clone(), source))?;
+        for entry in entries {
+            let entry = entry.map_err(|source| ext4_io("read tree entry", path.clone(), source))?;
+            let child = entry.path();
+            let metadata = std::fs::symlink_metadata(&child)
+                .map_err(|source| ext4_io("stat tree entry", child.clone(), source))?;
+            if metadata.file_type().is_dir() {
+                pending.push(child);
+                continue;
+            }
+            if metadata.file_type().is_symlink() {
+                let target = std::fs::read_link(&child)
+                    .map_err(|source| ext4_io("read tree symlink", child.clone(), source))?;
+                total = total.saturating_add(target.as_os_str().len() as u64);
+                continue;
+            }
+            if !metadata.file_type().is_file() {
+                continue;
+            }
+            let inode = (metadata.dev(), metadata.ino());
+            if seen_inodes.insert(inode) {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    Ok(total)
+}
+
+fn ext4_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
+    ResolveError::Ext4Io {
+        operation,
+        path,
+        source,
+    }
+}

--- a/firecrab-api/src/oci/ext4_tests.rs
+++ b/firecrab-api/src/oci/ext4_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+use std::os::unix::fs::MetadataExt as _;
+use tempfile::tempdir;
+
+fn write_file(path: &std::path::Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    std::fs::write(path, bytes).expect("write fixture file");
+}
+
+#[test]
+fn an_empty_tree_plans_the_minimum_headroom_image() {
+    assert_eq!(ext4::plan_ext4_size(0), 32 * 1024 * 1024);
+}
+
+#[test]
+fn a_one_megabyte_payload_adds_metadata_and_headroom_then_aligns() {
+    let payload = 1024 * 1024;
+    // 1 MiB + 25% + 32 MiB = 33.25 MiB → 34 MiB
+    assert_eq!(ext4::plan_ext4_size(payload), 34 * 1024 * 1024);
+}
+
+#[test]
+fn a_hundred_megabyte_payload_is_not_a_fixed_two_gigabyte_image() {
+    let payload = 100 * 1024 * 1024;
+    let size = ext4::plan_ext4_size(payload);
+    assert_eq!(size, 157 * 1024 * 1024);
+    assert!(size < 2 * 1024 * 1024 * 1024);
+    assert!(size >= payload + ext4::HEADROOM_BYTES);
+}
+
+#[tokio::test]
+async fn measuring_a_tree_counts_regular_bytes_and_symlink_targets() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = directory.path().join("tree");
+    write_file(&tree.join("bin/app"), &vec![0_u8; 1000]);
+    std::os::unix::fs::symlink("app", tree.join("bin/alias")).expect("symlink");
+
+    let payload = ext4::measure_tree_payload(&tree).expect("measure tree");
+    assert_eq!(payload, 1000 + 3); // "app"
+}
+
+#[tokio::test]
+async fn measuring_a_tree_counts_hard_links_once() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = directory.path().join("tree");
+    write_file(&tree.join("share/data"), &vec![0_u8; 4096]);
+    std::fs::hard_link(tree.join("share/data"), tree.join("share/copy")).expect("hard link");
+
+    let payload = ext4::measure_tree_payload(&tree).expect("measure tree");
+    assert_eq!(payload, 4096);
+    assert!(std::fs::hard_link(tree.join("share/data"), tree.join("share/copy")).is_err());
+    let meta = std::fs::symlink_metadata(tree.join("share/data")).unwrap();
+    assert!(meta.nlink() >= 2);
+}

--- a/firecrab-api/src/oci/ext4_tests.rs
+++ b/firecrab-api/src/oci/ext4_tests.rs
@@ -55,3 +55,155 @@ async fn measuring_a_tree_counts_hard_links_once() {
     let meta = std::fs::symlink_metadata(tree.join("share/data")).unwrap();
     assert!(meta.nlink() >= 2);
 }
+
+fn provisioned(tree: std::path::PathBuf) -> ProvisionedRootfs {
+    ProvisionedRootfs {
+        path: tree,
+        toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+    }
+}
+
+fn tree_with_payload(root: &std::path::Path, bytes: usize) -> std::path::PathBuf {
+    tree_with_filled_payload(root, bytes, 0)
+}
+
+fn tree_with_filled_payload(root: &std::path::Path, bytes: usize, fill: u8) -> std::path::PathBuf {
+    let tree = root.join("tree");
+    write_file(&tree.join("app/payload"), &vec![fill; bytes]);
+    tree
+}
+
+#[tokio::test]
+async fn packing_a_small_tree_leaves_required_headroom() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = tree_with_payload(directory.path(), 64 * 1024);
+    let destination = directory.path().join("rootfs.ext4");
+    let image = ext4::write_provisioned_ext4(&provisioned(tree.clone()), &destination)
+        .await
+        .expect("pack a small tree");
+
+    assert_eq!(image.path(), destination.as_path());
+    assert_eq!(image.payload_bytes(), 64 * 1024);
+    assert_eq!(image.size_bytes(), ext4::plan_ext4_size(64 * 1024));
+    assert!(
+        image.free_bytes() >= ext4::MIN_FREE_AFTER_PACK,
+        "packed image must not be full: {} free",
+        image.free_bytes()
+    );
+    assert!(image.free_bytes() > image.payload_bytes());
+    assert_eq!(
+        image.toolbox_digest(),
+        &Sha256Digest::of_bytes(b"toolbox-fixture")
+    );
+    assert!(destination.is_file());
+    assert_eq!(
+        std::fs::metadata(&destination).expect("stat image").len(),
+        image.size_bytes()
+    );
+    // Source tree is the caller's and must survive packing.
+    assert_eq!(
+        std::fs::read(tree.join("app/payload")).unwrap().len(),
+        64 * 1024
+    );
+}
+
+#[tokio::test]
+async fn packing_refuses_to_overwrite_an_existing_destination() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = tree_with_payload(directory.path(), 1024);
+    let destination = directory.path().join("rootfs.ext4");
+    std::fs::write(&destination, b"already here").expect("seed destination");
+
+    let error = ext4::write_provisioned_ext4(&provisioned(tree), &destination)
+        .await
+        .expect_err("existing destination must fail");
+    assert!(matches!(error, ResolveError::Ext4DestinationExists { .. }));
+    assert_eq!(std::fs::read(&destination).unwrap(), b"already here");
+}
+
+#[tokio::test]
+async fn an_undersized_image_fails_and_leaves_no_destination() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = tree_with_filled_payload(directory.path(), 2 * 1024 * 1024, 0xA5);
+    let destination = directory.path().join("rootfs.ext4");
+
+    let error =
+        ext4::write_provisioned_ext4_with_size(&provisioned(tree), &destination, 3 * 1024 * 1024)
+            .await
+            .expect_err("a 3 MiB image cannot hold 2 MiB plus headroom");
+
+    assert!(
+        matches!(
+            error,
+            ResolveError::Ext4Full { .. } | ResolveError::Ext4Build { .. }
+        ),
+        "undersize must fail loudly, got {error}"
+    );
+    assert!(
+        !destination.exists(),
+        "must not publish a full or failed image"
+    );
+    let leftovers: Vec<_> = std::fs::read_dir(directory.path())
+        .unwrap()
+        .filter_map(|entry| {
+            let name = entry.ok()?.file_name();
+            let name = name.to_string_lossy();
+            name.contains("partial").then_some(name.into_owned())
+        })
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "partial images must be removed: {leftovers:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_planned_image_over_the_operator_ceiling_fails_before_mkfs() {
+    let directory = tempdir().expect("create fixture directory");
+    let tree = tree_with_payload(directory.path(), 1024);
+    let destination = directory.path().join("rootfs.ext4");
+
+    let error =
+        ext4::write_provisioned_ext4_with_limit(&provisioned(tree), &destination, 1024 * 1024)
+            .await
+            .expect_err("1 MiB ceiling cannot fit the planned image");
+    assert!(
+        matches!(
+            error,
+            ResolveError::Ext4TooLarge { limit, .. } if limit == 1024 * 1024
+        ),
+        "expected Ext4TooLarge with 1 MiB limit, got {error}"
+    );
+    assert!(!destination.exists());
+}
+
+#[tokio::test]
+async fn ext4_refusals_render_operator_readable_messages() {
+    let rendered = [
+        ResolveError::Ext4Full {
+            path: std::path::PathBuf::from("/images/rootfs.ext4"),
+            size_bytes: 8 * 1024 * 1024,
+            free_bytes: 0,
+            required_bytes: ext4::MIN_FREE_AFTER_PACK,
+        },
+        ResolveError::Ext4TooLarge {
+            path: std::path::PathBuf::from("/images/rootfs.ext4"),
+            size_bytes: 40 * 1024 * 1024 * 1024,
+            limit: ext4::DEFAULT_MAX_ROOTFS_BYTES,
+        },
+        ResolveError::Ext4Build {
+            path: std::path::PathBuf::from("/images/rootfs.ext4"),
+            detail: "No space left on device".to_owned(),
+        },
+        ResolveError::Ext4Cancelled {
+            path: std::path::PathBuf::from("/images/rootfs.ext4"),
+        },
+    ]
+    .map(|error| error.to_string());
+
+    assert!(rendered[0].contains("is full after packing"));
+    assert!(rendered[0].contains("1048576 required"));
+    assert!(rendered[1].contains("exceeding the"));
+    assert!(rendered[2].contains("No space left on device"));
+    assert!(rendered[3].contains("cancelled"));
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,8 +2,8 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-Building the result into a registered `rootfs.ext4` is separate work and not
-available yet.
+The internal pipeline can size a provisioned tree into an ext4 image.
+Pairing a kernel and registering a template are still separate work.
 
 ## Inspect
 
@@ -131,11 +131,31 @@ inside the tree and never out of it, and an entry already occupying a guest
 path is replaced without writing through it. A failed activation restores every
 path it touched and leaves the merged tree as it found it.
 
+## Ext4 image
+
+The internal pipeline sizes the ext4 from the provisioned tree rather than
+from a fixed image length.
+Payload bytes count each regular inode once and include symlink targets;
+hard links are not added again.
+
+The image is the payload plus a quarter for ext4 metadata plus 32 MiB of
+headroom, rounded up to a whole mebibyte and never below 8 MiB.
+One image is limited to 32 GiB by default; operators can change this with
+`FIRECRAB_OCI_MAX_ROOTFS_BYTES`.
+
+The file is created sparse, formatted with `mkfs.ext4 -d`, and published
+only after `tune2fs` shows free space remains.
+A full image, a failed format, or a destination that already exists is an
+error, and a partial file is removed.
+The provisioned tree is left in place.
+This stage still pairs no kernel and registers nothing.
+
 Registry inspection, raw blob caching, decompression, safety validation, merge,
-and guest activation remain distinct import stages. `GET /api/oci/inspect` stops
-at metadata and fills no OCI cache; caching and decompression do not publish a
-merged tree; activation neither sizes nor writes an ext4 image, pairs no kernel,
-and registers nothing.
+guest activation, and ext4 sizing remain distinct import stages.
+`GET /api/oci/inspect` stops at metadata and fills no OCI cache;
+caching and decompression do not publish a merged tree;
+activation does not write an ext4 image;
+ext4 sizing pairs no kernel and registers nothing.
 
 ## Related
 

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -43,6 +43,7 @@ systemctl restart firecrab-api
 | `FIRECRAB_IMAGE_BASE_URL` | Public MicroRegistry | Image package base URL; `none` disables remote installs |
 | `FIRECRAB_OCI_MAX_BLOB_BYTES` | 16 GiB | Maximum compressed size of one downloaded OCI config or layer blob |
 | `FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES` | 64 GiB | Maximum decoded size of one OCI layer tar stream |
+| `FIRECRAB_OCI_MAX_ROOTFS_BYTES` | 32 GiB | Maximum size of one OCI-imported ext4 image |
 | `FIRECRAB_STATIC_ROOT` | Installed dashboard | Static UI path |
 | `FIRECRAB_STORAGE_ROOTS` | `default=data` | Fixed storage roots |
 | `FIRECRAB_NET_HELPER_SOCK` | `/run/firecrab/net-helper.sock` | Helper socket |


### PR DESCRIPTION
## Summary

- Size the ext4 from the provisioned tree plus headroom, not a fixed image length.
- Count each regular inode once and include symlink targets, so hard-link aliases do not double the image.
- Pack with `mkfs.ext4 -d` onto a sparse file, then publish only after `tune2fs` still reports free space.
- Fail loudly and delete the partial file when the filesystem is full, `mkfs` fails, or the destination already exists. The source tree stays in place.
- Leave kernel pairing and template registration to a later stage.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Stacked on #101. Related to #90.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating ext4 images from provisioned OCI root filesystems.
  * Reports image size, payload size, available space, and related metadata.
  * Preserves the source tree and prevents overwriting existing destinations.
  * Supports configurable maximum image sizes, cancellation, and cleanup after failures.

* **Documentation**
  * Documented ext4 image sizing, publication behavior, and lifecycle details.
  * Added configuration guidance for limiting imported root filesystem size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->