### PR TITLE
Feat/oci register 90

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -881,6 +881,20 @@ pub enum ResolveError {
         #[source]
         source: io::Error,
     },
+    /// The derived alias is already an installed or catalog image.
+    #[error("OCI import alias {alias} collides with installed image {occupant}")]
+    AliasCollision {
+        /// Alias derived from the reference.
+        alias: String,
+        /// Alias already claimed by the registry or catalog.
+        occupant: String,
+    },
+    /// The reference cannot be turned into a safe template alias.
+    #[error("OCI reference {reference} cannot be turned into a template alias")]
+    AliasUnusable {
+        /// Original reference text, for the operator.
+        reference: String,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1886,6 +1900,11 @@ mod boot;
 #[cfg(test)]
 mod boot_tests;
 
+mod name;
+
+#[cfg(test)]
+mod name_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2406,6 +2425,44 @@ impl OciBootableImage {
     }
 }
 
+/// Alias and version later registration can copy into a [`crate::templates::TemplateSpec`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciTemplateName {
+    /// User-facing alias derived from the reference.
+    pub alias: String,
+    /// Version tag or digest pin from the reference.
+    pub version: String,
+}
+
+/// A bootable OCI image that has a unique alias and version.
+///
+/// Deliberately distinct from [`OciBootableImage`] so registration can require
+/// proof that the name was derived and does not collide with an installed
+/// image.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamedOciImage {
+    image: OciBootableImage,
+    alias: String,
+    version: String,
+}
+
+impl NamedOciImage {
+    /// Kernel, boot args, and packed ext4 this name will register.
+    pub fn image(&self) -> &OciBootableImage {
+        &self.image
+    }
+
+    /// Unique alias derived from the image reference.
+    pub fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    /// Version derived from the image reference's tag or digest.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2790,6 +2847,19 @@ pub fn pair_ext4_with_host_kernel(
     image_root: &Path,
 ) -> Result<OciBootableImage, ResolveError> {
     boot::pair_ext4_with_host_kernel(image, image_root)
+}
+
+/// Derives a unique alias and version from the reference and attaches them
+/// to a paired image.
+///
+/// An installed alias or a catalog alias is a collision and is refused.
+/// This stage does not register a template.
+pub fn name_oci_image(
+    image: OciBootableImage,
+    reference: &ImageReference,
+    templates: &crate::templates::TemplateRegistry,
+) -> Result<NamedOciImage, ResolveError> {
+    name::name_oci_image(image, reference, templates)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -827,6 +827,60 @@ pub enum ResolveError {
         /// Destination that was left unpublished.
         path: PathBuf,
     },
+    /// The compiled-in catalog has no kernel that can boot a module-less
+    /// OCI rootfs on this architecture.
+    #[error("no architecture-matched kernel without an initrd is published for {architecture}")]
+    NoHostKernel {
+        /// Architecture a later TemplateSpec would have to boot.
+        architecture: Architecture,
+    },
+    /// The catalog kernel for this host is not installed under the image root.
+    #[error("no architecture-matched kernel at {path}; install {hint} for {architecture}")]
+    KernelMissing {
+        /// Catalog-relative kernel path that was required.
+        path: PathBuf,
+        /// Template alias that publishes that kernel.
+        hint: String,
+        /// Architecture the missing kernel must match.
+        architecture: Architecture,
+    },
+    /// The catalog kernel exists but is built for another architecture.
+    #[error("kernel {path} is built for {found}, but this host is {host}")]
+    KernelArchitectureMismatch {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+        /// Architecture the kernel header declares.
+        found: Architecture,
+        /// Architecture this build of the API runs on.
+        host: Architecture,
+    },
+    /// The catalog kernel is a well-formed ELF Firecracker cannot boot.
+    #[error(
+        "kernel {path} targets an architecture firecrab does not support (ELF machine {machine:#06x})"
+    )]
+    UnsupportedKernelArchitecture {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+        /// ELF `e_machine` value that identified it.
+        machine: u16,
+    },
+    /// The file at the catalog kernel path is not a classifiable kernel.
+    #[error("kernel {path} is not a classifiable Firecracker kernel")]
+    KernelUnrecognized {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+    },
+    /// A filesystem operation failed while inspecting the paired kernel.
+    #[error("OCI kernel pairing {operation} failed at {path}: {source}")]
+    KernelIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Kernel path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1827,6 +1881,11 @@ mod ext4;
 #[cfg(test)]
 mod ext4_tests;
 
+mod boot;
+
+#[cfg(test)]
+mod boot_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2303,6 +2362,50 @@ impl OciExt4Image {
     }
 }
 
+/// An ext4 image paired with the kernel and boot args a TemplateSpec needs.
+///
+/// Deliberately distinct from [`OciExt4Image`] so registration can require
+/// proof that an architecture-matched kernel was chosen. An OCI image
+/// supplies neither field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciBootableImage {
+    rootfs: OciExt4Image,
+    kernel: PathBuf,
+    initrd: Option<PathBuf>,
+    boot_args: String,
+    architecture: Architecture,
+}
+
+impl OciBootableImage {
+    /// Packed ext4 this pair will boot.
+    pub fn rootfs(&self) -> &OciExt4Image {
+        &self.rootfs
+    }
+
+    /// Kernel path relative to the image root.
+    pub fn kernel(&self) -> &Path {
+        &self.kernel
+    }
+
+    /// Initrd path relative to the image root, if the paired kernel needs one.
+    ///
+    /// The current catalog pair does not: a module-less OCI tree cannot use
+    /// a distro initrd without losing the injected guest init.
+    pub fn initrd(&self) -> Option<&Path> {
+        self.initrd.as_deref()
+    }
+
+    /// Firecracker kernel command line recorded from the paired kernel.
+    pub fn boot_args(&self) -> &str {
+        &self.boot_args
+    }
+
+    /// Architecture the paired kernel was classified as.
+    pub fn architecture(&self) -> Architecture {
+        self.architecture
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2673,6 +2776,20 @@ pub async fn write_provisioned_ext4(
     destination: &Path,
 ) -> Result<OciExt4Image, ResolveError> {
     ext4::write_provisioned_ext4(rootfs, destination).await
+}
+
+/// Pairs a packed ext4 with this host's architecture-matched kernel and
+/// boot args.
+///
+/// `TemplateSpec` requires both; an OCI image supplies neither. The kernel
+/// is the catalog artifact for this architecture that needs no initrd —
+/// currently Ubuntu — and must already be installed under `image_root`.
+/// The ext4 is left in place. This stage does not register a template.
+pub fn pair_ext4_with_host_kernel(
+    image: OciExt4Image,
+    image_root: &Path,
+) -> Result<OciBootableImage, ResolveError> {
+    boot::pair_ext4_with_host_kernel(image, image_root)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -920,6 +920,23 @@ pub enum ResolveError {
         /// Registry diagnostic.
         detail: String,
     },
+    /// An image Env entry was not `KEY=value`.
+    #[error("OCI image Env entry {entry:?} is not KEY=value")]
+    ServiceEnvInvalid {
+        /// The rejected environment entry.
+        entry: String,
+    },
+    /// A filesystem operation failed while writing the image service.
+    #[error("OCI service {operation} failed at {path}: {source}")]
+    ServiceIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Guest or host path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1935,6 +1952,11 @@ mod register;
 #[cfg(test)]
 mod register_tests;
 
+mod service;
+
+#[cfg(test)]
+mod service_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2518,6 +2540,53 @@ impl RegisteredOciImage {
     }
 }
 
+/// Process fields from an OCI image configuration.
+///
+/// These become a service under the injected init, never PID 1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciProcessConfig {
+    entrypoint: Vec<String>,
+    cmd: Vec<String>,
+    env: Vec<String>,
+    working_dir: String,
+}
+
+impl OciProcessConfig {
+    /// Reads Entrypoint, Cmd, Env, and WorkingDir from an image config blob.
+    pub fn from_image_config(bytes: &[u8]) -> Result<Self, ResolveError> {
+        service::process_config_from_image_config(bytes)
+    }
+
+    /// Config `Entrypoint`.
+    pub fn entrypoint(&self) -> &[String] {
+        &self.entrypoint
+    }
+
+    /// Config `Cmd`.
+    pub fn cmd(&self) -> &[String] {
+        &self.cmd
+    }
+
+    /// Config `Env` entries, each `KEY=value`.
+    pub fn env(&self) -> &[String] {
+        &self.env
+    }
+
+    /// Config `WorkingDir`, empty when the image did not set one.
+    pub fn working_dir(&self) -> &str {
+        &self.working_dir
+    }
+
+    /// The argv the service will exec: Entrypoint followed by Cmd.
+    pub fn argv(&self) -> Vec<&str> {
+        self.entrypoint
+            .iter()
+            .chain(self.cmd.iter())
+            .map(String::as_str)
+            .collect()
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2926,6 +2995,18 @@ pub fn register_named_oci_image(
     templates: &crate::templates::TemplateRegistry,
 ) -> Result<RegisteredOciImage, ResolveError> {
     register::register_named_oci_image(named, templates)
+}
+
+/// Translates the image process config into a service under the injected init.
+///
+/// The script lands in `/etc/firecrab/services.d` and is started after the
+/// readiness sentinel. It is never PID 1. An image with no command is a
+/// no-op.
+pub fn install_oci_service(
+    rootfs: &ProvisionedRootfs,
+    process: &OciProcessConfig,
+) -> Result<(), ResolveError> {
+    service::install_oci_service(rootfs, process)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -895,6 +895,31 @@ pub enum ResolveError {
         /// Original reference text, for the operator.
         reference: String,
     },
+    /// The published rootfs path already exists and must not be replaced.
+    #[error("OCI rootfs destination already exists at {path}")]
+    RegisterDestinationExists {
+        /// Intended published rootfs path.
+        path: PathBuf,
+    },
+    /// A filesystem operation failed while publishing the rootfs.
+    #[error("OCI registration {operation} failed at {path}: {source}")]
+    RegisterIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
+    /// Publishing succeeded but the template registry refused the spec.
+    #[error("OCI image {alias} could not be registered: {detail}")]
+    RegisterFailed {
+        /// Alias that was not registered.
+        alias: String,
+        /// Registry diagnostic.
+        detail: String,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1905,6 +1930,11 @@ mod name;
 #[cfg(test)]
 mod name_tests;
 
+mod register;
+
+#[cfg(test)]
+mod register_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2463,6 +2493,31 @@ impl NamedOciImage {
     }
 }
 
+/// A named OCI image that has been published and registered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegisteredOciImage {
+    alias: String,
+    version: String,
+    rootfs: PathBuf,
+}
+
+impl RegisteredOciImage {
+    /// Registered alias.
+    pub fn alias(&self) -> &str {
+        &self.alias
+    }
+
+    /// Registered version.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Rootfs path relative to the image root.
+    pub fn rootfs(&self) -> &Path {
+        &self.rootfs
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2860,6 +2915,17 @@ pub fn name_oci_image(
     templates: &crate::templates::TemplateRegistry,
 ) -> Result<NamedOciImage, ResolveError> {
     name::name_oci_image(image, reference, templates)
+}
+
+/// Publishes the packed ext4 under the image root and registers it.
+///
+/// A failed publish or registration removes the partial rootfs and leaves
+/// the source ext4 in place. The shared kernel is not copied.
+pub fn register_named_oci_image(
+    named: NamedOciImage,
+    templates: &crate::templates::TemplateRegistry,
+) -> Result<RegisteredOciImage, ResolveError> {
+    register::register_named_oci_image(named, templates)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci/boot.rs
+++ b/firecrab-api/src/oci/boot.rs
@@ -1,0 +1,121 @@
+//! Pairs a packed OCI ext4 with the kernel and boot args TemplateSpec needs.
+//!
+//! An OCI image carries neither. A container tree also has no `/lib/modules`,
+//! so the kernel must have the Firecracker boot path built in — `virtio_blk`,
+//! `virtio_net`, `virtio_mmio`, and `ext4`. Distro kernels that keep those as
+//! modules need their matching initrd, and that initrd would take PID 1 away
+//! from the injected guest init. The compiled-in catalog's first host
+//! artifact without an initrd is the Ubuntu kernel; this stage records that
+//! pair and does not register a template.
+
+use std::io::Read as _;
+use std::os::unix::fs::OpenOptionsExt as _;
+
+use super::*;
+
+use crate::m2image_manifest;
+use crate::templates::{KernelFormat, kernel_architecture};
+
+/// Kernel, optional initrd, and command line later registration can copy
+/// into a [`crate::templates::TemplateSpec`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct KernelBootPair {
+    pub architecture: Architecture,
+    pub source_alias: String,
+    pub kernel: PathBuf,
+    pub initrd: Option<PathBuf>,
+    pub boot_args: String,
+}
+
+/// The architecture-matched pair this host will boot imported images with.
+pub(super) fn host_kernel_pair() -> Result<KernelBootPair, ResolveError> {
+    kernel_pair_for(Architecture::HOST)
+}
+
+/// First catalog artifact for `architecture` that needs no initrd.
+pub(super) fn kernel_pair_for(architecture: Architecture) -> Result<KernelBootPair, ResolveError> {
+    m2image_manifest::load()
+        .images
+        .into_iter()
+        .find_map(|image| {
+            let artifact = image.artifacts.get(architecture.as_str())?;
+            if artifact.initrd.is_some() {
+                return None;
+            }
+            Some(KernelBootPair {
+                architecture,
+                source_alias: image.alias,
+                kernel: PathBuf::from(&artifact.kernel),
+                initrd: None,
+                boot_args: artifact.boot_args.clone(),
+            })
+        })
+        .ok_or(ResolveError::NoHostKernel { architecture })
+}
+
+/// Records the host catalog kernel and its boot args on a packed ext4.
+///
+/// The kernel file must already exist under `image_root`. Its header is
+/// classified with the same rules registration uses. A mismatch is refused
+/// here so a later TemplateSpec is never pointed at a silent-hang kernel.
+/// The ext4 is not moved or deleted, and nothing is registered.
+pub(super) fn pair_ext4_with_host_kernel(
+    image: OciExt4Image,
+    image_root: &Path,
+) -> Result<OciBootableImage, ResolveError> {
+    let pair = host_kernel_pair()?;
+    let kernel_path = image_root.join(&pair.kernel);
+    let header = read_kernel_header(&kernel_path, &pair)?;
+    match kernel_architecture(&header) {
+        KernelFormat::Bootable(found) if found == pair.architecture => Ok(OciBootableImage {
+            rootfs: image,
+            kernel: pair.kernel,
+            initrd: pair.initrd,
+            boot_args: pair.boot_args,
+            architecture: found,
+        }),
+        KernelFormat::Bootable(found) => Err(ResolveError::KernelArchitectureMismatch {
+            path: pair.kernel,
+            found,
+            host: pair.architecture,
+        }),
+        KernelFormat::Foreign { machine } => Err(ResolveError::UnsupportedKernelArchitecture {
+            path: pair.kernel,
+            machine,
+        }),
+        KernelFormat::Unrecognized => Err(ResolveError::KernelUnrecognized { path: pair.kernel }),
+    }
+}
+
+fn read_kernel_header(path: &Path, pair: &KernelBootPair) -> Result<Vec<u8>, ResolveError> {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            return Err(ResolveError::KernelMissing {
+                path: pair.kernel.clone(),
+                hint: pair.source_alias.clone(),
+                architecture: pair.architecture,
+            });
+        }
+        Err(source) => {
+            return Err(ResolveError::KernelIo {
+                operation: "open kernel",
+                path: pair.kernel.clone(),
+                source,
+            });
+        }
+    };
+    let mut header = Vec::new();
+    file.take(64)
+        .read_to_end(&mut header)
+        .map_err(|source| ResolveError::KernelIo {
+            operation: "read kernel header",
+            path: pair.kernel.clone(),
+            source,
+        })?;
+    Ok(header)
+}

--- a/firecrab-api/src/oci/boot_tests.rs
+++ b/firecrab-api/src/oci/boot_tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+use crate::m2image_manifest;
+
+fn ubuntu_artifact(architecture: Architecture) -> crate::m2image_manifest::ReleaseArtifact {
+    m2image_manifest::image("ubuntu-26.04")
+        .expect("ubuntu is a release image")
+        .artifacts
+        .remove(architecture.as_str())
+        .expect("ubuntu publishes this architecture")
+}
+
+#[test]
+fn kernel_pair_for_x86_64_is_the_ubuntu_vmlinux_without_an_initrd() {
+    let pair = boot::kernel_pair_for(Architecture::X86_64).expect("ubuntu publishes x86_64");
+    let ubuntu = ubuntu_artifact(Architecture::X86_64);
+
+    assert_eq!(pair.architecture, Architecture::X86_64);
+    assert_eq!(pair.source_alias, "ubuntu-26.04");
+    assert_eq!(
+        pair.kernel.as_os_str(),
+        "kernel/vmlinux-ubuntu-26.04-x86_64"
+    );
+    assert_eq!(pair.initrd, None);
+    assert_eq!(pair.boot_args, ubuntu.boot_args);
+    assert!(!pair.boot_args.contains("keep_bootcon"));
+    assert!(pair.boot_args.contains("console=ttyS0"));
+    assert!(pair.boot_args.contains("root=/dev/vda"));
+}
+
+#[test]
+fn kernel_pair_for_aarch64_is_the_ubuntu_image_without_an_initrd() {
+    let pair = boot::kernel_pair_for(Architecture::Aarch64).expect("ubuntu publishes aarch64");
+    let ubuntu = ubuntu_artifact(Architecture::Aarch64);
+
+    assert_eq!(pair.architecture, Architecture::Aarch64);
+    assert_eq!(pair.source_alias, "ubuntu-26.04");
+    assert_eq!(pair.kernel.as_os_str(), "kernel/Image-ubuntu-26.04-aarch64");
+    assert_eq!(pair.initrd, None);
+    assert_eq!(pair.boot_args, ubuntu.boot_args);
+    assert!(pair.boot_args.contains("keep_bootcon"));
+    assert!(pair.boot_args.contains("console=ttyS0"));
+    assert!(pair.boot_args.contains("root=/dev/vda"));
+}
+
+#[test]
+fn host_kernel_pair_is_the_pair_for_this_build() {
+    let host = boot::host_kernel_pair().expect("a no-initrd host kernel exists");
+    let expected = boot::kernel_pair_for(Architecture::HOST).expect("host pair exists");
+    assert_eq!(host, expected);
+}
+
+fn elf_kernel(machine: u16) -> Vec<u8> {
+    let mut header = vec![0_u8; 64];
+    header[0..4].copy_from_slice(b"\x7fELF");
+    header[4] = 2;
+    header[5] = 1;
+    header[6] = 1;
+    header[16..18].copy_from_slice(&2_u16.to_le_bytes());
+    header[18..20].copy_from_slice(&machine.to_le_bytes());
+    header
+}
+
+fn arm64_image_kernel() -> Vec<u8> {
+    let mut header = vec![0_u8; 64];
+    header[0..2].copy_from_slice(b"MZ");
+    header[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+    header
+}
+
+fn kernel_bytes_for(architecture: Architecture) -> Vec<u8> {
+    match architecture {
+        Architecture::Aarch64 => arm64_image_kernel(),
+        Architecture::X86_64 => elf_kernel(0x3e),
+    }
+}
+
+fn write_file(path: &std::path::Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    std::fs::write(path, bytes).expect("write fixture file");
+}
+
+fn packed_ext4(path: std::path::PathBuf) -> OciExt4Image {
+    write_file(&path, b"ext4-fixture");
+    OciExt4Image {
+        path,
+        size_bytes: 8 * 1024 * 1024,
+        payload_bytes: 64,
+        free_bytes: 1024 * 1024,
+        toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+    }
+}
+
+fn install_kernel(image_root: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let path = image_root.join(&pair.kernel);
+    write_file(&path, bytes);
+    pair.kernel
+}
+
+#[test]
+fn pairing_records_the_host_kernel_and_its_boot_args() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let expected_kernel = install_kernel(image_root, &kernel_bytes_for(Architecture::HOST));
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path.clone());
+    let expected = boot::host_kernel_pair().expect("host kernel pair");
+
+    let paired = pair_ext4_with_host_kernel(image, image_root).expect("pair kernel");
+
+    assert_eq!(paired.architecture(), Architecture::HOST);
+    assert_eq!(paired.kernel(), expected_kernel.as_path());
+    assert_eq!(paired.initrd(), None);
+    assert_eq!(paired.boot_args(), expected.boot_args);
+    assert_eq!(paired.rootfs().path(), ext4_path.as_path());
+    assert_eq!(
+        std::fs::read(&ext4_path).expect("ext4 remains"),
+        b"ext4-fixture"
+    );
+    assert!(!image_root.join(".templates.json").exists());
+}
+
+#[test]
+fn pairing_rejects_a_missing_host_kernel() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path.clone());
+    let expected = boot::host_kernel_pair().expect("host kernel pair");
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("missing kernel");
+
+    match error {
+        ResolveError::KernelMissing {
+            path,
+            hint,
+            architecture,
+        } => {
+            assert_eq!(path, expected.kernel);
+            assert_eq!(hint, expected.source_alias);
+            assert_eq!(architecture, Architecture::HOST);
+        }
+        other => panic!("expected KernelMissing, got {other}"),
+    }
+    assert_eq!(
+        std::fs::read(&ext4_path).expect("ext4 remains"),
+        b"ext4-fixture"
+    );
+}
+
+#[test]
+fn pairing_rejects_a_kernel_built_for_another_architecture() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, &kernel_bytes_for(Architecture::HOST.other()));
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path);
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("foreign arch");
+
+    match error {
+        ResolveError::KernelArchitectureMismatch { found, host, .. } => {
+            assert_eq!(found, Architecture::HOST.other());
+            assert_eq!(host, Architecture::HOST);
+        }
+        other => panic!("expected KernelArchitectureMismatch, got {other}"),
+    }
+}
+
+#[test]
+fn pairing_rejects_an_elf_firecracker_cannot_boot() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, &elf_kernel(0xf3));
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("riscv");
+
+    match error {
+        ResolveError::UnsupportedKernelArchitecture { machine, .. } => {
+            assert_eq!(machine, 0xf3);
+        }
+        other => panic!("expected UnsupportedKernelArchitecture, got {other}"),
+    }
+}
+
+#[test]
+fn pairing_does_not_follow_a_kernel_symlink() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let target = directory.path().join("elsewhere");
+    write_file(&target, &kernel_bytes_for(Architecture::HOST));
+    let kernel_path = image_root.join(&pair.kernel);
+    std::fs::create_dir_all(kernel_path.parent().unwrap()).expect("create kernel parent");
+    std::os::unix::fs::symlink(&target, &kernel_path).expect("symlink kernel");
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("symlink");
+
+    assert!(
+        matches!(error, ResolveError::KernelIo { .. }),
+        "expected KernelIo for a kernel path that is a symlink, got {error}"
+    );
+}
+
+#[test]
+fn pairing_rejects_an_unclassifiable_kernel() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, b"not-a-kernel");
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("garbage");
+
+    match error {
+        ResolveError::KernelUnrecognized { path } => {
+            assert_eq!(path, boot::host_kernel_pair().expect("host pair").kernel);
+        }
+        other => panic!("expected KernelUnrecognized, got {other}"),
+    }
+}
+
+#[test]
+fn kernel_pair_skips_kernels_that_need_an_initrd() {
+    for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+        let pair = boot::kernel_pair_for(architecture).expect("a no-initrd kernel exists");
+        for alias in ["alpine-3.24.1", "rocky-9.8"] {
+            let artifact = m2image_manifest::image(alias)
+                .expect("release image")
+                .artifacts
+                .remove(architecture.as_str())
+                .expect("release image publishes this architecture");
+            assert!(
+                artifact.initrd.is_some(),
+                "{alias}/{architecture} must remain an initrd kernel so this test stays meaningful"
+            );
+            assert_ne!(pair.kernel, std::path::PathBuf::from(artifact.kernel));
+            assert_ne!(pair.source_alias, alias);
+        }
+    }
+}

--- a/firecrab-api/src/oci/name.rs
+++ b/firecrab-api/src/oci/name.rs
@@ -1,0 +1,163 @@
+//! Derives a unique template alias and version from an OCI reference.
+//!
+//! `TemplateSpec` needs both. A reference already has a repository and a tag
+//! or digest, so this stage turns those into the same shape built-in images
+//! use and refuses a name that would overwrite an installed or catalog image.
+//! It does not register anything.
+
+use super::*;
+
+use crate::templates::TemplateRegistry;
+
+/// Hex characters of a digest kept in a derived alias.
+const DIGEST_ALIAS_HEX: usize = 12;
+
+/// Builds the candidate alias and version without consulting the registry.
+pub(super) fn template_name_from_reference(
+    reference: &ImageReference,
+) -> Result<OciTemplateName, ResolveError> {
+    let alias = alias_from_reference(reference)?;
+    let version = match &reference.version {
+        ImageVersion::Tag(tag) => tag.clone(),
+        ImageVersion::Digest(digest) => digest.as_str().to_owned(),
+    };
+    Ok(OciTemplateName { alias, version })
+}
+
+/// Derives the name and refuses it when an installed or reserved alias exists.
+pub(super) fn claim_template_name(
+    reference: &ImageReference,
+    templates: &TemplateRegistry,
+) -> Result<OciTemplateName, ResolveError> {
+    let named = template_name_from_reference(reference)?;
+    if let Some(occupant) = occupied_by(&named.alias, templates) {
+        return Err(ResolveError::AliasCollision {
+            alias: named.alias,
+            occupant,
+        });
+    }
+    Ok(named)
+}
+
+/// Attaches a claimed name to a paired image. The pair is left unchanged.
+pub(super) fn name_oci_image(
+    image: OciBootableImage,
+    reference: &ImageReference,
+    templates: &TemplateRegistry,
+) -> Result<NamedOciImage, ResolveError> {
+    let named = claim_template_name(reference, templates)?;
+    Ok(NamedOciImage {
+        image,
+        alias: named.alias,
+        version: named.version,
+    })
+}
+
+fn occupied_by(alias: &str, templates: &TemplateRegistry) -> Option<String> {
+    if templates.resolve_alias(alias).is_some() {
+        return Some(alias.to_owned());
+    }
+    TemplateRegistry::known_spec(alias).map(|spec| spec.alias)
+}
+
+fn alias_from_reference(reference: &ImageReference) -> Result<String, ResolveError> {
+    let mut parts = Vec::new();
+    if reference.registry != DOCKER_HUB_REGISTRY {
+        parts.push(sanitize_segment(&reference.registry));
+    }
+    let repository = docker_hub_repository(&reference.registry, &reference.repository);
+    parts.push(sanitize_segment(&repository.replace('/', "-")));
+    parts.push(version_segment(&reference.version));
+
+    let alias = parts
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    let alias = collapse_dashes(&alias);
+    if alias.is_empty() || !is_valid_alias(&alias) {
+        return Err(ResolveError::AliasUnusable {
+            reference: display_reference(reference),
+        });
+    }
+    Ok(alias)
+}
+
+fn docker_hub_repository<'a>(registry: &str, repository: &'a str) -> &'a str {
+    if registry == DOCKER_HUB_REGISTRY {
+        repository
+            .strip_prefix(&format!("{DOCKER_HUB_LIBRARY}/"))
+            .unwrap_or(repository)
+    } else {
+        repository
+    }
+}
+
+fn version_segment(version: &ImageVersion) -> String {
+    match version {
+        ImageVersion::Tag(tag) => sanitize_segment(tag),
+        ImageVersion::Digest(digest) => {
+            let hex = digest.encoded();
+            let short = &hex[..DIGEST_ALIAS_HEX.min(hex.len())];
+            format!("sha256-{short}")
+        }
+    }
+}
+
+fn sanitize_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        let mapped = if byte.is_ascii_uppercase() {
+            (byte - b'A' + b'a') as char
+        } else if byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_')
+        {
+            byte as char
+        } else {
+            '-'
+        };
+        out.push(mapped);
+    }
+    collapse_dashes(&out)
+}
+
+fn collapse_dashes(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut previous_dash = false;
+    for ch in value.chars() {
+        if ch == '-' {
+            if !previous_dash && !out.is_empty() {
+                out.push('-');
+            }
+            previous_dash = true;
+        } else {
+            out.push(ch);
+            previous_dash = false;
+        }
+    }
+    if out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+fn is_valid_alias(alias: &str) -> bool {
+    !alias.is_empty()
+        && alias
+            .split('-')
+            .all(|part| !part.is_empty() && is_valid_component(part))
+}
+
+fn display_reference(reference: &ImageReference) -> String {
+    match &reference.version {
+        ImageVersion::Tag(tag) => format!(
+            "{}/{repository}:{tag}",
+            reference.registry,
+            repository = reference.repository
+        ),
+        ImageVersion::Digest(digest) => format!(
+            "{}/{repository}@{digest}",
+            reference.registry,
+            repository = reference.repository
+        ),
+    }
+}

--- a/firecrab-api/src/oci/name_tests.rs
+++ b/firecrab-api/src/oci/name_tests.rs
@@ -1,0 +1,174 @@
+use super::*;
+
+use crate::templates::{TemplateRegistry, TemplateSpec};
+
+fn parse(reference: &str) -> ImageReference {
+    ImageReference::parse(reference).expect(reference)
+}
+
+fn name_of(reference: &str) -> OciTemplateName {
+    name::template_name_from_reference(&parse(reference)).expect(reference)
+}
+
+#[test]
+fn a_docker_hub_official_tag_becomes_name_plus_tag() {
+    let named = name_of("nginx:1.27");
+    assert_eq!(named.alias, "nginx-1.27");
+    assert_eq!(named.version, "1.27");
+}
+
+#[test]
+fn a_bare_name_uses_the_implicit_latest_tag() {
+    let named = name_of("nginx");
+    assert_eq!(named.alias, "nginx-latest");
+    assert_eq!(named.version, "latest");
+}
+
+#[test]
+fn a_user_repository_replaces_slashes() {
+    let named = name_of("myuser/app:v2");
+    assert_eq!(named.alias, "myuser-app-v2");
+    assert_eq!(named.version, "v2");
+}
+
+#[test]
+fn docker_hub_library_is_not_part_of_the_alias() {
+    let named = name_of("docker.io/library/alpine:3.24");
+    assert_eq!(named.alias, "alpine-3.24");
+    assert_eq!(named.version, "3.24");
+}
+
+#[test]
+fn a_private_registry_stays_in_the_alias() {
+    let named = name_of("ghcr.io/owner/repo:1.0");
+    assert_eq!(named.alias, "ghcr.io-owner-repo-1.0");
+    assert_eq!(named.version, "1.0");
+}
+
+#[test]
+fn a_registry_port_does_not_break_the_alias() {
+    let named = name_of("localhost:5000/app:v1");
+    assert_eq!(named.alias, "localhost-5000-app-v1");
+    assert_eq!(named.version, "v1");
+}
+
+#[test]
+fn a_digest_pin_uses_a_short_hash_in_the_alias_and_the_full_digest_as_version() {
+    let digest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let named = name_of(&format!("nginx@{digest}"));
+    assert_eq!(named.alias, "nginx-sha256-0123456789ab");
+    assert_eq!(named.version, digest);
+}
+
+#[test]
+fn an_unusable_reference_is_refused_instead_of_minting_an_empty_alias() {
+    let reference = ImageReference {
+        registry: DOCKER_HUB_REGISTRY.to_owned(),
+        repository: String::new(),
+        version: ImageVersion::Tag(String::new()),
+    };
+    let error = name::template_name_from_reference(&reference).expect_err("empty name");
+    assert!(matches!(error, ResolveError::AliasUnusable { .. }));
+}
+
+#[test]
+fn alias_letters_are_lowercased() {
+    let named = name_of("myuser/app:Release");
+    assert_eq!(named.alias, "myuser-app-release");
+    assert_eq!(named.version, "Release");
+}
+
+fn registry_with(alias: &str) -> (tempfile::TempDir, TemplateRegistry) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let root = directory.path();
+    std::fs::create_dir_all(root.join("kernel")).expect("create kernel dir");
+    std::fs::write(root.join("kernel/vmlinux"), b"kernel").expect("write kernel");
+    std::fs::write(root.join("rootfs.ext4"), b"rootfs").expect("write rootfs");
+    let registry = TemplateRegistry::from_specs(
+        root,
+        [TemplateSpec {
+            alias: alias.to_owned(),
+            version: "installed".to_owned(),
+            kernel: std::path::PathBuf::from("kernel/vmlinux"),
+            initrd: None,
+            rootfs: std::path::PathBuf::from("rootfs.ext4"),
+            boot_args: "console=ttyS0".to_owned(),
+        }],
+    )
+    .expect("register fixture alias");
+    (directory, registry)
+}
+
+fn empty_registry() -> (tempfile::TempDir, TemplateRegistry) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let registry = TemplateRegistry::from_specs(directory.path(), []).expect("empty registry");
+    (directory, registry)
+}
+
+#[test]
+fn claiming_rejects_an_alias_that_is_already_installed() {
+    let (_keep, templates) = registry_with("nginx-1.27");
+    let error =
+        name::claim_template_name(&parse("nginx:1.27"), &templates).expect_err("installed alias");
+    match error {
+        ResolveError::AliasCollision { alias, occupant } => {
+            assert_eq!(alias, "nginx-1.27");
+            assert_eq!(occupant, "nginx-1.27");
+        }
+        other => panic!("expected AliasCollision, got {other}"),
+    }
+    assert!(templates.resolve_alias("nginx-1.27").is_some());
+}
+
+#[test]
+fn claiming_rejects_a_catalog_alias_even_when_it_is_not_installed() {
+    let (_keep, templates) = empty_registry();
+    assert!(templates.resolve_alias("ubuntu-26.04").is_none());
+
+    let error =
+        name::claim_template_name(&parse("ubuntu:26.04"), &templates).expect_err("catalog alias");
+    match error {
+        ResolveError::AliasCollision { alias, occupant } => {
+            assert_eq!(alias, "ubuntu-26.04");
+            assert_eq!(occupant, "ubuntu-26.04");
+        }
+        other => panic!("expected AliasCollision, got {other}"),
+    }
+}
+
+#[test]
+fn claiming_accepts_a_free_alias_and_does_not_register_it() {
+    let (_keep, templates) = empty_registry();
+    let named = name::claim_template_name(&parse("nginx:1.27"), &templates).expect("free alias");
+    assert_eq!(named.alias, "nginx-1.27");
+    assert_eq!(named.version, "1.27");
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
+fn naming_a_bootable_image_records_the_alias_and_leaves_the_pair_in_place() {
+    let (_keep, templates) = empty_registry();
+    let image = OciBootableImage {
+        rootfs: OciExt4Image {
+            path: std::path::PathBuf::from("/tmp/oci.ext4"),
+            size_bytes: 8 * 1024 * 1024,
+            payload_bytes: 64,
+            free_bytes: 1024 * 1024,
+            toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+        },
+        kernel: std::path::PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64"),
+        initrd: None,
+        boot_args: "console=ttyS0".to_owned(),
+        architecture: Architecture::HOST,
+    };
+
+    let named = name_oci_image(image, &parse("nginx:1.27"), &templates).expect("name image");
+
+    assert_eq!(named.alias(), "nginx-1.27");
+    assert_eq!(named.version(), "1.27");
+    assert_eq!(
+        named.image().kernel().as_os_str(),
+        "kernel/vmlinux-ubuntu-26.04-x86_64"
+    );
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}

--- a/firecrab-api/src/oci/register.rs
+++ b/firecrab-api/src/oci/register.rs
@@ -1,0 +1,109 @@
+//! Publishes a packed OCI ext4 and registers it as a template.
+//!
+//! The earlier stages produced a named, kernel-paired image that still lives
+//! at a scratch path. This stage copies it to `rootfs/<alias>.ext4`, records
+//! a `TemplateSpec`, and deletes that published file if registration fails.
+//! The source ext4 and the shared catalog kernel stay where they are.
+
+use super::*;
+
+use crate::templates::{TemplateRegistry, TemplateSpec};
+
+/// Relative location of a registered OCI rootfs.
+fn rootfs_relative(alias: &str) -> PathBuf {
+    Path::new("rootfs").join(format!("{alias}.ext4"))
+}
+
+/// Copies the packed ext4 into the image root and registers the spec.
+pub(super) fn register_named_oci_image(
+    named: NamedOciImage,
+    templates: &TemplateRegistry,
+) -> Result<RegisteredOciImage, ResolveError> {
+    let image_root = templates.image_root_path();
+    let relative = rootfs_relative(named.alias());
+    let destination = image_root.join(&relative);
+    let source = named.image().rootfs().path();
+    let published = publish_rootfs(source, &destination)?;
+    let spec = TemplateSpec {
+        alias: named.alias().to_owned(),
+        version: named.version().to_owned(),
+        kernel: named.image().kernel().to_path_buf(),
+        initrd: named.image().initrd().map(Path::to_path_buf),
+        rootfs: relative.clone(),
+        boot_args: named.image().boot_args().to_owned(),
+    };
+    if let Err(error) = templates.register_spec(spec) {
+        published.revert();
+        return Err(ResolveError::RegisterFailed {
+            alias: named.alias().to_owned(),
+            detail: error.to_string(),
+        });
+    }
+    Ok(RegisteredOciImage {
+        alias: named.alias().to_owned(),
+        version: named.version().to_owned(),
+        rootfs: relative,
+    })
+}
+
+/// A published rootfs that can still be withdrawn if registration fails.
+struct PublishedRootfs {
+    path: PathBuf,
+    owned: bool,
+}
+
+impl PublishedRootfs {
+    fn revert(&self) {
+        if self.owned {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn publish_rootfs(source: &Path, destination: &Path) -> Result<PublishedRootfs, ResolveError> {
+    match std::fs::symlink_metadata(destination) {
+        Ok(_) => {
+            return Err(ResolveError::RegisterDestinationExists {
+                path: destination.to_owned(),
+            });
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(source_error) => {
+            return Err(register_io(
+                "inspect destination",
+                destination.to_owned(),
+                source_error,
+            ));
+        }
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|source_error| {
+            register_io("create rootfs directory", parent.to_owned(), source_error)
+        })?;
+    }
+    let mut partial = destination.as_os_str().to_os_string();
+    partial.push(".partial");
+    let partial = PathBuf::from(partial);
+    let _ = std::fs::remove_file(&partial);
+    if let Err(error) = std::fs::copy(source, &partial) {
+        let _ = std::fs::remove_file(&partial);
+        return Err(register_io("copy rootfs", partial, error));
+    }
+    if let Err(error) = std::fs::rename(&partial, destination) {
+        let _ = std::fs::remove_file(&partial);
+        let _ = std::fs::remove_file(destination);
+        return Err(register_io("publish rootfs", destination.to_owned(), error));
+    }
+    Ok(PublishedRootfs {
+        path: destination.to_owned(),
+        owned: true,
+    })
+}
+
+fn register_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
+    ResolveError::RegisterIo {
+        operation,
+        path,
+        source,
+    }
+}

--- a/firecrab-api/src/oci/register_tests.rs
+++ b/firecrab-api/src/oci/register_tests.rs
@@ -130,6 +130,50 @@ fn a_failed_registration_removes_the_partial_rootfs() {
 }
 
 #[test]
+fn a_missing_source_ext4_is_a_copy_error_and_leaves_no_partial() {
+    let (_keep, templates) = empty_registry();
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+    std::fs::remove_file(named.image().rootfs().path()).expect("remove source");
+
+    let error = register_named_oci_image(named, &templates).expect_err("missing source");
+
+    match error {
+        ResolveError::RegisterIo { operation, .. } => assert_eq!(operation, "copy rootfs"),
+        other => panic!("expected RegisterIo, got {other}"),
+    }
+    assert!(
+        !templates
+            .image_root_path()
+            .join("rootfs/nginx-1.27.ext4")
+            .exists()
+    );
+    assert!(
+        !templates
+            .image_root_path()
+            .join("rootfs/nginx-1.27.ext4.partial")
+            .exists()
+    );
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
+fn a_file_blocking_the_rootfs_directory_is_an_io_error() {
+    let (_keep, templates) = empty_registry();
+    write_file(&templates.image_root_path().join("rootfs"), b"not-a-dir");
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+
+    let error = register_named_oci_image(named, &templates).expect_err("rootfs is a file");
+
+    match error {
+        ResolveError::RegisterIo { operation, .. } => {
+            assert_eq!(operation, "inspect destination");
+        }
+        other => panic!("expected RegisterIo, got {other}"),
+    }
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
 fn a_failed_registration_does_not_delete_the_source_ext4() {
     let (_keep, templates) = empty_registry();
     let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");

--- a/firecrab-api/src/oci/register_tests.rs
+++ b/firecrab-api/src/oci/register_tests.rs
@@ -1,0 +1,146 @@
+use super::*;
+
+use crate::templates::TemplateRegistry;
+
+fn write_file(path: &std::path::Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    std::fs::write(path, bytes).expect("write fixture file");
+}
+
+fn empty_registry() -> (tempfile::TempDir, TemplateRegistry) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let registry = TemplateRegistry::from_specs(directory.path(), []).expect("empty registry");
+    (directory, registry)
+}
+
+fn named_image(image_root: &std::path::Path, alias: &str, ext4_bytes: &[u8]) -> NamedOciImage {
+    let kernel = std::path::PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64");
+    write_file(&image_root.join(&kernel), b"unclassified-kernel");
+    let ext4 = image_root.join("scratch/packed.ext4");
+    write_file(&ext4, ext4_bytes);
+    NamedOciImage {
+        image: OciBootableImage {
+            rootfs: OciExt4Image {
+                path: ext4,
+                size_bytes: ext4_bytes.len() as u64,
+                payload_bytes: ext4_bytes.len() as u64,
+                free_bytes: 1024 * 1024,
+                toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+            },
+            kernel,
+            initrd: None,
+            boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw".to_owned(),
+            architecture: Architecture::HOST,
+        },
+        alias: alias.to_owned(),
+        version: "1.27".to_owned(),
+    }
+}
+
+#[test]
+fn registering_publishes_the_ext4_and_pins_the_alias() {
+    let (_keep, templates) = empty_registry();
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+
+    let registered = register_named_oci_image(named, &templates).expect("register named image");
+
+    assert_eq!(registered.alias(), "nginx-1.27");
+    assert_eq!(registered.version(), "1.27");
+    assert_eq!(registered.rootfs().as_os_str(), "rootfs/nginx-1.27.ext4");
+    let dest = templates.image_root_path().join("rootfs/nginx-1.27.ext4");
+    assert_eq!(
+        std::fs::read(&dest).expect("published rootfs"),
+        b"ext4-bytes"
+    );
+    let template = templates
+        .resolve_alias("nginx-1.27")
+        .expect("alias is installed");
+    assert_eq!(template.version, "1.27");
+    assert_eq!(
+        template.rootfs.relative_path().as_os_str(),
+        "rootfs/nginx-1.27.ext4"
+    );
+    assert_eq!(
+        template.kernel.relative_path().as_os_str(),
+        "kernel/vmlinux-ubuntu-26.04-x86_64"
+    );
+    assert!(template.initrd.is_none());
+    assert!(template.boot_args.contains("root=/dev/vda"));
+}
+
+#[test]
+fn registering_leaves_the_source_ext4_in_place() {
+    let (_keep, templates) = empty_registry();
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+    let source = named.image().rootfs().path().to_path_buf();
+
+    register_named_oci_image(named, &templates).expect("register");
+
+    assert_eq!(
+        std::fs::read(&source).expect("source remains"),
+        b"ext4-bytes"
+    );
+}
+
+#[test]
+fn registering_refuses_to_overwrite_an_existing_rootfs() {
+    let (_keep, templates) = empty_registry();
+    let dest = templates.image_root_path().join("rootfs/nginx-1.27.ext4");
+    write_file(&dest, b"already-there");
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"new-bytes");
+
+    let error = register_named_oci_image(named, &templates).expect_err("existing dest");
+
+    assert!(matches!(
+        error,
+        ResolveError::RegisterDestinationExists { .. }
+    ));
+    assert_eq!(
+        std::fs::read(&dest).expect("existing dest"),
+        b"already-there"
+    );
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
+fn a_failed_registration_removes_the_partial_rootfs() {
+    let (_keep, templates) = empty_registry();
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+    std::fs::remove_file(templates.image_root_path().join(named.image().kernel()))
+        .expect("hide the kernel so register_spec fails");
+
+    let error = register_named_oci_image(named, &templates).expect_err("missing kernel");
+
+    assert!(matches!(error, ResolveError::RegisterFailed { .. }));
+    assert!(
+        !templates
+            .image_root_path()
+            .join("rootfs/nginx-1.27.ext4")
+            .exists()
+    );
+    assert!(
+        !templates
+            .image_root_path()
+            .join("rootfs/nginx-1.27.ext4.partial")
+            .exists()
+    );
+    assert!(templates.resolve_alias("nginx-1.27").is_none());
+}
+
+#[test]
+fn a_failed_registration_does_not_delete_the_source_ext4() {
+    let (_keep, templates) = empty_registry();
+    let named = named_image(templates.image_root_path(), "nginx-1.27", b"ext4-bytes");
+    let source = named.image().rootfs().path().to_path_buf();
+    std::fs::remove_file(templates.image_root_path().join(named.image().kernel()))
+        .expect("hide the kernel");
+
+    let _ = register_named_oci_image(named, &templates).expect_err("missing kernel");
+
+    assert_eq!(
+        std::fs::read(&source).expect("source remains"),
+        b"ext4-bytes"
+    );
+}

--- a/firecrab-api/src/oci/service.rs
+++ b/firecrab-api/src/oci/service.rs
@@ -1,0 +1,144 @@
+//! Turns an OCI process config into a service under the injected init.
+//!
+//! The image's Entrypoint and Cmd are an application, not an operating system.
+//! Writing them to `/sbin/init` would steal PID 1 from DHCP and the readiness
+//! sentinel. The guest boot script already runs every executable in
+//! `/etc/firecrab/services.d`, so this stage drops one script there.
+
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+use super::*;
+
+const GUEST_SERVICE: &str = "etc/firecrab/services.d/app";
+const GUEST_TOOLBOX: &str = "/sbin/firecrab-busybox";
+
+#[derive(Debug, Deserialize)]
+struct RawImageProcess {
+    #[serde(default)]
+    config: Option<RawContainerConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawContainerConfig {
+    #[serde(default, rename = "Entrypoint")]
+    entrypoint: Option<Vec<String>>,
+    #[serde(default, rename = "Cmd")]
+    cmd: Option<Vec<String>>,
+    #[serde(default, rename = "Env")]
+    env: Option<Vec<String>>,
+    #[serde(default, rename = "WorkingDir")]
+    working_dir: Option<String>,
+}
+
+pub(super) fn process_config_from_image_config(
+    bytes: &[u8],
+) -> Result<OciProcessConfig, ResolveError> {
+    let raw: RawImageProcess = serde_json::from_slice(bytes)
+        .map_err(|error| ResolveError::MalformedConfig(error.to_string()))?;
+    let config = raw.config.unwrap_or(RawContainerConfig {
+        entrypoint: None,
+        cmd: None,
+        env: None,
+        working_dir: None,
+    });
+    let env = config.env.unwrap_or_default();
+    for entry in &env {
+        if !is_valid_env(entry) {
+            return Err(ResolveError::ServiceEnvInvalid {
+                entry: entry.clone(),
+            });
+        }
+    }
+    Ok(OciProcessConfig {
+        entrypoint: config.entrypoint.unwrap_or_default(),
+        cmd: config.cmd.unwrap_or_default(),
+        env,
+        working_dir: config.working_dir.unwrap_or_default(),
+    })
+}
+
+pub(super) fn install_oci_service(
+    rootfs: &ProvisionedRootfs,
+    process: &OciProcessConfig,
+) -> Result<(), ResolveError> {
+    let argv = process.argv();
+    if argv.is_empty() {
+        return Ok(());
+    }
+    let path = rootfs.path().join(GUEST_SERVICE);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|source| service_io("create services.d", parent, source))?;
+    }
+    let script = render_service(process, &argv);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(&path)
+        .map_err(|source| service_io("create service", &path, source))?;
+    file.write_all(script.as_bytes())
+        .map_err(|source| service_io("write service", &path, source))?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o755))
+        .map_err(|source| service_io("chmod service", &path, source))?;
+    Ok(())
+}
+
+fn render_service(process: &OciProcessConfig, argv: &[&str]) -> String {
+    let mut script = format!(
+        "#!{GUEST_TOOLBOX} sh\n\
+         # Firecrab service for the imported image entrypoint (public-docs/oci.md).\n\
+         # This is not PID 1. The injected init keeps DHCP and the readiness sentinel.\n"
+    );
+    if !process.working_dir.is_empty() {
+        script.push_str(&format!("cd {}\n", posix_quote(&process.working_dir)));
+    }
+    for entry in &process.env {
+        let (key, value) = entry.split_once('=').expect("validated Env");
+        script.push_str(&format!("export {key}={}\n", posix_quote(value)));
+    }
+    script.push_str("exec");
+    for arg in argv {
+        script.push(' ');
+        script.push_str(&posix_quote(arg));
+    }
+    script.push('\n');
+    script
+}
+
+fn is_valid_env(entry: &str) -> bool {
+    match entry.split_once('=') {
+        Some((key, _)) => {
+            let mut chars = key.chars();
+            let Some(first) = chars.next() else {
+                return false;
+            };
+            (first.is_ascii_alphabetic() || first == '_')
+                && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        }
+        None => false,
+    }
+}
+
+fn posix_quote(value: &str) -> String {
+    let mut out = String::from("'");
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn service_io(operation: &'static str, path: &Path, source: io::Error) -> ResolveError {
+    ResolveError::ServiceIo {
+        operation,
+        path: path.to_owned(),
+        source,
+    }
+}

--- a/firecrab-api/src/oci/service_tests.rs
+++ b/firecrab-api/src/oci/service_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+
+fn tree_with_services() -> (tempfile::TempDir, ProvisionedRootfs) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let tree = directory.path().join("tree");
+    std::fs::create_dir_all(tree.join("etc/firecrab/services.d")).expect("services.d");
+    std::fs::create_dir_all(tree.join("sbin")).expect("sbin");
+    std::fs::write(tree.join("sbin/init"), b"injected-init").expect("init");
+    (
+        directory,
+        ProvisionedRootfs {
+            path: tree,
+            toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+        },
+    )
+}
+
+fn config_json(config: serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "architecture": "amd64",
+        "os": "linux",
+        "config": config,
+        "rootfs": { "type": "layers", "diff_ids": [] }
+    }))
+    .expect("serialize config")
+}
+
+#[test]
+fn process_config_joins_entrypoint_and_cmd() {
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["nginx"],
+        "Cmd": ["-g", "daemon off;"],
+        "Env": ["PATH=/usr/bin", "NGINX=1"],
+        "WorkingDir": "/usr/share/nginx/html"
+    })))
+    .expect("parse process config");
+
+    assert_eq!(process.entrypoint(), &["nginx"]);
+    assert_eq!(process.cmd(), &["-g", "daemon off;"]);
+    assert_eq!(process.env(), &["PATH=/usr/bin", "NGINX=1"]);
+    assert_eq!(process.working_dir(), "/usr/share/nginx/html");
+    assert_eq!(process.argv(), ["nginx", "-g", "daemon off;"]);
+}
+
+#[test]
+fn process_config_uses_cmd_when_entrypoint_is_absent() {
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Cmd": ["/bin/app", "serve"]
+    })))
+    .expect("parse");
+    assert!(process.entrypoint().is_empty());
+    assert_eq!(process.argv(), ["/bin/app", "serve"]);
+}
+
+#[test]
+fn installing_a_service_writes_env_workdir_and_exec_under_services_d() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["/bin/app"],
+        "Cmd": ["--port", "8080"],
+        "Env": ["PATH=/usr/bin", "APP_ENV=prod"],
+        "WorkingDir": "/opt/app"
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install service");
+
+    let script = std::fs::read_to_string(rootfs.path().join("etc/firecrab/services.d/app"))
+        .expect("read service");
+    assert!(script.starts_with("#!/sbin/firecrab-busybox sh\n"));
+    assert!(script.contains("cd '/opt/app'"));
+    assert!(script.contains("export PATH='/usr/bin'"));
+    assert!(script.contains("export APP_ENV='prod'"));
+    assert!(script.contains("exec '/bin/app' '--port' '8080'"));
+    assert!(!script.contains("/sbin/init"));
+    assert_eq!(
+        std::fs::read(rootfs.path().join("sbin/init")).expect("init untouched"),
+        b"injected-init"
+    );
+}
+
+#[test]
+fn the_service_is_executable_and_is_not_pid_1() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Cmd": ["/bin/app"]
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install");
+
+    let metadata =
+        std::fs::metadata(rootfs.path().join("etc/firecrab/services.d/app")).expect("stat");
+    assert!(metadata.permissions().mode() & 0o111 != 0);
+    assert_eq!(
+        std::fs::read(rootfs.path().join("sbin/init")).expect("init"),
+        b"injected-init"
+    );
+}
+
+#[test]
+fn an_image_with_no_command_does_not_install_a_service() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({})))
+        .expect("empty process");
+
+    install_oci_service(&rootfs, &process).expect("skip empty");
+
+    assert!(!rootfs.path().join("etc/firecrab/services.d/app").exists());
+}
+
+#[test]
+fn malformed_env_is_refused() {
+    let error = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Env": ["PATH=/usr/bin", "NOTAPAIR"]
+    })))
+    .expect_err("malformed env");
+    assert!(matches!(error, ResolveError::ServiceEnvInvalid { .. }));
+}
+
+#[test]
+fn quotes_in_arguments_stay_inside_the_script() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["sh", "-c"],
+        "Cmd": ["echo it's"]
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install");
+
+    let script = std::fs::read_to_string(rootfs.path().join("etc/firecrab/services.d/app"))
+        .expect("read service");
+    assert!(script.contains("exec 'sh' '-c' 'echo it'\\''s'"));
+}

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -830,7 +830,7 @@ fn open_beneath(root: &File, path: &Path) -> Result<File, TemplateError> {
 /// [`Unrecognized`](KernelFormat::Unrecognized) is the point of this type:
 /// only one of them may be treated leniently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KernelFormat {
+pub(crate) enum KernelFormat {
     /// A kernel for an architecture Firecracker supports.
     Bootable(Architecture),
     /// A well-formed ELF for an architecture Firecracker cannot boot at all,
@@ -848,7 +848,7 @@ enum KernelFormat {
 /// Classifies a kernel artifact from its own header.
 ///
 /// x86_64 boots an ELF `vmlinux`; ARM64 boots Linux's `Image` container.
-fn kernel_architecture(header: &[u8]) -> KernelFormat {
+pub(crate) fn kernel_architecture(header: &[u8]) -> KernelFormat {
     if header.starts_with(b"\x7fELF") {
         // e_machine, a little-endian u16 at offset 18. Both architectures
         // Firecrab supports are little-endian, so the byte order is fixed.

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -149,19 +149,17 @@ A full image, a failed format, or an existing destination is an error;
 the partial file is removed and the provisioned tree is left in place.
 This stage still pairs no kernel and registers nothing.
 
-## Kernel pairing
+## Kernel, name, register
 
 The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
-A foreign architecture, an unbootable ELF, or a symbolic link is refused.
-
-## Name
-
 The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
-An alias that matches an installed image or a catalog name is refused.
+A catalog or installed alias is refused.
+The ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
 
-## Register
+## Service
 
-The packed ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
+Entrypoint, Cmd, Env, and WorkingDir become `/etc/firecrab/services.d/app`.
+The injected init starts it after the sentinel. It is never PID 1.
 
 ## Related
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,8 +2,9 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-The internal pipeline can size a provisioned tree into an ext4 image.
-Pairing a kernel and registering a template are still separate work.
+The internal pipeline can size a provisioned tree into an ext4 image and pair
+it with an architecture-matched kernel.
+Registering a template is still separate work.
 
 ## Inspect
 
@@ -59,8 +60,8 @@ process-wide, and each zstd decoder has a 128 MiB window limit.
 Before extraction, the internal pipeline scans every decompressed tar using
 GNU long-name/link metadata and PAX overrides. Member names must be relative
 paths without parent components; only a directory may name the archive root
-as `.` or `./`. Character and block devices are
-rejected, as are unsupported special entries. Links must name a target;
+as `.` or `./`. Character and block devices are rejected, as are unsupported
+special entries. Links must name a target;
 hard-link targets are archive-root-relative and cannot be absolute or contain
 parent components. Regular whiteout files remain valid for the later merge
 stage.
@@ -125,11 +126,10 @@ empty for the image's own entrypoint, which a later stage translates into an
 ordinary service under that init rather than PID 1.
 
 Images that place `/sbin` or `/etc` behind a symbolic link are activated
-through it, because most distribution images link `/sbin` at `/usr/sbin`.
-Resolution is clamped to the tree, so a link naming a host path is followed
-inside the tree and never out of it, and an entry already occupying a guest
-path is replaced without writing through it. A failed activation restores every
-path it touched and leaves the merged tree as it found it.
+through it.
+Resolution is clamped to the tree, and an entry already occupying a guest
+path is replaced without writing through it.
+A failed activation restores every path it touched.
 
 ## Ext4 image
 
@@ -145,17 +145,23 @@ One image is limited to 32 GiB by default; operators can change this with
 
 The file is created sparse, formatted with `mkfs.ext4 -d`, and published
 only after `tune2fs` shows free space remains.
-A full image, a failed format, or a destination that already exists is an
-error, and a partial file is removed.
-The provisioned tree is left in place.
+A full image, a failed format, or an existing destination is an error;
+the partial file is removed and the provisioned tree is left in place.
 This stage still pairs no kernel and registers nothing.
 
-Registry inspection, raw blob caching, decompression, safety validation, merge,
-guest activation, and ext4 sizing remain distinct import stages.
-`GET /api/oci/inspect` stops at metadata and fills no OCI cache;
-caching and decompression do not publish a merged tree;
-activation does not write an ext4 image;
-ext4 sizing pairs no kernel and registers nothing.
+## Kernel pairing
+
+`TemplateSpec` needs a kernel and boot args; an OCI image carries neither.
+The packed ext4 is paired with this host's catalog kernel that has the
+Firecracker boot path built in and needs no initrd — currently Ubuntu.
+Alpine and Rocky keep those drivers as modules; their initrd would take
+PID 1 from the injected guest init. The kernel must already be installed.
+Its header is classified the same way registration classifies any kernel.
+A foreign architecture, an unbootable ELF, an unclassifiable file, or a
+symbolic link at the catalog path is refused.
+Boot args are that artifact's own command line.
+The ext4 is left in place; this stage still registers nothing.
+Each import stage stops where the next begins: inspect fills no cache, and pairing registers nothing.
 
 ## Related
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,8 +2,8 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-The internal pipeline can size a provisioned tree into an ext4 image and pair
-it with an architecture-matched kernel.
+The internal pipeline can size a provisioned tree into an ext4 image, pair
+it with an architecture-matched kernel, and derive an alias from the reference.
 Registering a template is still separate work.
 
 ## Inspect
@@ -152,16 +152,16 @@ This stage still pairs no kernel and registers nothing.
 ## Kernel pairing
 
 `TemplateSpec` needs a kernel and boot args; an OCI image carries neither.
-The packed ext4 is paired with this host's catalog kernel that has the
-Firecracker boot path built in and needs no initrd — currently Ubuntu.
-Alpine and Rocky keep those drivers as modules; their initrd would take
-PID 1 from the injected guest init. The kernel must already be installed.
-Its header is classified the same way registration classifies any kernel.
-A foreign architecture, an unbootable ELF, an unclassifiable file, or a
-symbolic link at the catalog path is refused.
-Boot args are that artifact's own command line.
-The ext4 is left in place; this stage still registers nothing.
-Each import stage stops where the next begins: inspect fills no cache, and pairing registers nothing.
+The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
+A foreign architecture, an unbootable ELF, or a symbolic link is refused.
+
+## Name
+
+The alias is the repository and tag, with Docker Hub's `library/` dropped
+and slashes or ports turned into dashes — `nginx:1.27` becomes `nginx-1.27`.
+A digest pin keeps twelve hex characters in the alias and the full digest as the version.
+An alias that matches an installed image or a catalog name is refused.
+This stage still registers nothing.
 
 ## Related
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -151,17 +151,17 @@ This stage still pairs no kernel and registers nothing.
 
 ## Kernel pairing
 
-`TemplateSpec` needs a kernel and boot args; an OCI image carries neither.
 The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
 A foreign architecture, an unbootable ELF, or a symbolic link is refused.
 
 ## Name
 
-The alias is the repository and tag, with Docker Hub's `library/` dropped
-and slashes or ports turned into dashes — `nginx:1.27` becomes `nginx-1.27`.
-A digest pin keeps twelve hex characters in the alias and the full digest as the version.
+The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
 An alias that matches an installed image or a catalog name is refused.
-This stage still registers nothing.
+
+## Register
+
+The packed ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Pair a packed OCI ext4 with this host's architecture-matched catalog kernel.
- Derive a unique template alias and version from the image reference.
- Copy the ext4 into the image root and register it, removing a partial rootfs on failure.

## Details

- Select the first catalog artifact for this architecture that boots without an initrd, because an OCI tree ships no `/lib/modules`.
- Classify the kernel header with the rules registration already uses, so a mismatch is refused before a `TemplateSpec` can point at a kernel that would hang silently.
- Turn `nginx:1.27` into the alias `nginx-1.27`, sanitising repository and tag into catalog-legal segments.
- Keep 12 hex characters of a digest reference so a digest-pinned import still derives a stable alias.
- Refuse an alias already held by a catalog or installed image rather than overwriting it.
- Publish the rootfs to `rootfs/<alias>.ext4` and withdraw that file when registration fails.
- Pair and name without moving or deleting the ext4, so each stage stays separately testable.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace --locked`
- `cargo llvm-cov --workspace --locked --lcov --output-path lcov.info`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Related to #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCI image import support, including architecture-matched kernel pairing and boot configuration.
  * Added automatic image naming, alias validation, and template registration.
  * Added service installation based on container process configuration, including environment and working-directory support.
* **Bug Fixes**
  * Added safeguards for invalid kernels, alias conflicts, registration failures, and malformed process settings.
  * Improved cleanup and protection against overwriting existing image data.
* **Documentation**
  * Expanded OCI documentation covering image processing, kernel pairing, registration, services, and activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->