### PR TITLE
feat(images): register a local MicroImage into MicroRegistry

### DIFF
--- a/firecrab-frontend/src/api/client.ts
+++ b/firecrab-frontend/src/api/client.ts
@@ -11,6 +11,8 @@ import type {
   HostStatusResponse,
   ImageInstallResponse,
   ImageResponse,
+  MicroRegistryRegisterRequest,
+  MicroRegistryRegisterResponse,
   MicroRegistryResponse,
   MicroNetworkDetailResponse,
   MicroNetworkResponse,
@@ -144,6 +146,22 @@ export function listImages(): Promise<ImageResponse[]> {
 /** Published M2Image packages and this host's matching cache/install state. */
 export function getMicroRegistry(): Promise<MicroRegistryResponse> {
   return fetchJson("/api/microregistry");
+}
+
+/** Start a MicroRegistry register job (`POST /api/microregistry/register`). Returns 202 + snapshot. */
+export function startMicroRegistryRegister(
+  request: MicroRegistryRegisterRequest,
+): Promise<MicroRegistryRegisterResponse> {
+  return fetchJson("/api/microregistry/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+}
+
+/** Poll a MicroRegistry register job (`GET /api/microregistry/jobs/{jobId}`). */
+export function getMicroRegistryRegisterJob(jobId: string): Promise<MicroRegistryRegisterResponse> {
+  return fetchJson(`/api/microregistry/jobs/${encodeURIComponent(jobId)}`);
 }
 
 /** Start package download + verification (`POST /api/images/{alias}/package`). */

--- a/firecrab-frontend/src/bindings/MicroRegistryRegisterRequest.ts
+++ b/firecrab-frontend/src/bindings/MicroRegistryRegisterRequest.ts
@@ -1,0 +1,6 @@
+/** Body of `POST /api/microregistry/register`. */
+
+export type MicroRegistryRegisterRequest = {
+  alias: string;
+  version: string;
+};

--- a/firecrab-frontend/src/bindings/MicroRegistryRegisterResponse.ts
+++ b/firecrab-frontend/src/bindings/MicroRegistryRegisterResponse.ts
@@ -1,0 +1,7 @@
+/** Snapshot of `POST /api/microregistry/register` and `GET /api/microregistry/jobs/{jobId}`. */
+
+import type { ImageInstallResponse } from "./ImageInstallResponse";
+
+export type MicroRegistryRegisterResponse = ImageInstallResponse & {
+  jobId: string;
+};

--- a/firecrab-frontend/src/bindings/index.ts
+++ b/firecrab-frontend/src/bindings/index.ts
@@ -17,6 +17,8 @@ export * from "./ImageInstallResponse";
 export * from "./ImageInstallStatus";
 export * from "./ImageResponse";
 export * from "./MicroRegistryImageResponse";
+export * from "./MicroRegistryRegisterRequest";
+export * from "./MicroRegistryRegisterResponse";
 export * from "./MicroRegistryResponse";
 export * from "./PackageOrigin";
 export * from "./MicroNetworkBridge";

--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
 import type {
   BootstrapResponse,
   BootstrapStep,
   BootstrapStepRun,
   ImageInstallResponse,
   ImageResponse,
+  MicroRegistryRegisterResponse,
   MicroRegistryResponse,
   VmResponse,
 } from "../bindings";
@@ -19,14 +20,17 @@ import {
   getImageInstall,
   getImagePackage,
   getMicroRegistry,
+  getMicroRegistryRegisterJob,
   listImages,
   listVms,
   startBootstrap,
   startImageInstall,
   startImagePackage,
+  startMicroRegistryRegister,
   stopVm,
 } from "../api/client";
 import { logDownloadFilename } from "../lib/textExport";
+import Banner from "./Banner";
 import LogExportActions from "./LogExportActions";
 import InlineConsole from "./InlineConsole";
 import { useI18n } from "../i18n";
@@ -118,10 +122,10 @@ function PackageDownloadProgress({ job }: { job: ImageInstallResponse }) {
  * Do not let that older `idle`/`running` response erase the state returned by
  * the POST (or a terminal state for the same job).
  */
-function keepNewestJobSnapshot(
-  current: ImageInstallResponse | null | undefined,
-  incoming: ImageInstallResponse,
-): ImageInstallResponse {
+function keepNewestJobSnapshot<T extends ImageInstallResponse>(
+  current: T | null | undefined,
+  incoming: T,
+): T {
   if (!current) return incoming;
   if (incoming.status === "idle" && current.status !== "idle") return current;
   const currentStarted = current.startedAtMs;
@@ -370,12 +374,14 @@ function ImageJobLog({
   kind,
 }: {
   job: ImageInstallResponse;
-  kind: "download" | "import";
+  kind: "download" | "import" | "register";
 }) {
   const { t } = useI18n();
   const label = kind === "download"
     ? t("Package download log", "패키지 다운로드 로그")
-    : t("Image import log", "이미지 가져오기 로그");
+    : kind === "register"
+      ? t("Register log", "등록 로그")
+      : t("Image import log", "이미지 가져오기 로그");
 
   return (
     <div className="subpanel">
@@ -578,6 +584,18 @@ function MicroBootPanel({
   );
 }
 
+function lastLogLine(log: string, fallback: string): string {
+  const line = log.trim().split("\n").filter(Boolean).at(-1);
+  return line || fallback;
+}
+
+function jobStatusClass(status: ImageInstallResponse["status"]): string {
+  if (status === "running") return " starting";
+  if (status === "succeeded") return " running";
+  if (status === "failed") return " error";
+  return "";
+}
+
 /**
  * M2Image inventory, MicroBoot builder, and MicroRegistry are intentionally
  * separate panels so local images, local builds, and remote packages do not
@@ -589,6 +607,12 @@ export default function Images() {
   const [listError, setListError] = useState<string | null>(null);
   const [registry, setRegistry] = useState<MicroRegistryResponse | null>(null);
   const [registryError, setRegistryError] = useState<string | null>(null);
+  const [registerAlias, setRegisterAlias] = useState("");
+  const [registerVersion, setRegisterVersion] = useState("");
+  const [registerJob, setRegisterJob] = useState<MicroRegistryRegisterResponse | null>(null);
+  const [registerError, setRegisterError] = useState<string | null>(null);
+  const [registerStarting, setRegisterStarting] = useState(false);
+  const registerPollingRef = useRef<string | null>(null);
   const [busyAlias, setBusyAlias] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [packageJobs, setPackageJobs] = useState<Record<string, ImageInstallResponse>>({});
@@ -757,6 +781,37 @@ export default function Images() {
     void tick();
   };
 
+  const pollRegister = (jobId: string) => {
+    if (registerPollingRef.current === jobId) return;
+    registerPollingRef.current = jobId;
+    const stop = () => {
+      if (registerPollingRef.current === jobId) registerPollingRef.current = null;
+    };
+    const tick = async () => {
+      if (!mountedRef.current) return stop();
+      try {
+        const latest = await getMicroRegistryRegisterJob(jobId);
+        if (!mountedRef.current) return stop();
+        setRegisterJob((current) => keepNewestJobSnapshot(current, latest));
+        if (latest.status === "running") {
+          setTimeout(() => void tick(), 400);
+          return;
+        }
+        stop();
+        if (latest.status === "succeeded") {
+          setRegisterError(null);
+          await refreshRegistry();
+        } else if (latest.status === "failed") {
+          setRegisterError(lastLogLine(latest.log, t("Register failed.", "등록에 실패했습니다.")));
+        }
+      } catch {
+        if (mountedRef.current) setTimeout(() => void tick(), 400);
+        else stop();
+      }
+    };
+    void tick();
+  };
+
   // 404는 취소로 삭제된 세션이라는 확정 신호(그만 폴링), 그 외 에러는
   // 일시적일 수 있으니 계속 폴링한다.
   const pollBootstrap = (bootstrapId: string) => {
@@ -890,6 +945,29 @@ export default function Images() {
       setActionError((error as Error).message);
     } finally {
       setBusyAlias(null);
+    }
+  };
+
+  const handleRegister = async (event: FormEvent) => {
+    event.preventDefault();
+    const alias = registerAlias;
+    const version = registerVersion.trim();
+    if (!alias || !version || registerStarting || registerJob?.status === "running") return;
+    setRegisterStarting(true);
+    setRegisterError(null);
+    try {
+      const started = await startMicroRegistryRegister({ alias, version });
+      if (!mountedRef.current) return;
+      setRegisterJob((current) => keepNewestJobSnapshot(current, started));
+      if (started.status === "failed") {
+        setRegisterError(lastLogLine(started.log, t("Register failed.", "등록에 실패했습니다.")));
+      }
+      pollRegister(started.jobId);
+    } catch (error) {
+      if (!mountedRef.current) return;
+      setRegisterError(error instanceof ApiClientError ? error.message : (error as Error).message);
+    } finally {
+      if (mountedRef.current) setRegisterStarting(false);
     }
   };
 
@@ -1031,6 +1109,82 @@ export default function Images() {
             "공개된 M2Image 패키지입니다. 다운로드는 이 호스트에서 검증하고, 설치는 준비된 로컬 패키지를 등록합니다.",
           )}
         </p>
+        <form className="create-grid" onSubmit={(event) => void handleRegister(event)}>
+          <div className="field">
+            <label htmlFor="microregistry-register-alias">{t("Image", "이미지")}</label>
+            <select
+              id="microregistry-register-alias"
+              value={registerAlias}
+              onChange={(event) => setRegisterAlias(event.target.value)}
+              disabled={registerStarting || registerJob?.status === "running"}
+            >
+              <option value="">
+                {(images ?? []).some((image) => image.installed)
+                  ? t("Select an installed image", "설치된 이미지를 선택하세요")
+                  : t("No installed images", "설치된 이미지가 없습니다")}
+              </option>
+              {(images ?? []).filter((image) => image.installed).map((image) => (
+                <option key={image.alias} value={image.alias}>
+                  {image.alias}{image.version ? ` · ${image.version}` : ""}
+                </option>
+              ))}
+            </select>
+            <span className="field-error" aria-hidden />
+          </div>
+          <div className="field">
+            <label htmlFor="microregistry-register-version">{t("Version", "버전")}</label>
+            <input
+              id="microregistry-register-version"
+              name="version"
+              value={registerVersion}
+              onChange={(event) => setRegisterVersion(event.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+              disabled={registerStarting || registerJob?.status === "running"}
+            />
+            <span className="field-error" aria-hidden />
+          </div>
+          <div className="field">
+            <label htmlFor="microregistry-register-submit">&nbsp;</label>
+            <button
+              id="microregistry-register-submit"
+              className="btn"
+              type="submit"
+              disabled={!registerAlias || !registerVersion.trim() || registerStarting || registerJob?.status === "running"}
+            >
+              {registerStarting || registerJob?.status === "running"
+                ? t("Registering…", "등록 중…")
+                : t("Register", "등록")}
+            </button>
+            <span className="field-error" aria-hidden />
+          </div>
+        </form>
+        {registerError && (
+          <div style={{ margin: "1rem 0" }}>
+            <Banner kind="error" text={registerError} onDismiss={() => setRegisterError(null)} />
+          </div>
+        )}
+        {registerJob && registerJob.status !== "idle" && (
+          <>
+            <div className="subpanel">
+              <dl className="detail-fields mono">
+                <dt>{t("Register status", "등록 상태")}</dt>
+                <dd>
+                  <span className={`state-badge${jobStatusClass(registerJob.status)}`}>
+                    {registerJob.status === "running"
+                      ? t("Registering…", "등록 중…")
+                      : registerJob.status === "succeeded"
+                        ? t("Registered", "등록됨")
+                        : registerJob.status === "failed"
+                          ? t("Register failed", "등록 실패")
+                          : t("Idle", "대기")}
+                  </span>
+                </dd>
+              </dl>
+            </div>
+            <ImageJobLog job={registerJob} kind="register" />
+          </>
+        )}
         {registryError && <div className="field-error">{registryError}</div>}
         {registry === null && !registryError && (
           <div className="empty microregistry-empty">{t("Loading MicroRegistry…", "MicroRegistry 불러오는 중…")}</div>


### PR DESCRIPTION
## Summary

A host can **publish** an already-installed image into *its own* MicroRegistry catalog, then install that package again through the existing download → install path.

Consume already exists (`GET /api/microregistry` → package → install). This PR is the missing publish half on the dashboard. It is **not** “install registers a staged `.tar.zst`” (that already exists), and it is **not** the operator rclone push to `registry.firecrab.dev`.

This PR is **L1 Dashboard only**.

## Motivation

- #87 split inputs (Native / OCI / MicroBoot) from the **published catalog**. Only consume landed.
- #90 produces a local MicroImage (`nginx-1.27`) and left **pushing** out of scope. That image never appears in the MicroRegistry panel.
- `GET /api/microregistry` drops anything outside `known_spec`, so a custom alias cannot show up even if packaged by hand.
- Public R2 publish stays operator-only (`docs/microregistry/`). The API must not hold object-store credentials.

## Position

```text
#87 MicroImage (immutable rootfs.ext4)
├─ Native / MicroBoot          have
├─ OCI import           #90    have (local template only)
└─ MicroRegistry               published catalog
   ├─ Consume                  have  GET catalog → download → install
   └─ Register          this   template → package → catalog row
```

## Layers (this PR = L1)

```text
L1  Dashboard
    MicroRegistry panel: pick installed image → version → Register
    same table then shows the new row (Available / Package ready)

L2  API          (not this PR)
L3  Catalog      (not this PR)
L4  Package      (not this PR)
L5  Verify       (not this PR)
```

## What landed (L1)

- Register form on the existing MicroRegistry panel: select an installed image, set version, start a local catalog publish.
- Client: `POST /api/microregistry/register` `{alias, version}` → 202 `{jobId, alias, status, log, …}` and `GET /api/microregistry/jobs/{jobId}`.
- Reuse `Banner`, `div.field`, `ImageJobLog`, and `keepNewestJobSnapshot`. New copy is `t(en, ko)`.
- Success refreshes via existing `GET /api/microregistry` so the current table and Download / Install buttons show the new row.
- 409 / transport errors show a Banner and do not refresh the catalog or insert a row.

This PR does not add the register job backend, catalog persist, package build, kernel-arch verify, or any `registry.firecrab.dev` / R2 push.

## Acceptance (L1)

- From the MicroRegistry panel, registering an installed image (including an OCI import from #90) can start a job and show progress or a useful failure.
- After a successful job the existing Download / Install buttons work on that row (once L2–L5 exist). Until then the endpoints 404, which is expected for this slice.

## Out of scope

- L2 API, L3 catalog persist, L4 package build, L5 kernel-arch verify
- Push to `registry.firecrab.dev` / R2; object-store credentials in the API
- Private remote-registry auth
- Multi-arch publish from one host
- Applying an updated package to existing VM disks
- Replacing the operator rclone scripts

## Testing

- `npm run lint` in `firecrab-frontend` (0 errors; existing `i18n.tsx` Fast Refresh warning)
- `npx tsc -b` in `firecrab-frontend`

Related to #108.