### PR TITLE
Feat/oci ext4 size 90

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -827,6 +827,60 @@ pub enum ResolveError {
         /// Destination that was left unpublished.
         path: PathBuf,
     },
+    /// The compiled-in catalog has no kernel that can boot a module-less
+    /// OCI rootfs on this architecture.
+    #[error("no architecture-matched kernel without an initrd is published for {architecture}")]
+    NoHostKernel {
+        /// Architecture a later TemplateSpec would have to boot.
+        architecture: Architecture,
+    },
+    /// The catalog kernel for this host is not installed under the image root.
+    #[error("no architecture-matched kernel at {path}; install {hint} for {architecture}")]
+    KernelMissing {
+        /// Catalog-relative kernel path that was required.
+        path: PathBuf,
+        /// Template alias that publishes that kernel.
+        hint: String,
+        /// Architecture the missing kernel must match.
+        architecture: Architecture,
+    },
+    /// The catalog kernel exists but is built for another architecture.
+    #[error("kernel {path} is built for {found}, but this host is {host}")]
+    KernelArchitectureMismatch {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+        /// Architecture the kernel header declares.
+        found: Architecture,
+        /// Architecture this build of the API runs on.
+        host: Architecture,
+    },
+    /// The catalog kernel is a well-formed ELF Firecracker cannot boot.
+    #[error(
+        "kernel {path} targets an architecture firecrab does not support (ELF machine {machine:#06x})"
+    )]
+    UnsupportedKernelArchitecture {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+        /// ELF `e_machine` value that identified it.
+        machine: u16,
+    },
+    /// The file at the catalog kernel path is not a classifiable kernel.
+    #[error("kernel {path} is not a classifiable Firecracker kernel")]
+    KernelUnrecognized {
+        /// Catalog-relative kernel path that was inspected.
+        path: PathBuf,
+    },
+    /// A filesystem operation failed while inspecting the paired kernel.
+    #[error("OCI kernel pairing {operation} failed at {path}: {source}")]
+    KernelIo {
+        /// Operation being attempted.
+        operation: &'static str,
+        /// Kernel path involved.
+        path: PathBuf,
+        /// Operating-system failure.
+        #[source]
+        source: io::Error,
+    },
     /// One manifest contradicted itself about a shared content address.
     #[error("manifest declares {digest} with conflicting sizes {first} and {second}")]
     ConflictingDescriptorSize {
@@ -1827,6 +1881,11 @@ mod ext4;
 #[cfg(test)]
 mod ext4_tests;
 
+mod boot;
+
+#[cfg(test)]
+mod boot_tests;
+
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CachedBlob {
@@ -2303,6 +2362,50 @@ impl OciExt4Image {
     }
 }
 
+/// An ext4 image paired with the kernel and boot args a TemplateSpec needs.
+///
+/// Deliberately distinct from [`OciExt4Image`] so registration can require
+/// proof that an architecture-matched kernel was chosen. An OCI image
+/// supplies neither field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OciBootableImage {
+    rootfs: OciExt4Image,
+    kernel: PathBuf,
+    initrd: Option<PathBuf>,
+    boot_args: String,
+    architecture: Architecture,
+}
+
+impl OciBootableImage {
+    /// Packed ext4 this pair will boot.
+    pub fn rootfs(&self) -> &OciExt4Image {
+        &self.rootfs
+    }
+
+    /// Kernel path relative to the image root.
+    pub fn kernel(&self) -> &Path {
+        &self.kernel
+    }
+
+    /// Initrd path relative to the image root, if the paired kernel needs one.
+    ///
+    /// The current catalog pair does not: a module-less OCI tree cannot use
+    /// a distro initrd without losing the injected guest init.
+    pub fn initrd(&self) -> Option<&Path> {
+        self.initrd.as_deref()
+    }
+
+    /// Firecracker kernel command line recorded from the paired kernel.
+    pub fn boot_args(&self) -> &str {
+        &self.boot_args
+    }
+
+    /// Architecture the paired kernel was classified as.
+    pub fn architecture(&self) -> Architecture {
+        self.architecture
+    }
+}
+
 /// A verified static program cached on the host to become a guest's init.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ToolboxProgram {
@@ -2673,6 +2776,20 @@ pub async fn write_provisioned_ext4(
     destination: &Path,
 ) -> Result<OciExt4Image, ResolveError> {
     ext4::write_provisioned_ext4(rootfs, destination).await
+}
+
+/// Pairs a packed ext4 with this host's architecture-matched kernel and
+/// boot args.
+///
+/// `TemplateSpec` requires both; an OCI image supplies neither. The kernel
+/// is the catalog artifact for this architecture that needs no initrd —
+/// currently Ubuntu — and must already be installed under `image_root`.
+/// The ext4 is left in place. This stage does not register a template.
+pub fn pair_ext4_with_host_kernel(
+    image: OciExt4Image,
+    image_root: &Path,
+) -> Result<OciBootableImage, ResolveError> {
+    boot::pair_ext4_with_host_kernel(image, image_root)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci/boot.rs
+++ b/firecrab-api/src/oci/boot.rs
@@ -1,0 +1,121 @@
+//! Pairs a packed OCI ext4 with the kernel and boot args TemplateSpec needs.
+//!
+//! An OCI image carries neither. A container tree also has no `/lib/modules`,
+//! so the kernel must have the Firecracker boot path built in — `virtio_blk`,
+//! `virtio_net`, `virtio_mmio`, and `ext4`. Distro kernels that keep those as
+//! modules need their matching initrd, and that initrd would take PID 1 away
+//! from the injected guest init. The compiled-in catalog's first host
+//! artifact without an initrd is the Ubuntu kernel; this stage records that
+//! pair and does not register a template.
+
+use std::io::Read as _;
+use std::os::unix::fs::OpenOptionsExt as _;
+
+use super::*;
+
+use crate::m2image_manifest;
+use crate::templates::{KernelFormat, kernel_architecture};
+
+/// Kernel, optional initrd, and command line later registration can copy
+/// into a [`crate::templates::TemplateSpec`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct KernelBootPair {
+    pub architecture: Architecture,
+    pub source_alias: String,
+    pub kernel: PathBuf,
+    pub initrd: Option<PathBuf>,
+    pub boot_args: String,
+}
+
+/// The architecture-matched pair this host will boot imported images with.
+pub(super) fn host_kernel_pair() -> Result<KernelBootPair, ResolveError> {
+    kernel_pair_for(Architecture::HOST)
+}
+
+/// First catalog artifact for `architecture` that needs no initrd.
+pub(super) fn kernel_pair_for(architecture: Architecture) -> Result<KernelBootPair, ResolveError> {
+    m2image_manifest::load()
+        .images
+        .into_iter()
+        .find_map(|image| {
+            let artifact = image.artifacts.get(architecture.as_str())?;
+            if artifact.initrd.is_some() {
+                return None;
+            }
+            Some(KernelBootPair {
+                architecture,
+                source_alias: image.alias,
+                kernel: PathBuf::from(&artifact.kernel),
+                initrd: None,
+                boot_args: artifact.boot_args.clone(),
+            })
+        })
+        .ok_or(ResolveError::NoHostKernel { architecture })
+}
+
+/// Records the host catalog kernel and its boot args on a packed ext4.
+///
+/// The kernel file must already exist under `image_root`. Its header is
+/// classified with the same rules registration uses. A mismatch is refused
+/// here so a later TemplateSpec is never pointed at a silent-hang kernel.
+/// The ext4 is not moved or deleted, and nothing is registered.
+pub(super) fn pair_ext4_with_host_kernel(
+    image: OciExt4Image,
+    image_root: &Path,
+) -> Result<OciBootableImage, ResolveError> {
+    let pair = host_kernel_pair()?;
+    let kernel_path = image_root.join(&pair.kernel);
+    let header = read_kernel_header(&kernel_path, &pair)?;
+    match kernel_architecture(&header) {
+        KernelFormat::Bootable(found) if found == pair.architecture => Ok(OciBootableImage {
+            rootfs: image,
+            kernel: pair.kernel,
+            initrd: pair.initrd,
+            boot_args: pair.boot_args,
+            architecture: found,
+        }),
+        KernelFormat::Bootable(found) => Err(ResolveError::KernelArchitectureMismatch {
+            path: pair.kernel,
+            found,
+            host: pair.architecture,
+        }),
+        KernelFormat::Foreign { machine } => Err(ResolveError::UnsupportedKernelArchitecture {
+            path: pair.kernel,
+            machine,
+        }),
+        KernelFormat::Unrecognized => Err(ResolveError::KernelUnrecognized { path: pair.kernel }),
+    }
+}
+
+fn read_kernel_header(path: &Path, pair: &KernelBootPair) -> Result<Vec<u8>, ResolveError> {
+    let file = match std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            return Err(ResolveError::KernelMissing {
+                path: pair.kernel.clone(),
+                hint: pair.source_alias.clone(),
+                architecture: pair.architecture,
+            });
+        }
+        Err(source) => {
+            return Err(ResolveError::KernelIo {
+                operation: "open kernel",
+                path: pair.kernel.clone(),
+                source,
+            });
+        }
+    };
+    let mut header = Vec::new();
+    file.take(64)
+        .read_to_end(&mut header)
+        .map_err(|source| ResolveError::KernelIo {
+            operation: "read kernel header",
+            path: pair.kernel.clone(),
+            source,
+        })?;
+    Ok(header)
+}

--- a/firecrab-api/src/oci/boot_tests.rs
+++ b/firecrab-api/src/oci/boot_tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+
+use crate::m2image_manifest;
+
+fn ubuntu_artifact(architecture: Architecture) -> crate::m2image_manifest::ReleaseArtifact {
+    m2image_manifest::image("ubuntu-26.04")
+        .expect("ubuntu is a release image")
+        .artifacts
+        .remove(architecture.as_str())
+        .expect("ubuntu publishes this architecture")
+}
+
+#[test]
+fn kernel_pair_for_x86_64_is_the_ubuntu_vmlinux_without_an_initrd() {
+    let pair = boot::kernel_pair_for(Architecture::X86_64).expect("ubuntu publishes x86_64");
+    let ubuntu = ubuntu_artifact(Architecture::X86_64);
+
+    assert_eq!(pair.architecture, Architecture::X86_64);
+    assert_eq!(pair.source_alias, "ubuntu-26.04");
+    assert_eq!(
+        pair.kernel.as_os_str(),
+        "kernel/vmlinux-ubuntu-26.04-x86_64"
+    );
+    assert_eq!(pair.initrd, None);
+    assert_eq!(pair.boot_args, ubuntu.boot_args);
+    assert!(!pair.boot_args.contains("keep_bootcon"));
+    assert!(pair.boot_args.contains("console=ttyS0"));
+    assert!(pair.boot_args.contains("root=/dev/vda"));
+}
+
+#[test]
+fn kernel_pair_for_aarch64_is_the_ubuntu_image_without_an_initrd() {
+    let pair = boot::kernel_pair_for(Architecture::Aarch64).expect("ubuntu publishes aarch64");
+    let ubuntu = ubuntu_artifact(Architecture::Aarch64);
+
+    assert_eq!(pair.architecture, Architecture::Aarch64);
+    assert_eq!(pair.source_alias, "ubuntu-26.04");
+    assert_eq!(pair.kernel.as_os_str(), "kernel/Image-ubuntu-26.04-aarch64");
+    assert_eq!(pair.initrd, None);
+    assert_eq!(pair.boot_args, ubuntu.boot_args);
+    assert!(pair.boot_args.contains("keep_bootcon"));
+    assert!(pair.boot_args.contains("console=ttyS0"));
+    assert!(pair.boot_args.contains("root=/dev/vda"));
+}
+
+#[test]
+fn host_kernel_pair_is_the_pair_for_this_build() {
+    let host = boot::host_kernel_pair().expect("a no-initrd host kernel exists");
+    let expected = boot::kernel_pair_for(Architecture::HOST).expect("host pair exists");
+    assert_eq!(host, expected);
+}
+
+fn elf_kernel(machine: u16) -> Vec<u8> {
+    let mut header = vec![0_u8; 64];
+    header[0..4].copy_from_slice(b"\x7fELF");
+    header[4] = 2;
+    header[5] = 1;
+    header[6] = 1;
+    header[16..18].copy_from_slice(&2_u16.to_le_bytes());
+    header[18..20].copy_from_slice(&machine.to_le_bytes());
+    header
+}
+
+fn arm64_image_kernel() -> Vec<u8> {
+    let mut header = vec![0_u8; 64];
+    header[0..2].copy_from_slice(b"MZ");
+    header[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+    header
+}
+
+fn kernel_bytes_for(architecture: Architecture) -> Vec<u8> {
+    match architecture {
+        Architecture::Aarch64 => arm64_image_kernel(),
+        Architecture::X86_64 => elf_kernel(0x3e),
+    }
+}
+
+fn write_file(path: &std::path::Path, bytes: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create fixture parent");
+    }
+    std::fs::write(path, bytes).expect("write fixture file");
+}
+
+fn packed_ext4(path: std::path::PathBuf) -> OciExt4Image {
+    write_file(&path, b"ext4-fixture");
+    OciExt4Image {
+        path,
+        size_bytes: 8 * 1024 * 1024,
+        payload_bytes: 64,
+        free_bytes: 1024 * 1024,
+        toolbox: Sha256Digest::of_bytes(b"toolbox-fixture"),
+    }
+}
+
+fn install_kernel(image_root: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
+    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let path = image_root.join(&pair.kernel);
+    write_file(&path, bytes);
+    pair.kernel
+}
+
+#[test]
+fn pairing_records_the_host_kernel_and_its_boot_args() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let expected_kernel = install_kernel(image_root, &kernel_bytes_for(Architecture::HOST));
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path.clone());
+    let expected = boot::host_kernel_pair().expect("host kernel pair");
+
+    let paired = pair_ext4_with_host_kernel(image, image_root).expect("pair kernel");
+
+    assert_eq!(paired.architecture(), Architecture::HOST);
+    assert_eq!(paired.kernel(), expected_kernel.as_path());
+    assert_eq!(paired.initrd(), None);
+    assert_eq!(paired.boot_args(), expected.boot_args);
+    assert_eq!(paired.rootfs().path(), ext4_path.as_path());
+    assert_eq!(
+        std::fs::read(&ext4_path).expect("ext4 remains"),
+        b"ext4-fixture"
+    );
+    assert!(!image_root.join(".templates.json").exists());
+}
+
+#[test]
+fn pairing_rejects_a_missing_host_kernel() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path.clone());
+    let expected = boot::host_kernel_pair().expect("host kernel pair");
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("missing kernel");
+
+    match error {
+        ResolveError::KernelMissing {
+            path,
+            hint,
+            architecture,
+        } => {
+            assert_eq!(path, expected.kernel);
+            assert_eq!(hint, expected.source_alias);
+            assert_eq!(architecture, Architecture::HOST);
+        }
+        other => panic!("expected KernelMissing, got {other}"),
+    }
+    assert_eq!(
+        std::fs::read(&ext4_path).expect("ext4 remains"),
+        b"ext4-fixture"
+    );
+}
+
+#[test]
+fn pairing_rejects_a_kernel_built_for_another_architecture() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, &kernel_bytes_for(Architecture::HOST.other()));
+    let ext4_path = image_root.join("rootfs/oci.ext4");
+    let image = packed_ext4(ext4_path);
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("foreign arch");
+
+    match error {
+        ResolveError::KernelArchitectureMismatch { found, host, .. } => {
+            assert_eq!(found, Architecture::HOST.other());
+            assert_eq!(host, Architecture::HOST);
+        }
+        other => panic!("expected KernelArchitectureMismatch, got {other}"),
+    }
+}
+
+#[test]
+fn pairing_rejects_an_elf_firecracker_cannot_boot() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, &elf_kernel(0xf3));
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("riscv");
+
+    match error {
+        ResolveError::UnsupportedKernelArchitecture { machine, .. } => {
+            assert_eq!(machine, 0xf3);
+        }
+        other => panic!("expected UnsupportedKernelArchitecture, got {other}"),
+    }
+}
+
+#[test]
+fn pairing_does_not_follow_a_kernel_symlink() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let target = directory.path().join("elsewhere");
+    write_file(&target, &kernel_bytes_for(Architecture::HOST));
+    let kernel_path = image_root.join(&pair.kernel);
+    std::fs::create_dir_all(kernel_path.parent().unwrap()).expect("create kernel parent");
+    std::os::unix::fs::symlink(&target, &kernel_path).expect("symlink kernel");
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("symlink");
+
+    assert!(
+        matches!(error, ResolveError::KernelIo { .. }),
+        "expected KernelIo for a kernel path that is a symlink, got {error}"
+    );
+}
+
+#[test]
+fn pairing_rejects_an_unclassifiable_kernel() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    install_kernel(image_root, b"not-a-kernel");
+    let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
+
+    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("garbage");
+
+    match error {
+        ResolveError::KernelUnrecognized { path } => {
+            assert_eq!(path, boot::host_kernel_pair().expect("host pair").kernel);
+        }
+        other => panic!("expected KernelUnrecognized, got {other}"),
+    }
+}
+
+#[test]
+fn kernel_pair_skips_kernels_that_need_an_initrd() {
+    for architecture in [Architecture::X86_64, Architecture::Aarch64] {
+        let pair = boot::kernel_pair_for(architecture).expect("a no-initrd kernel exists");
+        for alias in ["alpine-3.24.1", "rocky-9.8"] {
+            let artifact = m2image_manifest::image(alias)
+                .expect("release image")
+                .artifacts
+                .remove(architecture.as_str())
+                .expect("release image publishes this architecture");
+            assert!(
+                artifact.initrd.is_some(),
+                "{alias}/{architecture} must remain an initrd kernel so this test stays meaningful"
+            );
+            assert_ne!(pair.kernel, std::path::PathBuf::from(artifact.kernel));
+            assert_ne!(pair.source_alias, alias);
+        }
+    }
+}

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -830,7 +830,7 @@ fn open_beneath(root: &File, path: &Path) -> Result<File, TemplateError> {
 /// [`Unrecognized`](KernelFormat::Unrecognized) is the point of this type:
 /// only one of them may be treated leniently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum KernelFormat {
+pub(crate) enum KernelFormat {
     /// A kernel for an architecture Firecracker supports.
     Bootable(Architecture),
     /// A well-formed ELF for an architecture Firecracker cannot boot at all,
@@ -848,7 +848,7 @@ enum KernelFormat {
 /// Classifies a kernel artifact from its own header.
 ///
 /// x86_64 boots an ELF `vmlinux`; ARM64 boots Linux's `Image` container.
-fn kernel_architecture(header: &[u8]) -> KernelFormat {
+pub(crate) fn kernel_architecture(header: &[u8]) -> KernelFormat {
     if header.starts_with(b"\x7fELF") {
         // e_machine, a little-endian u16 at offset 18. Both architectures
         // Firecrab supports are little-endian, so the byte order is fixed.

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -2,8 +2,9 @@
 
 firecrab can read a container image from a registry and report whether this
 host can run it.
-The internal pipeline can size a provisioned tree into an ext4 image.
-Pairing a kernel and registering a template are still separate work.
+The internal pipeline can size a provisioned tree into an ext4 image and pair
+it with an architecture-matched kernel.
+Registering a template is still separate work.
 
 ## Inspect
 
@@ -59,8 +60,8 @@ process-wide, and each zstd decoder has a 128 MiB window limit.
 Before extraction, the internal pipeline scans every decompressed tar using
 GNU long-name/link metadata and PAX overrides. Member names must be relative
 paths without parent components; only a directory may name the archive root
-as `.` or `./`. Character and block devices are
-rejected, as are unsupported special entries. Links must name a target;
+as `.` or `./`. Character and block devices are rejected, as are unsupported
+special entries. Links must name a target;
 hard-link targets are archive-root-relative and cannot be absolute or contain
 parent components. Regular whiteout files remain valid for the later merge
 stage.
@@ -125,11 +126,10 @@ empty for the image's own entrypoint, which a later stage translates into an
 ordinary service under that init rather than PID 1.
 
 Images that place `/sbin` or `/etc` behind a symbolic link are activated
-through it, because most distribution images link `/sbin` at `/usr/sbin`.
-Resolution is clamped to the tree, so a link naming a host path is followed
-inside the tree and never out of it, and an entry already occupying a guest
-path is replaced without writing through it. A failed activation restores every
-path it touched and leaves the merged tree as it found it.
+through it.
+Resolution is clamped to the tree, and an entry already occupying a guest
+path is replaced without writing through it.
+A failed activation restores every path it touched.
 
 ## Ext4 image
 
@@ -145,17 +145,23 @@ One image is limited to 32 GiB by default; operators can change this with
 
 The file is created sparse, formatted with `mkfs.ext4 -d`, and published
 only after `tune2fs` shows free space remains.
-A full image, a failed format, or a destination that already exists is an
-error, and a partial file is removed.
-The provisioned tree is left in place.
+A full image, a failed format, or an existing destination is an error;
+the partial file is removed and the provisioned tree is left in place.
 This stage still pairs no kernel and registers nothing.
 
-Registry inspection, raw blob caching, decompression, safety validation, merge,
-guest activation, and ext4 sizing remain distinct import stages.
-`GET /api/oci/inspect` stops at metadata and fills no OCI cache;
-caching and decompression do not publish a merged tree;
-activation does not write an ext4 image;
-ext4 sizing pairs no kernel and registers nothing.
+## Kernel pairing
+
+`TemplateSpec` needs a kernel and boot args; an OCI image carries neither.
+The packed ext4 is paired with this host's catalog kernel that has the
+Firecracker boot path built in and needs no initrd — currently Ubuntu.
+Alpine and Rocky keep those drivers as modules; their initrd would take
+PID 1 from the injected guest init. The kernel must already be installed.
+Its header is classified the same way registration classifies any kernel.
+A foreign architecture, an unbootable ELF, an unclassifiable file, or a
+symbolic link at the catalog path is refused.
+Boot args are that artifact's own command line.
+The ext4 is left in place; this stage still registers nothing.
+Each import stage stops where the next begins: inspect fills no cache, and pairing registers nothing.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Pair a packed OCI ext4 with an architecture-matched kernel and its boot arguments.
- Refuse a kernel this host cannot boot before any template is allowed to point at it.
- Leave the ext4 in place and register nothing, so pairing stays its own stage.

## Details

- Choose the first catalog image whose artifact for this architecture needs no initrd, because an OCI tree ships no `/lib/modules`.
- Carry that artifact's own boot arguments instead of inventing a command line for imported images.
- Classify the kernel from its own header through `templates::kernel_architecture`, so pairing and registration can never disagree about what boots.
- Refuse an unclassifiable kernel here even though registration tolerates one: a kernel that hangs with no console output is the worst failure this pipeline can hand an operator.
- Report a foreign ELF machine and a host/kernel architecture mismatch as separate errors, so the message names what was actually found.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets`
- `cargo test --workspace --locked`
- `cargo llvm-cov --workspace --locked --lcov --output-path lcov.info`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`
- `python3 scripts/check-doc-links.py`

Note: these two commits also appear in #105, so whichever merges first empties the other.

Related to #90
