### PR TITLE
feat(oci): derive a unique alias and version from the reference

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -881,6 +881,20 @@ pub enum ResolveError {
         #[source]
         source: io::Error,
     },
+    /// The derived alias is already an installed or catalog image.
+    #[error("OCI import alias {alias} collides with installed image {occupant}")]
+    AliasCollision {
+        /// Alias derived from the reference.
+        alias: String,
+        /// Alias already claimed by the registry or catalog.
+        occupant: String,
+    },
+    /// The reference cannot be turned into a safe template alias.
+    #[error("OCI reference {reference} cannot be turned into a template alias")]
+    AliasUnusable {
+        /// Original reference text, for the operator.
+        reference: String,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1886,6 +1900,11 @@ mod boot;
 #[cfg(test)]
 mod boot_tests;
 
+mod name;
+
+#[cfg(test)]
+mod name_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2406,6 +2425,44 @@ impl OciBootableImage {
     }
 }
 
+/// Alias and version later registration can copy into a [`crate::templates::TemplateSpec`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciTemplateName {
+    /// User-facing alias derived from the reference.
+    pub alias: String,
+    /// Version tag or digest pin from the reference.
+    pub version: String,
+}
+
+/// A bootable OCI image that has a unique alias and version.
+///
+/// Deliberately distinct from [`OciBootableImage`] so registration can require
+/// proof that the name was derived and does not collide with an installed
+/// image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedOciImage {
+    image: OciBootableImage,
+    alias: String,
+    version: String,
+}
+
+impl NamedOciImage {
+    /// Kernel, boot args, and packed ext4 this name will register.
+    pub fn image(&self) -> &OciBootableImage {
+        &self.image
+    }
+
+    /// Unique alias derived from the image reference.
+    pub fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    /// Version derived from the image reference's tag or digest.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2790,6 +2847,19 @@ pub fn pair_ext4_with_host_kernel(
     image_root: &Path,
 ) -> Result<OciBootableImage, ResolveError> {
     boot::pair_ext4_with_host_kernel(image, image_root)
+}
+
+/// Derives a unique alias and version from the reference and attaches them
+/// to a paired image.
+///
+/// An installed alias or a catalog alias is a collision and is refused.
+/// This stage does not register a template.
+pub fn name_oci_image(
+    image: OciBootableImage,
+    reference: &ImageReference,
+    templates: &crate::templates::TemplateRegistry,
+) -> Result<NamedOciImage, ResolveError> {
+    name::name_oci_image(image, reference, templates)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci/name.rs
+++ b/firecrab-api/src/oci/name.rs
@@ -1,0 +1,163 @@
+//! Derives a unique template alias and version from an OCI reference.
+//!
+//! `TemplateSpec` needs both. A reference already has a repository and a tag
+//! or digest, so this stage turns those into the same shape built-in images
+//! use and refuses a name that would overwrite an installed or catalog image.
+//! It does not register anything.
+
+use super::*;
+
+use crate::templates::TemplateRegistry;
+
+/// Hex characters of a digest kept in a derived alias.
+const DIGEST_ALIAS_HEX: usize = 12;
+
+/// Builds the candidate alias and version without consulting the registry.
+pub(super) fn template_name_from_reference(
+    reference: &ImageReference,
+) -> Result<OciTemplateName, ResolveError> {
+    let alias = alias_from_reference(reference)?;
+    let version = match &reference.version {
+        ImageVersion::Tag(tag) => tag.clone(),
+        ImageVersion::Digest(digest) => digest.as_str().to_owned(),
+    };
+    Ok(OciTemplateName { alias, version })
+}
+
+/// Derives the name and refuses it when an installed or reserved alias exists.
+pub(super) fn claim_template_name(
+    reference: &ImageReference,
+    templates: &TemplateRegistry,
+) -> Result<OciTemplateName, ResolveError> {
+    let named = template_name_from_reference(reference)?;
+    if let Some(occupant) = occupied_by(&named.alias, templates) {
+        return Err(ResolveError::AliasCollision {
+            alias: named.alias,
+            occupant,
+        });
+    }
+    Ok(named)
+}
+
+/// Attaches a claimed name to a paired image. The pair is left unchanged.
+pub(super) fn name_oci_image(
+    image: OciBootableImage,
+    reference: &ImageReference,
+    templates: &TemplateRegistry,
+) -> Result<NamedOciImage, ResolveError> {
+    let named = claim_template_name(reference, templates)?;
+    Ok(NamedOciImage {
+        image,
+        alias: named.alias,
+        version: named.version,
+    })
+}
+
+fn occupied_by(alias: &str, templates: &TemplateRegistry) -> Option<String> {
+    if templates.resolve_alias(alias).is_some() {
+        return Some(alias.to_owned());
+    }
+    TemplateRegistry::known_spec(alias).map(|spec| spec.alias)
+}
+
+fn alias_from_reference(reference: &ImageReference) -> Result<String, ResolveError> {
+    let mut parts = Vec::new();
+    if reference.registry != DOCKER_HUB_REGISTRY {
+        parts.push(sanitize_segment(&reference.registry));
+    }
+    let repository = docker_hub_repository(&reference.registry, &reference.repository);
+    parts.push(sanitize_segment(&repository.replace('/', "-")));
+    parts.push(version_segment(&reference.version));
+
+    let alias = parts
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    let alias = collapse_dashes(&alias);
+    if alias.is_empty() || !is_valid_alias(&alias) {
+        return Err(ResolveError::AliasUnusable {
+            reference: display_reference(reference),
+        });
+    }
+    Ok(alias)
+}
+
+fn docker_hub_repository<'a>(registry: &str, repository: &'a str) -> &'a str {
+    if registry == DOCKER_HUB_REGISTRY {
+        repository
+            .strip_prefix(&format!("{DOCKER_HUB_LIBRARY}/"))
+            .unwrap_or(repository)
+    } else {
+        repository
+    }
+}
+
+fn version_segment(version: &ImageVersion) -> String {
+    match version {
+        ImageVersion::Tag(tag) => sanitize_segment(tag),
+        ImageVersion::Digest(digest) => {
+            let hex = digest.encoded();
+            let short = &hex[..DIGEST_ALIAS_HEX.min(hex.len())];
+            format!("sha256-{short}")
+        }
+    }
+}
+
+fn sanitize_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        let mapped = if byte.is_ascii_uppercase() {
+            (byte - b'A' + b'a') as char
+        } else if byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_')
+        {
+            byte as char
+        } else {
+            '-'
+        };
+        out.push(mapped);
+    }
+    collapse_dashes(&out)
+}
+
+fn collapse_dashes(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut previous_dash = false;
+    for ch in value.chars() {
+        if ch == '-' {
+            if !previous_dash && !out.is_empty() {
+                out.push('-');
+            }
+            previous_dash = true;
+        } else {
+            out.push(ch);
+            previous_dash = false;
+        }
+    }
+    if out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn is_valid_alias(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias
+            .split('-')
+            .all(|part| !part.is_empty() && is_valid_component(part))
+}
+
+fn display_reference(reference: &ImageReference) -> String {
+    match &reference.version {
+        ImageVersion::Tag(tag) => format!(
+            "{}/{repository}:{tag}",
+            reference.registry,
+            repository = reference.repository
+        ),
+        ImageVersion::Digest(digest) => format!(
+            "{}/{repository}@{digest}",
+            reference.registry,
+            repository = reference.repository
+        ),
+    }
+}

--- a/firecrab-api/src/oci/name_tests.rs
+++ b/firecrab-api/src/oci/name_tests.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+use crate::templates::{TemplateRegistry, TemplateSpec};
+
+fn parse(reference: &str) -> ImageReference {
+    ImageReference::parse(reference).expect(reference)
+}
+
+fn name_of(reference: &str) -> OciTemplateName {
+    name::template_name_from_reference(&parse(reference)).expect(reference)
+}
+
+#[test]
+fn a_docker_hub_official_tag_becomes_name_plus_tag() {
+    let named = name_of("nginx:1.27");
+    assert_eq!(named.alias, "nginx-1.27");
+    assert_eq!(named.version, "1.27");
+}
+
+#[test]
+fn a_bare_name_uses_the_implicit_latest_tag() {
+    let named = name_of("nginx");
+    assert_eq!(named.alias, "nginx-latest");
+    assert_eq!(named.version, "latest");
+}
+
+#[test]
+fn a_user_repository_replaces_slashes() {
+    let named = name_of("myuser/app:v2");
+    assert_eq!(named.alias, "myuser-app-v2");
+    assert_eq!(named.version, "v2");
+}
+
+#[test]
+fn docker_hub_library_is_not_part_of_the_alias() {
+    let named = name_of("docker.io/library/alpine:3.24");
+    assert_eq!(named.alias, "alpine-3.24");
+    assert_eq!(named.version, "3.24");
+}
+
+#[test]
+fn a_private_registry_stays_in_the_alias() {
+    let named = name_of("ghcr.io/owner/repo:1.0");
+    assert_eq!(named.alias, "ghcr.io-owner-repo-1.0");
+    assert_eq!(named.version, "1.0");
+}
+
+#[test]
+fn a_registry_port_does_not_break_the_alias() {
+    let named = name_of("localhost:5000/app:v1");
+    assert_eq!(named.alias, "localhost-5000-app-v1");
+    assert_eq!(named.version, "v1");
+}
+
+#[test]
+fn a_digest_pin_uses_a_short_hash_in_the_alias_and_the_full_digest_as_version() {
+    let digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let named = name_of(&format!("nginx@{digest}"));
+    assert_eq!(named.alias, "nginx-sha256-0123456789ab");
+    assert_eq!(named.version, digest);
+}
+
+#[test]
+fn an_unusable_reference_is_refused_instead_of_minting_an_empty_alias() {
+    let reference = ImageReference {
+        registry: DOCKER_HUB_REGISTRY.to_owned(),
+        repository: String::new(),
+        version: ImageVersion::Tag(String::new()),
+    };
+    let error = name::template_name_from_reference(&reference).expect_err("empty name");
+    assert!(matches!(error, ResolveError::AliasUnusable { .. }));
+}
+
+#[test]
+fn alias_letters_are_lowercased() {
+    let named = name_of("myuser/app:Release");
+    assert_eq!(named.alias, "myuser-app-release");
+    assert_eq!(named.version, "Release");
+}
+
+fn registry_with(alias: &str) -> (tempfile::TempDir, TemplateRegistry) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let root = directory.path();
+    std::fs::create_dir_all(root.join("kernel")).expect("create kernel dir");
+    std::fs::write(root.join("kernel/vmlinux"), b"kernel").expect("write kernel");
+    std::fs::write(root.join("rootfs.ext4"), b"rootfs").expect("write rootfs");
+    let registry = TemplateRegistry::from_specs(
+        root,
+        [TemplateSpec {
+            alias: alias.to_owned(),
+            version: "installed".to_owned(),
+            kernel: std::path::PathBuf::from("kernel/vmlinux"),
+            initrd: None,
+            rootfs: std::path::PathBuf::from("rootfs.ext4"),
+            boot_args: "console=ttyS0".to_owned(),
+        }],
+    )
+    .expect("register fixture alias");
+    (directory, registry)
+}
+
+fn empty_registry() -> (tempfile::TempDir, TemplateRegistry) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let registry = TemplateRegistry::from_specs(directory.path(), []).expect("empty registry");
+    (directory, registry)
+}
+
+#[test]
+fn claiming_rejects_an_alias_that_is_already_installed() {
+    let (_keep, templates) = registry_with("nginx-1.27");
+    let error =
+        name::claim_template_name(&parse("nginx:1.27"), &templates).expect_err("installed alias");
+    match error {
+        ResolveError::AliasCollision { alias, occupant } => {
+            assert_eq!(alias, "nginx-1.27");
+            assert_eq!(occupant, "nginx-1.27");
+        }
+        other => panic!("expected AliasCollision, got {other}"),
+    }
+    assert!(templates.resolve_alias("nginx-1.27").is_some());
+}
+
+#[test]
+fn claiming_rejects_a_catalog_alias_even_when_it_is_not_installed() {
+    let (_keep, templates) = empty_registry();
+    assert!(templates.resolve_alias("ubuntu-26.04").is_none());
+
+    let error =
+        name::claim_template_name(&parse("ubuntu:26.04"), &templates).expect_err("catalog alias");
+    match error {
+        ResolveError::AliasCollision { alias, occupant } => {
+            assert_eq!(alias, "ubuntu-26.04");
+            assert_eq!(occupant, "ubuntu-26.04");
+        }
+        other => panic!("expected AliasCollision, got {other}"),
+    }
+}
+
+#[test]
+fn claiming_accepts_a_free_alias_and_does_not_register_it() {
+    let (_keep, templates) = empty_registry();
+    let named = name::claim_template_name(&parse("nginx:1.27"), &templates).expect("free alias");
+    assert_eq!(named.alias, "nginx-1.27");
+    assert_eq!(named.version, "1.27");
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
+fn naming_a_bootable_image_records_the_alias_and_leaves_the_pair_in_place() {
+    let (_keep, templates) = empty_registry();
+    let image = OciBootableImage {
+        rootfs: OciExt4Image {
+            path: std::path::PathBuf::from("/tmp/oci.ext4"),
+            size_bytes: 8 * 1024 * 1024,
+            payload_bytes: 64,
+            free_bytes: 1024 * 1024,
+            toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+        },
+        kernel: std::path::PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64"),
+        initrd: None,
+        boot_args: "console=ttyS0".to_owned(),
+        architecture: Architecture::HOST,
+    };
+
+    let named = name_oci_image(image, &parse("nginx:1.27"), &templates).expect("name image");
+
+    assert_eq!(named.alias(), "nginx-1.27");
+    assert_eq!(named.version(), "1.27");
+    assert_eq!(
+        named.image().kernel().as_os_str(),
+        "kernel/vmlinux-ubuntu-26.04-x86_64"
+    );
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,8 +2,8 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-The internal pipeline can size a provisioned tree into an ext4 image and pair
-it with an architecture-matched kernel.
+The internal pipeline can size a provisioned tree into an ext4 image, pair
+it with an architecture-matched kernel, and derive an alias from the reference.
 Registering a template is still separate work.
 
 ## Inspect
@@ -152,16 +152,16 @@ This stage still pairs no kernel and registers nothing.
 ## Kernel pairing
 
 `TemplateSpec` needs a kernel and boot args; an OCI image carries neither.
-The packed ext4 is paired with this host's catalog kernel that has the
-Firecracker boot path built in and needs no initrd — currently Ubuntu.
-Alpine and Rocky keep those drivers as modules; their initrd would take
-PID 1 from the injected guest init. The kernel must already be installed.
-Its header is classified the same way registration classifies any kernel.
-A foreign architecture, an unbootable ELF, an unclassifiable file, or a
-symbolic link at the catalog path is refused.
-Boot args are that artifact's own command line.
-The ext4 is left in place; this stage still registers nothing.
-Each import stage stops where the next begins: inspect fills no cache, and pairing registers nothing.
+The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
+A foreign architecture, an unbootable ELF, or a symbolic link is refused.
+
+## Name
+
+The alias is the repository and tag, with Docker Hub's `library/` dropped
+and slashes or ports turned into dashes — `nginx:1.27` becomes `nginx-1.27`.
+A digest pin keeps twelve hex characters in the alias and the full digest as the version.
+An alias that matches an installed image or a catalog name is refused.
+This stage still registers nothing.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Derive a `TemplateSpec` alias and version from the OCI reference: `nginx:1.27` becomes alias `nginx-1.27` and version `1.27`.
- Drop Docker Hub's `library/` prefix. Turn repository slashes and registry ports into dashes. Keep a private registry host in the alias.
- A digest pin keeps twelve hex characters in the alias and the full digest as the version.
- Refuse an alias that is already installed or reserved by the catalog (`ubuntu-26.04`, `alpine-3.24.1`, `rocky-9.8`). `register_spec` would otherwise overwrite it.
- Leave the paired image in place. This stage does not register a template.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p firecrab-api` (492 passed)
- `cargo llvm-cov -p firecrab-api --locked` patch coverage 130/132 (98.5%), target 80%
- `python3 scripts/check-doc-links.py`

Stacked on #103. Related to #90.