### PR TITLE
Feat/oci service 90

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -920,6 +920,23 @@ pub enum ResolveError {
         /// Registry diagnostic.
         detail: String,
     },
+    /// An image Env entry was not `KEY=value`.
+    #[error("OCI image Env entry {entry:?} is not KEY=value")]
+    ServiceEnvInvalid {
+        /// The rejected environment entry.
+        entry: String,
+    },
+    /// A filesystem operation failed while writing the image service.
+    #[error("OCI service {operation} failed at {path}: {source}")]
+    ServiceIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Guest or host path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1935,6 +1952,11 @@ mod register;
 #[cfg(test)]
 mod register_tests;
 
+mod service;
+
+#[cfg(test)]
+mod service_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2518,6 +2540,53 @@ impl RegisteredOciImage {
     }
 }
 
+/// Process fields from an OCI image configuration.
+///
+/// These become a service under the injected init, never PID 1.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciProcessConfig {
+    entrypoint: Vec<String>,
+    cmd: Vec<String>,
+    env: Vec<String>,
+    working_dir: String,
+}
+
+impl OciProcessConfig {
+    /// Reads Entrypoint, Cmd, Env, and WorkingDir from an image config blob.
+    pub fn from_image_config(bytes: &[u8]) -> Result<Self, ResolveError> {
+        service::process_config_from_image_config(bytes)
+    }
+
+    /// Config `Entrypoint`.
+    pub fn entrypoint(&self) -> &[String] {
+        &self.entrypoint
+    }
+
+    /// Config `Cmd`.
+    pub fn cmd(&self) -> &[String] {
+        &self.cmd
+    }
+
+    /// Config `Env` entries, each `KEY=value`.
+    pub fn env(&self) -> &[String] {
+        &self.env
+    }
+
+    /// Config `WorkingDir`, empty when the image did not set one.
+    pub fn working_dir(&self) -> &str {
+        &self.working_dir
+    }
+
+    /// The argv the service will exec: Entrypoint followed by Cmd.
+    pub fn argv(&self) -> Vec<&str> {
+        self.entrypoint
+            .iter()
+            .chain(self.cmd.iter())
+            .map(String::as_str)
+            .collect()
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2926,6 +2995,18 @@ pub fn register_named_oci_image(
     templates: &crate::templates::TemplateRegistry,
 ) -> Result<RegisteredOciImage, ResolveError> {
     register::register_named_oci_image(named, templates)
+}
+
+/// Translates the image process config into a service under the injected init.
+///
+/// The script lands in `/etc/firecrab/services.d` and is started after the
+/// readiness sentinel. It is never PID 1. An image with no command is a
+/// no-op.
+pub fn install_oci_service(
+    rootfs: &ProvisionedRootfs,
+    process: &OciProcessConfig,
+) -> Result<(), ResolveError> {
+    service::install_oci_service(rootfs, process)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci/service.rs
+++ b/firecrab-api/src/oci/service.rs
@@ -1,0 +1,144 @@
+//! Turns an OCI process config into a service under the injected init.
+//!
+//! The image's Entrypoint and Cmd are an application, not an operating system.
+//! Writing them to `/sbin/init` would steal PID 1 from DHCP and the readiness
+//! sentinel. The guest boot script already runs every executable in
+//! `/etc/firecrab/services.d`, so this stage drops one script there.
+
+use std::io::Write as _;
+use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
+
+use super::*;
+
+const GUEST_SERVICE: &str = "etc/firecrab/services.d/app";
+const GUEST_TOOLBOX: &str = "/sbin/firecrab-busybox";
+
+#[derive(Debug, Deserialize)]
+struct RawImageProcess {
+    #[serde(default)]
+    config: Option<RawContainerConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawContainerConfig {
+    #[serde(default, rename = "Entrypoint")]
+    entrypoint: Option<Vec<String>>,
+    #[serde(default, rename = "Cmd")]
+    cmd: Option<Vec<String>>,
+    #[serde(default, rename = "Env")]
+    env: Option<Vec<String>>,
+    #[serde(default, rename = "WorkingDir")]
+    working_dir: Option<String>,
+}
+
+pub(super) fn process_config_from_image_config(
+    bytes: &[u8],
+) -> Result<OciProcessConfig, ResolveError> {
+    let raw: RawImageProcess = serde_json::from_slice(bytes)
+        .map_err(|error| ResolveError::MalformedConfig(error.to_string()))?;
+    let config = raw.config.unwrap_or(RawContainerConfig {
+        entrypoint: None,
+        cmd: None,
+        env: None,
+        working_dir: None,
+    });
+    let env = config.env.unwrap_or_default();
+    for entry in &env {
+        if !is_valid_env(entry) {
+            return Err(ResolveError::ServiceEnvInvalid {
+                entry: entry.clone(),
+            });
+        }
+    }
+    Ok(OciProcessConfig {
+        entrypoint: config.entrypoint.unwrap_or_default(),
+        cmd: config.cmd.unwrap_or_default(),
+        env,
+        working_dir: config.working_dir.unwrap_or_default(),
+    })
+}
+
+pub(super) fn install_oci_service(
+    rootfs: &ProvisionedRootfs,
+    process: &OciProcessConfig,
+) -> Result<(), ResolveError> {
+    let argv = process.argv();
+    if argv.is_empty() {
+        return Ok(());
+    }
+    let path = rootfs.path().join(GUEST_SERVICE);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|source| service_io("create services.d", parent, source))?;
+    }
+    let script = render_service(process, &argv);
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o755)
+        .open(&path)
+        .map_err(|source| service_io("create service", &path, source))?;
+    file.write_all(script.as_bytes())
+        .map_err(|source| service_io("write service", &path, source))?;
+    file.set_permissions(std::fs::Permissions::from_mode(0o755))
+        .map_err(|source| service_io("chmod service", &path, source))?;
+    Ok(())
+}
+
+fn render_service(process: &OciProcessConfig, argv: &[&str]) -> String {
+    let mut script = format!(
+        "#!{GUEST_TOOLBOX} sh\n\
+         # Firecrab service for the imported image entrypoint (public-docs/oci.md).\n\
+         # This is not PID 1. The injected init keeps DHCP and the readiness sentinel.\n"
+    );
+    if !process.working_dir.is_empty() {
+        script.push_str(&format!("cd {}\n", posix_quote(&process.working_dir)));
+    }
+    for entry in &process.env {
+        let (key, value) = entry.split_once('=').expect("validated Env");
+        script.push_str(&format!("export {key}={}\n", posix_quote(value)));
+    }
+    script.push_str("exec");
+    for arg in argv {
+        script.push(' ');
+        script.push_str(&posix_quote(arg));
+    }
+    script.push('\n');
+    script
+}
+
+fn is_valid_env(entry: &str) -> bool {
+    match entry.split_once('=') {
+        Some((key, _)) => {
+            let mut chars = key.chars();
+            let Some(first) = chars.next() else {
+                return false;
+            };
+            (first.is_ascii_alphabetic() || first == '_')
+                && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+        }
+        None => false,
+    }
+}
+
+fn posix_quote(value: &str) -> String {
+    let mut out = String::from("'");
+    for ch in value.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+fn service_io(operation: &'static str, path: &Path, source: io::Error) -> ResolveError {
+    ResolveError::ServiceIo {
+        operation,
+        path: path.to_owned(),
+        source,
+    }
+}

--- a/firecrab-api/src/oci/service_tests.rs
+++ b/firecrab-api/src/oci/service_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+use std::os::unix::fs::PermissionsExt;
+
+fn tree_with_services() -> (tempfile::TempDir, ProvisionedRootfs) {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let tree = directory.path().join("tree");
+    std::fs::create_dir_all(tree.join("etc/firecrab/services.d")).expect("services.d");
+    std::fs::create_dir_all(tree.join("sbin")).expect("sbin");
+    std::fs::write(tree.join("sbin/init"), b"injected-init").expect("init");
+    (
+        directory,
+        ProvisionedRootfs {
+            path: tree,
+            toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+        },
+    )
+}
+
+fn config_json(config: serde_json::Value) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "architecture": "amd64",
+        "os": "linux",
+        "config": config,
+        "rootfs": { "type": "layers", "diff_ids": [] }
+    }))
+    .expect("serialize config")
+}
+
+#[test]
+fn process_config_joins_entrypoint_and_cmd() {
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["nginx"],
+        "Cmd": ["-g", "daemon off;"],
+        "Env": ["PATH=/usr/bin", "NGINX=1"],
+        "WorkingDir": "/usr/share/nginx/html"
+    })))
+    .expect("parse process config");
+
+    assert_eq!(process.entrypoint(), &["nginx"]);
+    assert_eq!(process.cmd(), &["-g", "daemon off;"]);
+    assert_eq!(process.env(), &["PATH=/usr/bin", "NGINX=1"]);
+    assert_eq!(process.working_dir(), "/usr/share/nginx/html");
+    assert_eq!(process.argv(), ["nginx", "-g", "daemon off;"]);
+}
+
+#[test]
+fn process_config_uses_cmd_when_entrypoint_is_absent() {
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Cmd": ["/bin/app", "serve"]
+    })))
+    .expect("parse");
+    assert!(process.entrypoint().is_empty());
+    assert_eq!(process.argv(), ["/bin/app", "serve"]);
+}
+
+#[test]
+fn installing_a_service_writes_env_workdir_and_exec_under_services_d() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["/bin/app"],
+        "Cmd": ["--port", "8080"],
+        "Env": ["PATH=/usr/bin", "APP_ENV=prod"],
+        "WorkingDir": "/opt/app"
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install service");
+
+    let script = std::fs::read_to_string(rootfs.path().join("etc/firecrab/services.d/app"))
+        .expect("read service");
+    assert!(script.starts_with("#!/sbin/firecrab-busybox sh\n"));
+    assert!(script.contains("cd '/opt/app'"));
+    assert!(script.contains("export PATH='/usr/bin'"));
+    assert!(script.contains("export APP_ENV='prod'"));
+    assert!(script.contains("exec '/bin/app' '--port' '8080'"));
+    assert!(!script.contains("/sbin/init"));
+    assert_eq!(
+        std::fs::read(rootfs.path().join("sbin/init")).expect("init untouched"),
+        b"injected-init"
+    );
+}
+
+#[test]
+fn the_service_is_executable_and_is_not_pid_1() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Cmd": ["/bin/app"]
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install");
+
+    let metadata =
+        std::fs::metadata(rootfs.path().join("etc/firecrab/services.d/app")).expect("stat");
+    assert!(metadata.permissions().mode() & 0o111 != 0);
+    assert_eq!(
+        std::fs::read(rootfs.path().join("sbin/init")).expect("init"),
+        b"injected-init"
+    );
+}
+
+#[test]
+fn an_image_with_no_command_does_not_install_a_service() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({})))
+        .expect("empty process");
+
+    install_oci_service(&rootfs, &process).expect("skip empty");
+
+    assert!(!rootfs.path().join("etc/firecrab/services.d/app").exists());
+}
+
+#[test]
+fn malformed_env_is_refused() {
+    let error = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Env": ["PATH=/usr/bin", "NOTAPAIR"]
+    })))
+    .expect_err("malformed env");
+    assert!(matches!(error, ResolveError::ServiceEnvInvalid { .. }));
+}
+
+#[test]
+fn quotes_in_arguments_stay_inside_the_script() {
+    let (_keep, rootfs) = tree_with_services();
+    let process = OciProcessConfig::from_image_config(&config_json(serde_json::json!({
+        "Entrypoint": ["sh", "-c"],
+        "Cmd": ["echo it's"]
+    })))
+    .expect("parse");
+
+    install_oci_service(&rootfs, &process).expect("install");
+
+    let script = std::fs::read_to_string(rootfs.path().join("etc/firecrab/services.d/app"))
+        .expect("read service");
+    assert!(script.contains("exec 'sh' '-c' 'echo it'\\''s'"));
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -149,19 +149,17 @@ A full image, a failed format, or an existing destination is an error;
 the partial file is removed and the provisioned tree is left in place.
 This stage still pairs no kernel and registers nothing.
 
-## Kernel pairing
+## Kernel, name, register
 
 The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
-A foreign architecture, an unbootable ELF, or a symbolic link is refused.
-
-## Name
-
 The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
-An alias that matches an installed image or a catalog name is refused.
+A catalog or installed alias is refused.
+The ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
 
-## Register
+## Service
 
-The packed ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
+Entrypoint, Cmd, Env, and WorkingDir become `/etc/firecrab/services.d/app`.
+The injected init starts it after the sentinel. It is never PID 1.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Translate the image config's `Entrypoint`, `Cmd`, `Env`, and `WorkingDir` into a guest service.
- Install it at `/etc/firecrab/services.d/app`, which the injected init starts after the readiness sentinel.
- Keep the image's own process off PID 1.

## Details

- Concatenate `Entrypoint` and `Cmd` into the argv the service executes, quoting every argument for POSIX sh.
- Reject an `Env` entry that is not `KEY=value` instead of emitting a line that would fail silently in the guest.
- Apply `WorkingDir` before the exec so a relative entrypoint resolves the way the image expects.
- Run the service under the injected busybox, so a distroless image needs no shell of its own.
- `exec` the process rather than spawning it, so signals and the exit status reach it directly.
- Write nothing when the config declares no entrypoint or command, leaving a bare rootfs bootable.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace --locked`
- `cargo llvm-cov --workspace --locked --lcov --output-path lcov.info`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Stacked on #105 — this branch targets `feat/oci-register-90`, so review that one first.

Related to #90
