### PR TITLE
feat(images): convert an OCI image into a bootable rootfs.ext4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,19 @@ npm run lint --prefix firecrab-frontend
 npm run build --prefix firecrab-frontend
 ```
 
+### OCI import browser E2E
+
+Isolated Playwright suite in `firecrab-e2e/`. It is not part of `cargo test --workspace`.
+
+```sh
+npm ci --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+That covers inspect → import against a local registry fixture (no Docker Hub).
+The guest-boot half needs KVM, Firecracker, and `./scripts/dev-net-helper.sh`; see [firecrab-e2e/README.md](firecrab-e2e/README.md).
+
 ### Docs and installer scripts
 
 ```sh
@@ -137,6 +150,7 @@ Keep bodies short (see [#55](https://github.com/SteelCrab/firecrab/issues/55), [
 2. Prefer a **focused branch** and a **focused PR** — one concern per change when practical.
 3. Describe **what** changed and **why**. Link issues if any.
 4. Include tests for bug fixes and new API behavior when it is practical without nested KVM.
+   OCI import UI changes should keep `FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e` green.
 5. Keep the default security model in mind (see below).
 
 ### Commit messages

--- a/README.ja.md
+++ b/README.ja.md
@@ -37,9 +37,10 @@ firecrab は、管理下の Linux ホストで隔離された
 - **隔離ネットワークの選択:** 明示的な **MicroNetwork** を作成し、各 VM を一つに配置します。
   IPv4・MAC・hostname は保持され、ネットワーク同士は隔離されます。VM ごとにインターネット許可
   または隔離の egress を選べます。
-- **イメージとディスクの管理:** テンプレートのインストール・削除、暫定 builder VM での対応
-  ディストリビューションのブートストラップ、設定済みストレージルートまたは登録済み
-  **MicroStorage** プールへの VM ディスク配置をサポートします。
+- **イメージとディスクの管理:** M2Image テンプレートのインストール・削除、レジストリからの
+  OCI イメージ import、暫定 builder VM での対応ディストリビューションのブートストラップ、
+  設定済みストレージルートまたは登録済み **MicroStorage** プールへの VM ディスク配置を
+  サポートします。
 - **状態の確認:** 英語・韓国語対応のダッシュボードで起動進捗、コンソールログ、ホスト状態を確認できます。
 - **ホスト権限を最小化:** API は非特権で動作し、独立した `firecrab-net-helper` はホストネットワークに
   必要な capability だけを持ちます。
@@ -162,14 +163,17 @@ cd firecrab
 **M2Image** の一覧には、イメージごとのサイズと `パッケージ準備完了`・`インストール済み` などの
 状態が表示されます。行を選択すると、別名、バージョン、最小ディスク、rootfs サイズ、状態、その
 イメージを使う VM を確認できます。`…` メニューには状態に応じて、パッケージのインストール、
-イメージの取り込み、ブートストラップ、削除が表示されます。VM 作成に使えるのはインストール済みの
-イメージだけです。
+ブートストラップ、削除が表示されます。VM 作成に使えるのはインストール済みのイメージだけです。
+
+同じ画面で OCI 参照（`nginx:1.27`）がこのホストのアーキテクチャに合うかを検査し、
+テンプレートとして import できます。import はバックグラウンドジョブで、進捗・エラー・
+登録された別名をページに出します。
 
 ![M2Image の一覧](assets/dashboard/images.png)
 
 リクエスト形式、ライフサイクルの意味、エラー envelope は[API ガイド](public-docs/api.md)を、
-イメージパッケージとブラウザ主導のブートストラップは[イメージガイド](public-docs/images.md)
-を参照してください。
+イメージパッケージとブラウザ主導のブートストラップは[イメージガイド](public-docs/images.md)を、
+OCI の inspect と import は [OCI イメージガイド](public-docs/oci.md) を参照してください。
 
 ## ソースから開発
 
@@ -207,6 +211,19 @@ Rust のテストスイートは次で実行します。
 ```sh
 cargo test --workspace
 ```
+
+OCI inspect → import のブラウザ E2E（ローカルレジストリ fixture、Docker Hub なし）:
+
+```sh
+npm install --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+期待値は 1 passed、1 skipped です。
+skipped のテストは VM を作って起動します。フラグなしの `npm test --prefix firecrab-e2e` には
+KVM、Firecracker、`./scripts/dev-net-helper.sh` が必要です。
+詳細は [firecrab-e2e/README.md](firecrab-e2e/README.md) を見てください。
 
 開発時の注意点とブラウザのワークフローは[Web ダッシュボードガイド](public-docs/dashboard.md)にあります。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -36,8 +36,9 @@ microVM 환경을 위한 도구입니다. 호스팅 서비스나 멀티 호스�
 - **격리 네트워크 선택:** 명시적 **MicroNetwork**를 만들고 VM을 하나에 배치합니다. IPv4,
   MAC, hostname은 유지되며 네트워크끼리는 격리됩니다. VM별 인터넷 허용 또는 격리 egress를
   선택할 수 있습니다.
-- **이미지·디스크 관리:** 템플릿 설치·삭제, 임시 builder VM에서 지원 배포판 부트스트랩,
-  설정된 저장소 루트 또는 **MicroStorage** 풀에 VM 디스크 배치를 지원합니다.
+- **이미지·디스크 관리:** M2Image 템플릿 설치·삭제, 레지스트리에서 OCI 이미지 import,
+  임시 builder VM에서 지원 배포판 부트스트랩, 설정된 저장소 루트 또는 **MicroStorage**
+  풀에 VM 디스크 배치를 지원합니다.
 - **상태 확인:** 대시보드에서 시작 진행 상황, 콘솔 로그, 호스트 상태를 확인합니다. 대시보드는
   영어와 한국어를 지원합니다.
 - **작은 권한 범위:** API는 비특권으로 실행하며, 별도 `firecrab-net-helper`가 호스트
@@ -158,13 +159,18 @@ VM을 생성합니다. 아래 목록은 상태, 이미지, 리소스, ID를 3초
 
 **M2Image** 목록은 이미지별 크기와 `패키지 준비됨`·`설치됨` 같은 상태를 표시합니다. 행을 선택하면
 별칭, 버전, 최소 디스크, rootfs 크기, 상태와 해당 이미지를 사용하는 VM을 확인할 수 있습니다.
-오른쪽 `…` 메뉴에서는 상태에 따라 패키지 설치, 이미지 가져오기, 부트스트랩 또는 삭제 작업을
-수행합니다. VM 생성에는 설치된 이미지만 사용할 수 있습니다.
+오른쪽 `…` 메뉴에서는 상태에 따라 패키지 설치, 부트스트랩 또는 삭제 작업을 수행합니다.
+VM 생성에는 설치된 이미지만 사용할 수 있습니다.
+
+같은 화면에서 OCI 레퍼런스(`nginx:1.27`)가 이 호스트 아키텍처와 맞는지 검사한 뒤
+템플릿으로 import할 수 있습니다. import는 백그라운드 작업이며, 진행 상황·오류·등록된
+별칭을 페이지에서 보여 줍니다.
 
 ![M2Image 목록 화면](assets/dashboard/images.png)
 
 요청 형식, 생명주기 의미, 오류 envelope는 [API 가이드](public-docs/api.md)를, 이미지 패키지와
-브라우저 부트스트랩은 [이미지 가이드](public-docs/images.md)를 참고하세요.
+브라우저 부트스트랩은 [이미지 가이드](public-docs/images.md)를, OCI inspect·import는
+[OCI 이미지 가이드](public-docs/oci.md)를 참고하세요.
 
 ## 소스에서 개발
 
@@ -202,6 +208,19 @@ Rust 테스트는 다음처럼 실행합니다.
 ```sh
 cargo test --workspace
 ```
+
+OCI inspect → import 브라우저 E2E(로컬 레지스트리 fixture, Docker Hub 없음):
+
+```sh
+npm install --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+기대 결과는 1 passed, 1 skipped입니다.
+skip된 테스트는 VM을 만들어 부팅합니다. 플래그 없이 `npm test --prefix firecrab-e2e`를
+쓰려면 KVM, Firecracker, `./scripts/dev-net-helper.sh`가 필요합니다.
+자세한 내용은 [firecrab-e2e/README.md](firecrab-e2e/README.md)를 보세요.
 
 더 많은 개발 노트와 브라우저 워크플로는 [웹 대시보드 가이드](public-docs/dashboard.md)에 있습니다.
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ full cloud control plane. It is not a hosted service or a multi-host scheduler.
 - **Choose an isolated network:** create explicit **MicroNetworks**; each VM belongs
   to one network and receives a persistent IPv4, MAC, and hostname. Networks are
   isolated from one another, with per-VM internet or isolated egress.
-- **Manage images and disks:** install or remove templates, bootstrap supported
-  distributions in a temporary builder VM, and place VM disks on configured storage
-  roots or registered **MicroStorage** pools.
+- **Manage images and disks:** install M2Image templates, import an OCI image from a
+  registry, bootstrap supported distributions in a temporary builder VM, and place
+  VM disks on configured storage roots or registered **MicroStorage** pools.
 - **See what is happening:** inspect startup progress, console logs, and host status
   in the dashboard, available in English and Korean.
 - **Keep host privileges small:** the API runs unprivileged; the separate
@@ -166,14 +166,18 @@ member VM details.
 The **M2Image** list shows each image's size and state, such as `Package ready` or
 `Installed`. Select a row to inspect its alias, version, minimum disk, rootfs size,
 state, and the VMs that use it. The `…` menu offers state-appropriate package install,
-image import, bootstrap, or delete actions. Only installed images can be used to
-create VMs.
+bootstrap, or delete actions. Only installed images can be used to create VMs.
+
+The same screen can inspect an OCI reference (`nginx:1.27`) for this host's
+architecture and import it as a registered template. Import is a background job;
+the page shows progress, errors, and the registered alias when it finishes.
 
 ![M2Image list](assets/dashboard/images.png)
 
 For API request formats, lifecycle semantics, and error envelopes, see the
 [API guide](public-docs/api.md). For image packages and browser-driven bootstrap,
-see the [image guide](public-docs/images.md).
+see the [image guide](public-docs/images.md). For OCI inspect and import, see the
+[OCI image guide](public-docs/oci.md).
 
 ## Develop from source
 
@@ -211,6 +215,18 @@ Run the Rust test suite with:
 ```sh
 cargo test --workspace
 ```
+
+Browser E2E for OCI inspect → import (local registry fixture, no Docker Hub):
+
+```sh
+npm install --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+That command expects 1 passed and 1 skipped.
+The skipped test creates and boots a VM; run `npm test --prefix firecrab-e2e` without the flag on a KVM host with Firecracker and `./scripts/dev-net-helper.sh`.
+See [firecrab-e2e/README.md](firecrab-e2e/README.md).
 
 More development notes and browser workflow details are in the [web dashboard guide](public-docs/dashboard.md).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,8 +34,8 @@ firecrab 在你管理的 Linux 主机上运行和管理隔离的
   浏览器串口控制台。
 - **选择隔离网络：** 创建显式 **MicroNetwork**，每台 VM 都放入其中之一。IPv4、MAC 和
   hostname 会保留；网络彼此隔离，并可为每台 VM 选择互联网或隔离 egress。
-- **管理镜像与磁盘：** 安装或删除模板，在临时 builder VM 中引导支持的发行版，并将 VM 磁盘
-  放在配置的存储根目录或已注册的 **MicroStorage** 池中。
+- **管理镜像与磁盘：** 安装或删除 M2Image 模板，从仓库导入 OCI 镜像，在临时 builder VM
+  中引导支持的发行版，并将 VM 磁盘放在配置的存储根目录或已注册的 **MicroStorage** 池中。
 - **了解运行状态：** 在英文或韩文仪表盘中查看启动进度、控制台日志和主机状态。
 - **缩小主机权限：** API 以非特权方式运行；独立的 `firecrab-net-helper` 仅持有主机网络
   所需的 capability。
@@ -150,12 +150,16 @@ ID；可通过 **阻止互联网/启用互联网** 改变整个网络经 NAT 的
 
 **M2Image** 列表显示每个镜像的大小及 `软件包已就绪`、`已安装` 等状态。选择一行可查看其别名、
 版本、最小磁盘、rootfs 大小、状态以及正在使用该镜像的 VM。`…` 菜单会根据状态提供软件包安装、
-镜像导入、引导或删除操作。只有已安装的镜像可以用于创建 VM。
+引导或删除操作。只有已安装的镜像可以用于创建 VM。
+
+同一页面还可以检查 OCI 引用（`nginx:1.27`）是否匹配本机架构，并将其导入为模板。
+导入在后台进行，页面会显示进度、错误以及注册后的别名。
 
 ![M2Image 列表](assets/dashboard/images.png)
 
 请求格式、生命周期语义和错误 envelope 见 [API 指南](public-docs/api.md)。镜像包与浏览器引导
-流程见[镜像指南](public-docs/images.md)。
+流程见[镜像指南](public-docs/images.md)。OCI 检查与导入见
+[OCI 镜像指南](public-docs/oci.md)。
 
 ## 从源码开发
 
@@ -193,6 +197,19 @@ FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
 ```sh
 cargo test --workspace
 ```
+
+OCI 检查 → 导入的浏览器 E2E（本地仓库 fixture，不访问 Docker Hub）：
+
+```sh
+npm install --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+预期为 1 passed、1 skipped。
+被跳过的测试会创建并启动 VM。去掉该标志运行 `npm test --prefix firecrab-e2e` 需要
+KVM、Firecracker 和 `./scripts/dev-net-helper.sh`。
+详见 [firecrab-e2e/README.md](firecrab-e2e/README.md)。
 
 更多开发说明和浏览器工作流见[网页仪表盘指南](public-docs/dashboard.md)。
 

--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -870,6 +870,40 @@ pub struct ImageInstallResponse {
     pub total_bytes: Option<u64>,
 }
 
+/// What `GET /api/oci/inspect` resolved a reference to on this host.
+///
+/// Metadata only: the response names the manifest this host would pull and
+/// the alias `POST /api/oci/import` will claim. It does not start an import.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OciInspectResponse {
+    /// Registry host the reference resolved to.
+    pub registry: String,
+    /// Repository path, with Docker Hub's implicit `library/` filled in.
+    pub repository: String,
+    /// The tag or digest that was resolved.
+    pub version: String,
+    /// Whether that version can never be repointed at other content.
+    pub immutable: bool,
+    /// Digest of the manifest this host would pull.
+    pub digest: String,
+    /// The architecture that manifest runs, as a catalog label.
+    pub architecture: String,
+    /// True when the registry answered with a manifest rather than an index,
+    /// so no per-platform selection took place.
+    pub single_platform: bool,
+    /// Template alias `POST /api/oci/import` will claim for this reference.
+    pub alias: String,
+}
+
+/// Request body for `POST /api/oci/import`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OciImportRequest {
+    /// An image reference as typed at a `docker pull`, e.g. `nginx:1.27`.
+    pub reference: String,
+}
+
 /// Lifecycle of one from-scratch distro bootstrap session (`handlers::bootstrap`).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1260,6 +1294,41 @@ mod tests {
             "http://127.0.0.1:8765/ubuntu-26.04.tar.zst"
         );
         assert!(json.get("initrdSha256").is_none());
+    }
+
+    #[test]
+    fn oci_inspect_response_serializes_camel_case() {
+        let response = OciInspectResponse {
+            registry: "registry-1.docker.io".to_owned(),
+            repository: "library/nginx".to_owned(),
+            version: "1.27".to_owned(),
+            immutable: false,
+            digest: format!("sha256:{}", "a".repeat(64)),
+            architecture: "x86_64".to_owned(),
+            single_platform: false,
+            alias: "nginx-1.27".to_owned(),
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["singlePlatform"], false);
+        assert_eq!(json["alias"], "nginx-1.27");
+        assert_eq!(json["immutable"], false);
+        assert_eq!(
+            serde_json::from_value::<OciInspectResponse>(json).unwrap(),
+            response
+        );
+    }
+
+    #[test]
+    fn oci_import_request_round_trips_camel_case() {
+        let request = OciImportRequest {
+            reference: "nginx:1.27".to_owned(),
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(json, r#"{"reference":"nginx:1.27"}"#);
+        assert_eq!(
+            serde_json::from_str::<OciImportRequest>(&json).unwrap(),
+            request
+        );
     }
 
     #[test]

--- a/firecrab-api/src/handlers/oci.rs
+++ b/firecrab-api/src/handlers/oci.rs
@@ -1,18 +1,26 @@
-//! `GET /api/oci/inspect`: answer whether an OCI image can run on this host,
-//! before anything is downloaded.
+//! OCI inspect and import (`public-docs/oci.md`).
 //!
-//! Import itself (layer merge, whiteouts, guest enablement) is separate work;
-//! this endpoint only resolves a reference to the manifest this host would
-//! pull, so a wrong-architecture image is caught at the point a user types it.
+//! `GET /api/oci/inspect` is metadata-only: it resolves a reference to the
+//! manifest this host would pull so a wrong-architecture image is caught
+//! before any download. `POST /api/oci/import` claims the derived alias and
+//! runs the already-landed pipeline as an image-install job,
+//! because REST requests time out at 10s. Poll `GET /api/oci/import/{alias}`.
 
 use axum::Json;
-use axum::extract::Query;
-use serde::{Deserialize, Serialize};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use firecrab_api_types::{ImageInstallResponse, OciImportRequest, OciInspectResponse};
+use serde::Deserialize;
 
 use crate::error::AppError;
+use crate::extract::ValidatedJson;
 use crate::image_install::Architecture;
-use crate::oci::{ImageReference, is_loopback_registry, resolve};
+use crate::oci::{
+    ImageReference, ResolveError, claim_template_name, is_loopback_registry, resolve,
+    run_oci_import, template_name_from_reference,
+};
 use crate::server::RequestId;
+use crate::state::AppState;
 
 /// Query string for [`inspect_oci_image`].
 #[derive(Debug, Deserialize)]
@@ -21,38 +29,15 @@ pub struct InspectQuery {
     reference: String,
 }
 
-/// What this host resolved the reference to.
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InspectResponse {
-    /// Registry host the reference resolved to.
-    pub registry: String,
-    /// Repository path, with Docker Hub's implicit `library/` filled in.
-    pub repository: String,
-    /// The tag or digest that was resolved.
-    pub version: String,
-    /// Whether that version can never be repointed at other content.
-    pub immutable: bool,
-    /// Digest of the manifest this host would pull.
-    pub digest: String,
-    /// The architecture that manifest runs, as a registry label.
-    pub architecture: String,
-    /// True when the registry answered with a manifest rather than an index,
-    /// so no per-platform selection took place.
-    pub single_platform: bool,
-}
-
 /// `GET /api/oci/inspect?reference=nginx:1.27`.
 pub async fn inspect_oci_image(
     axum::Extension(request_id): axum::Extension<RequestId>,
     Query(query): Query<InspectQuery>,
-) -> Result<Json<InspectResponse>, AppError> {
-    let reference = ImageReference::parse(&query.reference).map_err(|error| {
-        AppError::validation(
-            [("reference".to_owned(), error.to_string())].into(),
-            request_id.0,
-        )
-    })?;
+) -> Result<Json<OciInspectResponse>, AppError> {
+    let reference = parse_reference(&query.reference, request_id.0)?;
+    let alias = template_name_from_reference(&reference)
+        .map_err(|error| validation_reference(error.to_string(), request_id.0))?
+        .alias;
 
     let insecure = is_loopback_registry(&reference.registry);
     let resolved = resolve(&reference, Architecture::HOST, insecure)
@@ -64,13 +49,10 @@ pub async fn inspect_oci_image(
                 error = %error,
                 "OCI image inspection failed"
             );
-            AppError::validation(
-                [("reference".to_owned(), error.to_string())].into(),
-                request_id.0,
-            )
+            validation_reference(error.to_string(), request_id.0)
         })?;
 
-    Ok(Json(InspectResponse {
+    Ok(Json(OciInspectResponse {
         registry: reference.registry,
         repository: reference.repository,
         version: reference.version.as_str().to_owned(),
@@ -78,19 +60,91 @@ pub async fn inspect_oci_image(
         digest: resolved.digest,
         architecture: resolved.architecture.as_str().to_owned(),
         single_platform: resolved.single_platform,
+        alias,
     }))
+}
+
+/// `POST /api/oci/import` — claim the alias and start the import job.
+pub async fn start_oci_import(
+    State(state): State<AppState>,
+    axum::Extension(request_id): axum::Extension<RequestId>,
+    ValidatedJson(body): ValidatedJson<OciImportRequest>,
+) -> Result<(StatusCode, Json<ImageInstallResponse>), AppError> {
+    let reference = parse_reference(&body.reference, request_id.0)?;
+    let named = match claim_template_name(&reference, &state.templates) {
+        Ok(named) => named,
+        Err(ResolveError::AliasCollision { .. }) => {
+            return Err(AppError::conflict(
+                "alias_collision",
+                "derived alias collides with a catalog or installed image",
+                request_id.0,
+            ));
+        }
+        Err(error) => return Err(validation_reference(error.to_string(), request_id.0)),
+    };
+
+    let response = match state.oci_imports.begin_with(&named.alias, "import started") {
+        Ok(snapshot) => snapshot,
+        Err("running") => {
+            return Err(AppError::conflict(
+                "import_in_progress",
+                "an import is already running for this image",
+                request_id.0,
+            ));
+        }
+        Err(_) => return Err(AppError::internal(request_id.0)),
+    };
+
+    let tracker = state.oci_imports.clone();
+    let templates = (*state.templates).clone();
+    let alias = named.alias.clone();
+    tokio::spawn(async move {
+        run_oci_import(tracker, templates, reference, alias).await;
+    });
+
+    Ok((StatusCode::ACCEPTED, Json(response)))
+}
+
+/// `GET /api/oci/import/{alias}` — latest import snapshot, including idle.
+pub async fn get_oci_import(
+    State(state): State<AppState>,
+    Path(alias): Path<String>,
+    axum::Extension(_request_id): axum::Extension<RequestId>,
+) -> Result<Json<ImageInstallResponse>, AppError> {
+    Ok(Json(state.oci_imports.snapshot(&alias)))
+}
+
+fn parse_reference(reference: &str, request_id: uuid::Uuid) -> Result<ImageReference, AppError> {
+    ImageReference::parse(reference)
+        .map_err(|error| validation_reference(error.to_string(), request_id))
+}
+
+fn validation_reference(message: String, request_id: uuid::Uuid) -> AppError {
+    AppError::validation([("reference".to_owned(), message)].into(), request_id)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extract::ValidatedJson;
     use crate::server::RequestId;
-    use axum::extract::Query;
+    use crate::state::AppState;
+    use crate::templates::TemplateRegistry;
+    use axum::Json;
+    use axum::extract::{Path, Query, State};
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
+    use firecrab_api_types::{ImageInstallStatus, OciImportRequest};
     use sha2::{Digest, Sha256};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    async fn empty_state(root: &std::path::Path) -> AppState {
+        let templates = TemplateRegistry::from_specs(root, std::iter::empty()).unwrap();
+        AppState::with_db_file(templates, root.join("state.db"))
+            .await
+            .unwrap()
+    }
 
     /// A reference the parser rejects must never reach the network: a typo
     /// should answer immediately, not after a registry timeout.
@@ -222,10 +276,157 @@ mod tests {
         assert_eq!(response.digest, selected_digest);
         assert_eq!(response.repository, "team/app");
         assert_eq!(response.architecture, Architecture::HOST.as_str());
+        assert_eq!(response.alias, format!("127.0.0.1-{port}-team-app-v1"));
         assert!(!response.immutable);
         assert!(!response.single_platform);
         assert_eq!(tag_requests.load(Ordering::SeqCst), 1);
         assert_eq!(selected_manifest_requests.load(Ordering::SeqCst), 1);
         assert_eq!(blob_requests.load(Ordering::SeqCst), 0);
+    }
+
+    /// A parsable unused loopback reference is accepted immediately as a job.
+    /// The pipeline is not waited on: REST would time out if it did.
+    #[tokio::test]
+    async fn start_oci_import_accepts_an_unused_loopback_reference() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let (status, Json(response)) = start_oci_import(
+            State(state.clone()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(OciImportRequest {
+                reference: "127.0.0.1:1/team/app:v1".to_owned(),
+            }),
+        )
+        .await
+        .expect("parsable unused reference must be accepted");
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(response.alias, "127.0.0.1-1-team-app-v1");
+        assert_eq!(response.status, ImageInstallStatus::Running);
+
+        let Json(snapshot) = get_oci_import(
+            State(state),
+            Path("127.0.0.1-1-team-app-v1".to_owned()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+        )
+        .await
+        .expect("accepted job must have a snapshot");
+        assert_eq!(snapshot.alias, "127.0.0.1-1-team-app-v1");
+        assert_eq!(snapshot.status, ImageInstallStatus::Running);
+    }
+
+    /// A parser rejection must not start a job: a typo should fail before
+    /// any alias is claimed or any pipeline work is spawned.
+    #[tokio::test]
+    async fn start_oci_import_rejects_an_unparsable_reference_without_a_job() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let error = start_oci_import(
+            State(state.clone()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(OciImportRequest {
+                reference: "NGINX".to_owned(),
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        let response = error.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "validation_failed");
+        assert!(!state.oci_imports.is_running("NGINX"));
+        assert_eq!(
+            state.oci_imports.snapshot("NGINX").status,
+            ImageInstallStatus::Idle
+        );
+    }
+
+    #[tokio::test]
+    async fn start_oci_import_rejects_a_catalog_alias_collision() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let error = start_oci_import(
+            State(state.clone()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(OciImportRequest {
+                reference: "ubuntu:26.04".to_owned(),
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.into_response().status(), StatusCode::CONFLICT);
+        assert_eq!(
+            state.oci_imports.snapshot("ubuntu-26.04").status,
+            ImageInstallStatus::Idle
+        );
+    }
+
+    #[tokio::test]
+    async fn start_oci_import_rejects_a_second_job_for_the_same_alias() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let body = OciImportRequest {
+            reference: "127.0.0.1:1/team/app:v1".to_owned(),
+        };
+        let _started = start_oci_import(
+            State(state.clone()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(body.clone()),
+        )
+        .await
+        .expect("first job");
+
+        let error = start_oci_import(
+            State(state),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(body),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.into_response().status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn a_started_import_finishes_failed_when_the_registry_cannot_be_reached() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let (_, Json(started)) = start_oci_import(
+            State(state.clone()),
+            axum::Extension(RequestId(uuid::Uuid::new_v4())),
+            ValidatedJson(OciImportRequest {
+                reference: "127.0.0.1:1/team/app:v1".to_owned(),
+            }),
+        )
+        .await
+        .expect("job accepted");
+
+        let mut snapshot = state.oci_imports.snapshot(&started.alias);
+        for _ in 0..80 {
+            if snapshot.status == ImageInstallStatus::Failed {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            snapshot = state.oci_imports.snapshot(&started.alias);
+        }
+        assert_eq!(snapshot.status, ImageInstallStatus::Failed);
+        assert!(
+            snapshot.log.contains("import failed"),
+            "failed job must record why: {}",
+            snapshot.log
+        );
+        assert!(
+            !state
+                .templates
+                .image_root_path()
+                .join(".oci/import")
+                .join(&started.alias)
+                .exists(),
+            "scratch must be removed after failure"
+        );
     }
 }

--- a/firecrab-api/src/image_install.rs
+++ b/firecrab-api/src/image_install.rs
@@ -256,14 +256,17 @@ impl ImageInstallTracker {
     }
 
     pub fn finish_err(&self, alias: &str, detail: impl Into<String>) {
+        self.finish_err_with(alias, format!("install failed: {}", detail.into()));
+    }
+
+    /// Mark a job failed with a caller-owned terminal message.
+    /// OCI import reuses this tracker but must not claim an image *install*
+    /// failed when the pipeline never ran that phase.
+    pub fn finish_err_with(&self, alias: &str, message: impl Into<String>) {
         let mut jobs = self.jobs.lock().unwrap_or_else(|p| p.into_inner());
         if let Some(job) = jobs.get_mut(alias) {
             let now = now_ms();
-            job.log.push(format!(
-                "[{}] install failed: {}",
-                clock(now),
-                detail.into()
-            ));
+            job.log.push(format!("[{}] {}", clock(now), message.into()));
             job.status = ImageInstallStatus::Failed;
             job.ended_at_ms = Some(now);
         }

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -19,7 +19,8 @@ use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, BufReader, ReadBuf};
 use tokio::sync::{Mutex as AsyncMutex, Semaphore};
 use uuid::Uuid;
 
-use crate::image_install::Architecture;
+use crate::image_install::{Architecture, ImageInstallTracker};
+use crate::templates::TemplateRegistry;
 
 /// The OS every Firecrab guest runs. Windows and BSD entries in a multi-OS
 /// index are never candidates.
@@ -3007,6 +3008,138 @@ pub fn install_oci_service(
     process: &OciProcessConfig,
 ) -> Result<(), ResolveError> {
     service::install_oci_service(rootfs, process)
+}
+
+/// Builds the candidate alias and version without consulting the registry.
+pub fn template_name_from_reference(
+    reference: &ImageReference,
+) -> Result<OciTemplateName, ResolveError> {
+    name::template_name_from_reference(reference)
+}
+
+/// Derives the name and refuses it when an installed or reserved alias exists.
+pub fn claim_template_name(
+    reference: &ImageReference,
+    templates: &TemplateRegistry,
+) -> Result<OciTemplateName, ResolveError> {
+    name::claim_template_name(reference, templates)
+}
+
+/// Runs the already-landed import stages as one background job.
+///
+/// Scratch lives at `{image_root}/.oci/import/{alias}/` and is removed when
+/// the job finishes, whether it succeeded or failed. Verified blob and
+/// decompressed-layer caches stay in place.
+pub async fn run_oci_import(
+    tracker: ImageInstallTracker,
+    templates: TemplateRegistry,
+    reference: ImageReference,
+    alias: String,
+) {
+    if let Err(error) = import_oci_image(&tracker, &templates, &reference, &alias).await {
+        tracker.finish_err_with(&alias, format!("import failed: {error}"));
+        return;
+    }
+    tracker.finish_ok_with(&alias, "import succeeded — template registered");
+}
+
+async fn import_oci_image(
+    tracker: &ImageInstallTracker,
+    templates: &TemplateRegistry,
+    reference: &ImageReference,
+    alias: &str,
+) -> Result<(), ResolveError> {
+    let image_root = templates.image_root_path();
+    let scratch = image_root.join(".oci/import").join(alias);
+    reset_import_scratch(&scratch).await?;
+
+    let result =
+        import_oci_image_in_scratch(tracker, templates, reference, alias, image_root, &scratch)
+            .await;
+    if let Err(error) = tokio::fs::remove_dir_all(&scratch).await
+        && error.kind() != io::ErrorKind::NotFound
+    {
+        tracing::warn!(
+            alias,
+            path = %scratch.display(),
+            error = %error,
+            "failed to remove OCI import scratch"
+        );
+    }
+    result
+}
+
+async fn reset_import_scratch(scratch: &Path) -> Result<(), ResolveError> {
+    match tokio::fs::remove_dir_all(scratch).await {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(cache_io("remove import scratch", scratch.to_owned(), error));
+        }
+    }
+    tokio::fs::create_dir_all(scratch)
+        .await
+        .map_err(|error| cache_io("create import scratch", scratch.to_owned(), error))
+}
+
+async fn import_oci_image_in_scratch(
+    tracker: &ImageInstallTracker,
+    templates: &TemplateRegistry,
+    reference: &ImageReference,
+    alias: &str,
+    image_root: &Path,
+    scratch: &Path,
+) -> Result<(), ResolveError> {
+    let insecure = is_loopback_registry(&reference.registry);
+    let blobs = BlobCache::new(image_root);
+    let layers = LayerCache::new(image_root);
+
+    tracker.append_log(alias, "caching image blobs");
+    let cached = cache_image_blobs(reference, Architecture::HOST, insecure, &blobs).await?;
+
+    tracker.append_log(alias, "reading image process config");
+    let process = read_cached_process_config(&cached).await?;
+
+    tracker.append_log(alias, "decompressing layers");
+    let decompressed = decompress_cached_layers(&cached, &layers).await?;
+
+    tracker.append_log(alias, "validating layer archives");
+    let validated = validate_decompressed_layers(decompressed).await?;
+
+    tracker.append_log(alias, "merging layers");
+    let merged = merge_validated_layers(&validated, &scratch.join("rootfs")).await?;
+
+    tracker.append_log(alias, "provisioning guest runtime");
+    let options = GuestRuntimeOptions {
+        image_root,
+        blobs: &blobs,
+        layers: &layers,
+        architecture: cached.resolved.architecture,
+    };
+    let provisioned = provision_merged_rootfs(merged, &options).await?;
+
+    tracker.append_log(alias, "installing image service");
+    install_oci_service(&provisioned, &process)?;
+
+    tracker.append_log(alias, "writing ext4 image");
+    let ext4 = write_provisioned_ext4(&provisioned, &scratch.join("rootfs.ext4")).await?;
+
+    tracker.append_log(alias, "pairing host kernel");
+    let bootable = pair_ext4_with_host_kernel(ext4, image_root)?;
+
+    tracker.append_log(alias, "naming and registering template");
+    let named = name_oci_image(bootable, reference, templates)?;
+    register_named_oci_image(named, templates)?;
+    Ok(())
+}
+
+async fn read_cached_process_config(
+    cached: &CachedImageBlobs,
+) -> Result<OciProcessConfig, ResolveError> {
+    let bytes = tokio::fs::read(&cached.config.path)
+        .await
+        .map_err(|error| cache_io("read config", cached.config.path.clone(), error))?;
+    OciProcessConfig::from_image_config(&bytes)
 }
 
 async fn validate_layer_archive(layer: &DecompressedLayer) -> Result<(), ResolveError> {

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -1148,13 +1148,13 @@ impl RegistrySession {
             let issued = read_token_body(response).await?;
             let issued: TokenResponse = serde_json::from_slice(&issued)
                 .map_err(|error| ResolveError::Authentication(error.to_string()))?;
-            if issued.token.is_empty() {
+            let Some(token) = issued.issued().map(str::to_owned) else {
                 return Err(ResolveError::Authentication(
                     "token endpoint returned an empty token".to_owned(),
                 ));
-            }
-            *stored = Some(issued.token.clone());
-            issued.token
+            };
+            *stored = Some(token.clone());
+            token
         };
         drop(stored);
 
@@ -1957,6 +1957,9 @@ mod service;
 
 #[cfg(test)]
 mod service_tests;
+
+#[cfg(test)]
+pub(crate) mod registry_fixture;
 
 /// One verified cache entry together with the descriptor that named it.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3872,10 +3875,28 @@ async fn cache_image_blobs_with_parallelism(
 }
 
 /// A registry token endpoint's answer.
+///
+/// The distribution spec allows `token` and `access_token`. Docker Hub
+/// sends both with the same value. A serde `alias` would treat that as a
+/// duplicate field and reject the body.
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
-    #[serde(alias = "access_token")]
-    token: String,
+    #[serde(default)]
+    token: Option<String>,
+    #[serde(default)]
+    access_token: Option<String>,
+}
+
+impl TokenResponse {
+    /// The bearer secret to send back to the registry.
+    fn issued(&self) -> Option<&str> {
+        let token = self.token.as_deref().filter(|value| !value.is_empty());
+        let access = self
+            .access_token
+            .as_deref()
+            .filter(|value| !value.is_empty());
+        token.or(access)
+    }
 }
 
 /// One path component, per the distribution spec: lowercase alphanumerics
@@ -4094,7 +4115,20 @@ mod tests {
         let response: TokenResponse =
             serde_json::from_slice(br#"{"access_token":"issued-token"}"#).unwrap();
 
-        assert_eq!(response.token, "issued-token");
+        assert_eq!(response.issued().unwrap(), "issued-token");
+    }
+
+    /// Docker Hub's auth.docker.io answers with both `token` and
+    /// `access_token`. Treating the latter as a serde alias for the former
+    /// rejects that body as a duplicate field.
+    #[test]
+    fn token_response_accepts_token_and_access_token_together() {
+        let response: TokenResponse = serde_json::from_slice(
+            br#"{"token":"issued-token","access_token":"issued-token","expires_in":300}"#,
+        )
+        .expect("Docker Hub sends both names");
+
+        assert_eq!(response.issued().unwrap(), "issued-token");
     }
 
     #[tokio::test]

--- a/firecrab-api/src/oci/provision.rs
+++ b/firecrab-api/src/oci/provision.rs
@@ -25,7 +25,14 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// `root=/dev/vda rw` command line every template already uses.
 const GUEST_INIT: &str = "/sbin/init";
 /// Guest path of the injected toolbox program.
-const GUEST_TOOLBOX: &str = "/sbin/firecrab-busybox";
+///
+/// The last component **must** be `busybox`. busybox is a multi-call binary:
+/// `argv[0]`'s basename is the applet. A name such as `firecrab-busybox` is
+/// not an applet, so every inittab and shebang invocation prints
+/// `firecrab-busybox: applet not found` and DHCP never runs. The path lives
+/// under `/etc/firecrab/` so an image that already ships `/bin/busybox` or
+/// `/sbin/busybox` keeps its own copy.
+pub(crate) const GUEST_TOOLBOX: &str = "/etc/firecrab/busybox";
 /// busybox init reads its job table from here.
 const GUEST_INITTAB: &str = "/etc/inittab";
 /// Boot script run once, before anything else the guest does.
@@ -164,7 +171,7 @@ fn inject_blocking(
 
         control.check()?;
         install_program(tree, GUEST_TOOLBOX, toolbox.path(), &mut unwind)?;
-        install_symlink(tree, GUEST_INIT, "firecrab-busybox", &mut unwind)?;
+        install_symlink(tree, GUEST_INIT, GUEST_TOOLBOX, &mut unwind)?;
 
         control.check()?;
         install_file(
@@ -184,7 +191,7 @@ fn inject_blocking(
         install_file(
             tree,
             GUEST_DHCP_SCRIPT,
-            DHCP_SCRIPT.as_bytes(),
+            dhcp_script().as_bytes(),
             0o755,
             &mut unwind,
         )?;
@@ -611,9 +618,11 @@ exit 0
 ///
 /// The lease arrives in the environment, not in arguments. `mask` is a prefix
 /// length in busybox, unlike the dotted `subnet` beside it.
-const DHCP_SCRIPT: &str = r#"#!/sbin/firecrab-busybox sh
+fn dhcp_script() -> String {
+    format!(
+        r#"#!{GUEST_TOOLBOX} sh
 # Firecrab guest DHCP hook for an imported OCI image (public-docs/oci.md).
-BB=/sbin/firecrab-busybox
+BB={GUEST_TOOLBOX}
 
 case "$1" in
   deconfig)
@@ -622,7 +631,7 @@ case "$1" in
     ;;
   bound|renew)
     $BB ip addr flush dev "$interface" 2>/dev/null
-    $BB ip addr add "$ip/${mask:-24}" dev "$interface" 2>/dev/null
+    $BB ip addr add "$ip/${{mask:-24}}" dev "$interface" 2>/dev/null
     $BB ip link set "$interface" up 2>/dev/null
     for gateway in $router; do
       $BB ip route add default via "$gateway" dev "$interface" 2>/dev/null
@@ -638,4 +647,6 @@ case "$1" in
     ;;
 esac
 exit 0
-"#;
+"#
+    )
+}

--- a/firecrab-api/src/oci/provision_tests.rs
+++ b/firecrab-api/src/oci/provision_tests.rs
@@ -210,15 +210,18 @@ async fn injecting_a_guest_installs_an_init_the_stock_kernel_command_line_finds(
     // The kernel execs /sbin/init when the command line carries no init=.
     assert_eq!(
         std::fs::read_link(tree.join("sbin/init")).expect("read /sbin/init"),
-        Path::new("firecrab-busybox")
+        Path::new(provision::GUEST_TOOLBOX)
     );
-    assert_eq!(read_guest(&tree, "/sbin/firecrab-busybox"), program);
-    assert_eq!(guest_mode(&tree, "/sbin/firecrab-busybox"), 0o755);
+    assert_eq!(read_guest(&tree, provision::GUEST_TOOLBOX), program);
+    assert_eq!(guest_mode(&tree, provision::GUEST_TOOLBOX), 0o755);
     assert_eq!(guest_mode(&tree, "/etc/firecrab/rc.boot"), 0o755);
     assert_eq!(guest_mode(&tree, "/etc/inittab"), 0o644);
 
     let inittab = String::from_utf8(read_guest(&tree, "/etc/inittab")).expect("inittab is text");
-    assert!(inittab.contains("::sysinit:/sbin/firecrab-busybox sh /etc/firecrab/rc.boot"));
+    assert!(inittab.contains(&format!(
+        "::sysinit:{} sh /etc/firecrab/rc.boot",
+        provision::GUEST_TOOLBOX
+    )));
 
     // The host fails the VM start unless one of these reaches the console.
     let boot = String::from_utf8(read_guest(&tree, "/etc/firecrab/rc.boot")).expect("script");
@@ -242,6 +245,56 @@ async fn injecting_a_guest_installs_an_init_the_stock_kernel_command_line_finds(
     assert!(tree.join("etc/firecrab/services.d").is_dir());
     // The image's own files are left exactly as they were.
     assert_eq!(read_guest(&tree, "/app/server"), b"binary");
+}
+
+#[tokio::test]
+async fn the_injected_toolbox_is_named_busybox_so_the_multiplexer_runs() {
+    let directory = tempdir().expect("create fixture directory");
+    let program = static_program();
+    let toolbox = toolbox(&directory, "busybox", &program).await;
+    let merged = merged(&directory, "mux", &application_layer()).await;
+    let tree = merged.path().to_owned();
+    provision::inject_with_toolbox(merged, &toolbox)
+        .await
+        .expect("inject a guest runtime");
+
+    // busybox treats argv[0]'s basename as the applet. A program named
+    // firecrab-busybox prints "applet not found" and never runs DHCP.
+    let init = std::fs::read_link(tree.join("sbin/init")).expect("read /sbin/init");
+    assert_eq!(
+        init.file_name().and_then(|name| name.to_str()),
+        Some("busybox")
+    );
+    let toolbox_guest = if init.is_absolute() {
+        init.to_string_lossy().into_owned()
+    } else {
+        format!("/sbin/{}", init.display())
+    };
+    assert_eq!(read_guest(&tree, &toolbox_guest), program);
+
+    let inittab = String::from_utf8(read_guest(&tree, "/etc/inittab")).expect("inittab");
+    assert!(
+        inittab.contains(&format!(
+            "::sysinit:{toolbox_guest} sh /etc/firecrab/rc.boot"
+        )),
+        "inittab must invoke the multiplexer by path: {inittab}"
+    );
+
+    let boot = String::from_utf8(read_guest(&tree, "/etc/firecrab/rc.boot")).expect("boot");
+    assert!(
+        boot.starts_with(&format!("#!{toolbox_guest} sh\n")),
+        "boot shebang must name the multiplexer: {boot}"
+    );
+
+    let dhcp = String::from_utf8(read_guest(&tree, "/etc/firecrab/dhcp.script")).expect("dhcp");
+    assert!(
+        dhcp.starts_with(&format!("#!{toolbox_guest} sh\n")),
+        "dhcp shebang must name the multiplexer: {dhcp}"
+    );
+    assert!(
+        dhcp.contains(r#"$BB ip addr add "$ip/${mask:-24}" dev "$interface""#),
+        "dhcp script must keep busybox parameter expansion: {dhcp}"
+    );
 }
 
 #[tokio::test]
@@ -327,10 +380,10 @@ async fn usr_merged_images_are_provisioned_through_their_symlinked_sbin() {
             .is_symlink(),
         "the image's own /sbin link is preserved"
     );
-    assert!(tree.join("usr/sbin/firecrab-busybox").is_file());
+    assert!(tree.join("etc/firecrab/busybox").is_file());
     assert_eq!(
         std::fs::read_link(tree.join("usr/sbin/init")).expect("read init link"),
-        Path::new("firecrab-busybox")
+        Path::new(provision::GUEST_TOOLBOX)
     );
 }
 
@@ -374,7 +427,7 @@ async fn an_image_supplied_init_is_replaced_without_touching_its_target() {
 
     assert_eq!(
         std::fs::read_link(tree.join("sbin/init")).expect("read init link"),
-        Path::new("firecrab-busybox")
+        Path::new(provision::GUEST_TOOLBOX)
     );
     // The final component is never followed, so the link was replaced rather
     // than written through onto systemd's own program.

--- a/firecrab-api/src/oci/registry_fixture.rs
+++ b/firecrab-api/src/oci/registry_fixture.rs
@@ -30,9 +30,9 @@ pub(crate) const TAG: &str = "ready";
 
 /// Entrypoint that becomes `/etc/firecrab/services.d/app` after import.
 ///
-/// `/sbin/firecrab-busybox` is injected during provisioning, so this image
+/// `/etc/firecrab/busybox` is injected during provisioning, so this image
 /// does not ship a shell of its own and never pulls from Docker Hub.
-const ENTRYPOINT: &[&str] = &["/sbin/firecrab-busybox", "sh", "-c"];
+const ENTRYPOINT: &[&str] = &[provision::GUEST_TOOLBOX, "sh", "-c"];
 
 #[derive(Clone)]
 struct FixtureState {
@@ -224,7 +224,10 @@ async fn gzip_bytes(bytes: &[u8]) -> Vec<u8> {
 }
 
 fn ready_command() -> String {
-    format!("while true; do echo {READY_SENTINEL}; /sbin/firecrab-busybox sleep 2; done")
+    format!(
+        "while true; do echo {READY_SENTINEL}; {} sleep 2; done",
+        provision::GUEST_TOOLBOX
+    )
 }
 
 async fn serve_api_version() -> Response<Body> {

--- a/firecrab-api/src/oci/registry_fixture.rs
+++ b/firecrab-api/src/oci/registry_fixture.rs
@@ -1,0 +1,368 @@
+//! Isolated loopback OCI registry used only by tests.
+//!
+//! Serves one tiny Linux image for this host (`amd64` or `arm64`) over plain
+//! HTTP on `127.0.0.1`. Testers and the browser E2E type
+//! `127.0.0.1:<port>/firecrab/e2e:ready`. After import the guest service
+//! prints [`READY_SENTINEL`] to the console. Nothing here is compiled into
+//! the production binary, and Drop aborts the listener and deletes scratch.
+
+use super::*;
+
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use async_compression::tokio::bufread::GzipEncoder;
+use axum::body::Body;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{Response, StatusCode, header::CONTENT_TYPE};
+use axum::routing::get;
+use tar::{Builder, EntryType, Header};
+use tempfile::TempDir;
+use tokio::task::JoinHandle;
+
+/// Console line the imported guest service prints after boot.
+pub(crate) const READY_SENTINEL: &str = "FIRECRAB_OCI_E2E_READY";
+/// Repository path under the loopback registry.
+pub(crate) const REPOSITORY: &str = "firecrab/e2e";
+/// Tag testers type after the repository.
+pub(crate) const TAG: &str = "ready";
+
+/// Entrypoint that becomes `/etc/firecrab/services.d/app` after import.
+///
+/// `/sbin/firecrab-busybox` is injected during provisioning, so this image
+/// does not ship a shell of its own and never pulls from Docker Hub.
+const ENTRYPOINT: &[&str] = &["/sbin/firecrab-busybox", "sh", "-c"];
+
+#[derive(Clone)]
+struct FixtureState {
+    manifest: Arc<Vec<u8>>,
+    blobs: Arc<BTreeMap<String, Arc<Vec<u8>>>>,
+}
+
+/// In-process OCI distribution server bound to `127.0.0.1:0`.
+pub(crate) struct LocalOciRegistry {
+    registry: String,
+    architecture: &'static str,
+    task: JoinHandle<()>,
+    scratch: Option<TempDir>,
+}
+
+impl LocalOciRegistry {
+    /// Builds the tiny image, writes scratch blobs, and serves them.
+    pub(crate) async fn start() -> Self {
+        let scratch = tempfile::tempdir().expect("create OCI fixture scratch");
+        let (manifest, blobs) = write_fixture_image(scratch.path()).await;
+        let state = FixtureState {
+            manifest: Arc::new(manifest),
+            blobs: Arc::new(blobs),
+        };
+        let app = axum::Router::new()
+            .route("/v2/", get(serve_api_version))
+            .route("/v2/firecrab/e2e/manifests/{selector}", get(serve_manifest))
+            .route("/v2/firecrab/e2e/blobs/{digest}", get(serve_blob))
+            .with_state(state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind isolated OCI fixture");
+        let registry = listener
+            .local_addr()
+            .expect("OCI fixture address")
+            .to_string();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve isolated OCI fixture");
+        });
+        Self {
+            registry,
+            architecture: oci_platform(Architecture::HOST),
+            task,
+            scratch: Some(scratch),
+        }
+    }
+
+    /// `host:port` the fixture is listening on.
+    pub(crate) fn registry(&self) -> &str {
+        &self.registry
+    }
+
+    /// Reference testers type: `127.0.0.1:<port>/firecrab/e2e:ready`.
+    pub(crate) fn reference(&self) -> String {
+        format!("{}/{REPOSITORY}:{TAG}", self.registry)
+    }
+
+    /// Parsed form of [`Self::reference`].
+    pub(crate) fn parsed_reference(&self) -> ImageReference {
+        ImageReference::parse(&self.reference()).expect("parse fixture reference")
+    }
+
+    /// Template alias `POST /api/oci/import` will claim for this listener.
+    pub(crate) fn alias(&self) -> String {
+        template_name_from_reference(&self.parsed_reference())
+            .expect("derive fixture alias")
+            .alias
+    }
+
+    /// OCI platform name baked into the image config (`amd64` or `arm64`).
+    pub(crate) fn architecture(&self) -> &'static str {
+        self.architecture
+    }
+
+    /// Stops the listener and deletes scratch blobs. Also run from [`Drop`].
+    pub(crate) fn shutdown(&mut self) {
+        self.task.abort();
+        if let Some(scratch) = self.scratch.take() {
+            let _ = scratch.close();
+        }
+    }
+}
+
+impl Drop for LocalOciRegistry {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+async fn write_fixture_image(scratch: &Path) -> (Vec<u8>, BTreeMap<String, Arc<Vec<u8>>>) {
+    let tar = layer_tar();
+    tokio::fs::write(scratch.join("layer.tar"), &tar)
+        .await
+        .expect("write fixture layer tar");
+    let diff_id = Sha256Digest::of_bytes(&tar);
+    let compressed = gzip_bytes(&tar).await;
+    tokio::fs::write(scratch.join("layer.tar.gz"), &compressed)
+        .await
+        .expect("write fixture compressed layer");
+    let layer_digest = Sha256Digest::of_bytes(&compressed);
+
+    let config = serde_json::to_vec(&serde_json::json!({
+        "architecture": oci_platform(Architecture::HOST),
+        "os": "linux",
+        "config": {
+            "Entrypoint": ENTRYPOINT,
+            "Cmd": [ready_command()],
+        },
+        "rootfs": {
+            "type": "layers",
+            "diff_ids": [diff_id.to_string()],
+        },
+    }))
+    .expect("serialize fixture image config");
+    tokio::fs::write(scratch.join("config.json"), &config)
+        .await
+        .expect("write fixture config");
+    let config_digest = Sha256Digest::of_bytes(&config);
+
+    let manifest = serde_json::to_vec(&serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": OCI_MANIFEST_MEDIA_TYPE,
+        "config": {
+            "mediaType": OCI_CONFIG_MEDIA_TYPE,
+            "digest": config_digest.to_string(),
+            "size": config.len(),
+        },
+        "layers": [{
+            "mediaType": OCI_LAYER_GZIP_MEDIA_TYPE,
+            "digest": layer_digest.to_string(),
+            "size": compressed.len(),
+        }],
+    }))
+    .expect("serialize fixture image manifest");
+    tokio::fs::write(scratch.join("manifest.json"), &manifest)
+        .await
+        .expect("write fixture manifest");
+
+    let blobs = BTreeMap::from([
+        (config_digest.to_string(), Arc::new(config)),
+        (layer_digest.to_string(), Arc::new(compressed)),
+    ]);
+    (manifest, blobs)
+}
+
+fn layer_tar() -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "etc/", EntryType::Directory, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "etc/firecrab-e2e",
+        EntryType::Regular,
+        format!("{READY_SENTINEL}\n").as_bytes(),
+        0o644,
+    );
+    builder.into_inner().expect("finish fixture layer tar")
+}
+
+fn append_entry(
+    builder: &mut Builder<Vec<u8>>,
+    path: &str,
+    entry_type: EntryType,
+    data: &[u8],
+    mode: u32,
+) {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(entry_type);
+    header.set_mode(mode);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(data.len() as u64);
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+async fn gzip_bytes(bytes: &[u8]) -> Vec<u8> {
+    let input = tokio::io::BufReader::new(bytes);
+    let mut encoder = GzipEncoder::new(input);
+    let mut output = Vec::new();
+    encoder
+        .read_to_end(&mut output)
+        .await
+        .expect("gzip fixture layer");
+    output
+}
+
+fn ready_command() -> String {
+    format!("while true; do echo {READY_SENTINEL}; /sbin/firecrab-busybox sleep 2; done")
+}
+
+async fn serve_api_version() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("docker-distribution-api-version", "registry/2.0")
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from("{}"))
+        .expect("build API version response")
+}
+
+async fn serve_manifest(
+    State(state): State<FixtureState>,
+    AxumPath(selector): AxumPath<String>,
+) -> Response<Body> {
+    let digest = Sha256Digest::of_bytes(&state.manifest);
+    if selector != TAG && selector != digest.as_str() {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .expect("build missing manifest response");
+    }
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, OCI_MANIFEST_MEDIA_TYPE)
+        .header("docker-content-digest", digest.as_str())
+        .body(Body::from(state.manifest.to_vec()))
+        .expect("build manifest response")
+}
+
+async fn serve_blob(
+    State(state): State<FixtureState>,
+    AxumPath(digest): AxumPath<String>,
+) -> Response<Body> {
+    match state.blobs.get(&digest) {
+        Some(bytes) => Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .header("docker-content-digest", digest)
+            .body(Body::from(bytes.to_vec()))
+            .expect("build blob response"),
+        None => Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .expect("build missing blob response"),
+    }
+}
+
+#[tokio::test]
+async fn the_fixture_serves_a_host_architecture_linux_image() {
+    let registry = LocalOciRegistry::start().await;
+    let reference = registry.parsed_reference();
+    let directory = tempfile::tempdir().expect("create image root");
+    let blobs = BlobCache::new(directory.path());
+    let layers = LayerCache::new(directory.path());
+
+    let resolved = resolve(&reference, Architecture::HOST, true)
+        .await
+        .expect("inspect the fixture over loopback HTTP");
+    assert_eq!(resolved.architecture, Architecture::HOST);
+    assert!(resolved.single_platform);
+    assert_eq!(registry.architecture(), oci_platform(Architecture::HOST));
+
+    let cached = cache_image_blobs(&reference, Architecture::HOST, true, &blobs)
+        .await
+        .expect("pull fixture config and layer");
+    let process = OciProcessConfig::from_image_config(
+        &tokio::fs::read(&cached.config.path)
+            .await
+            .expect("read cached fixture config"),
+    )
+    .expect("parse fixture process config");
+    assert_eq!(
+        process
+            .entrypoint()
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        ENTRYPOINT
+    );
+    assert!(
+        process.cmd().iter().any(|arg| arg.contains(READY_SENTINEL)),
+        "fixture Cmd must print {READY_SENTINEL}: {:?}",
+        process.cmd()
+    );
+
+    let decompressed = decompress_cached_layers(&cached, &layers)
+        .await
+        .expect("decompress fixture layer");
+    let validated = validate_decompressed_layers(decompressed)
+        .await
+        .expect("fixture layer must pass archive safety");
+    let merged = merge_validated_layers(&validated, &directory.path().join("rootfs"))
+        .await
+        .expect("merge fixture layer");
+    let marker = tokio::fs::read_to_string(merged.path().join("etc/firecrab-e2e"))
+        .await
+        .expect("read fixture marker");
+    assert_eq!(marker, format!("{READY_SENTINEL}\n"));
+}
+
+#[tokio::test]
+async fn the_fixture_reference_is_what_testers_type() {
+    let registry = LocalOciRegistry::start().await;
+    let reference = registry.reference();
+    assert!(
+        reference.starts_with("127.0.0.1:") && reference.ends_with("/firecrab/e2e:ready"),
+        "unexpected tester reference {reference}"
+    );
+    assert_eq!(
+        registry.alias(),
+        format!(
+            "{}-firecrab-e2e-ready",
+            registry.registry().replace(':', "-")
+        )
+    );
+}
+
+#[tokio::test]
+async fn dropping_the_fixture_stops_the_listener_and_deletes_scratch() {
+    let mut registry = LocalOciRegistry::start().await;
+    let address = registry.registry().to_owned();
+    let scratch = registry
+        .scratch
+        .as_ref()
+        .expect("scratch lives until shutdown")
+        .path()
+        .to_owned();
+    assert!(scratch.join("manifest.json").exists());
+
+    registry.shutdown();
+
+    assert!(
+        tokio::net::TcpStream::connect(&address).await.is_err(),
+        "listener must not survive shutdown"
+    );
+    assert!(
+        !scratch.exists(),
+        "scratch blobs must be deleted on shutdown, including after failure"
+    );
+}

--- a/firecrab-api/src/oci/service.rs
+++ b/firecrab-api/src/oci/service.rs
@@ -11,7 +11,7 @@ use std::os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _};
 use super::*;
 
 const GUEST_SERVICE: &str = "etc/firecrab/services.d/app";
-const GUEST_TOOLBOX: &str = "/sbin/firecrab-busybox";
+const GUEST_TOOLBOX: &str = super::provision::GUEST_TOOLBOX;
 
 #[derive(Debug, Deserialize)]
 struct RawImageProcess {

--- a/firecrab-api/src/oci/service_tests.rs
+++ b/firecrab-api/src/oci/service_tests.rs
@@ -69,7 +69,7 @@ fn installing_a_service_writes_env_workdir_and_exec_under_services_d() {
 
     let script = std::fs::read_to_string(rootfs.path().join("etc/firecrab/services.d/app"))
         .expect("read service");
-    assert!(script.starts_with("#!/sbin/firecrab-busybox sh\n"));
+    assert!(script.starts_with(&format!("#!{} sh\n", provision::GUEST_TOOLBOX)));
     assert!(script.contains("cd '/opt/app'"));
     assert!(script.contains("export PATH='/usr/bin'"));
     assert!(script.contains("export APP_ENV='prod'"));

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -195,6 +195,11 @@ pub fn build_router(state: AppState, config: &HttpConfig) -> Router {
             get(handlers::microregistry::list_microregistry),
         )
         .route("/api/oci/inspect", get(handlers::oci::inspect_oci_image))
+        .route("/api/oci/import", post(handlers::oci::start_oci_import))
+        .route(
+            "/api/oci/import/{alias}",
+            get(handlers::oci::get_oci_import),
+        )
         .route("/api/images", get(handlers::images::list_images))
         .route(
             "/api/images/{alias}",

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -104,6 +104,8 @@ pub struct AppState {
     pub(crate) image_packages: ImageInstallTracker,
     /// Async from-scratch distro bootstrap sessions (`POST /api/images/{alias}/bootstrap`).
     pub(crate) bootstraps: crate::bootstrap::BootstrapTracker,
+    /// Async OCI import jobs (`POST /api/oci/import`).
+    pub(crate) oci_imports: ImageInstallTracker,
     /// Previous `/proc` jiffy samples used to derive host-process CPU %.
     pub(crate) process_metrics: Arc<Mutex<ProcessMetricsTracker>>,
 }
@@ -147,6 +149,7 @@ impl AppState {
             image_installs: ImageInstallTracker::from_env(),
             image_packages: ImageInstallTracker::from_env(),
             bootstraps: crate::bootstrap::BootstrapTracker::default(),
+            oci_imports: ImageInstallTracker::default(),
             process_metrics: Arc::new(Mutex::new(ProcessMetricsTracker::default())),
         })
     }

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -564,7 +564,18 @@ impl TemplateRegistry {
                     .as_ref()
                     .map(|artifact| artifact.relative_path()),
             )
-            .filter(|relative| !still_referenced.contains(*relative))
+            .filter(|relative| {
+                if still_referenced.contains(*relative) {
+                    return false;
+                }
+                // Catalog artifacts belong to their known_spec alias. An OCI
+                // import borrows the Ubuntu kernel; deleting that import must
+                // not take the kernel with it or the next import cannot pair.
+                match catalog_owner_of(relative) {
+                    Some(owner) if owner != removed.name => false,
+                    _ => true,
+                }
+            })
             .map(|relative| self.image_root_path.join(relative))
             .collect()
     }
@@ -719,6 +730,17 @@ impl TemplateRegistry {
 /// Whether every file a spec needs is already on disk. A cheap existence
 /// check only — [`TemplateRegistry::from_specs`] still opens each one safely
 /// beneath the image root and hashes it.
+/// Alias whose compiled-in spec names this relative artifact, if any.
+fn catalog_owner_of(relative: &Path) -> Option<String> {
+    default_specs().into_iter().find_map(|spec| {
+        let owned = std::iter::once(spec.kernel.as_path())
+            .chain(std::iter::once(spec.rootfs.as_path()))
+            .chain(spec.initrd.as_deref())
+            .any(|path| path == relative);
+        owned.then_some(spec.alias)
+    })
+}
+
 fn artifacts_present(image_root: &Path, spec: &TemplateSpec) -> bool {
     std::iter::once(&spec.kernel)
         .chain(std::iter::once(&spec.rootfs))
@@ -1401,6 +1423,69 @@ mod tests {
                 .any(|path| path.file_name().and_then(|n| n.to_str()) == Some("rootfs-a"))
         );
         assert!(registry.resolve_alias("b").is_some());
+    }
+
+    #[test]
+    fn unregistering_an_oci_alias_does_not_delete_the_catalog_kernel_it_borrowed() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        let ubuntu = TemplateRegistry::known_spec("ubuntu-26.04").expect("ubuntu catalog spec");
+        if let Some(parent) = ubuntu.kernel.parent() {
+            fs::create_dir_all(root.join(parent)).unwrap();
+        }
+        fs::create_dir_all(root.join("rootfs")).unwrap();
+        fs::write(root.join(&ubuntu.kernel), b"catalog-kernel").unwrap();
+        fs::write(root.join("rootfs/nginx-1.27.ext4"), b"oci-rootfs").unwrap();
+        let registry = TemplateRegistry::from_specs(
+            root,
+            [TemplateSpec {
+                alias: "nginx-1.27".to_owned(),
+                version: "1.27".to_owned(),
+                kernel: ubuntu.kernel.clone(),
+                initrd: None,
+                rootfs: PathBuf::from("rootfs/nginx-1.27.ext4"),
+                boot_args: ubuntu.boot_args.clone(),
+            }],
+        )
+        .unwrap();
+
+        let (_version, orphans) = registry.unregister_alias("nginx-1.27").unwrap();
+        assert!(
+            !orphans.iter().any(|path| path.ends_with(&ubuntu.kernel)),
+            "catalog kernel must stay for the next OCI import: {orphans:?}"
+        );
+        assert!(
+            orphans
+                .iter()
+                .any(|path| path.ends_with("rootfs/nginx-1.27.ext4")),
+            "the imported rootfs is this alias's own file: {orphans:?}"
+        );
+    }
+
+    #[test]
+    fn unregistering_the_catalog_alias_still_deletes_its_own_kernel() {
+        let directory = tempdir().unwrap();
+        let root = directory.path();
+        let ubuntu = TemplateRegistry::known_spec("ubuntu-26.04").expect("ubuntu catalog spec");
+        if let Some(parent) = ubuntu.kernel.parent() {
+            fs::create_dir_all(root.join(parent)).unwrap();
+        }
+        if let Some(parent) = ubuntu.rootfs.parent() {
+            fs::create_dir_all(root.join(parent)).unwrap();
+        }
+        fs::write(root.join(&ubuntu.kernel), b"catalog-kernel").unwrap();
+        fs::write(root.join(&ubuntu.rootfs), b"catalog-rootfs").unwrap();
+        let registry = TemplateRegistry::from_specs(root, [ubuntu.clone()]).unwrap();
+
+        let (_version, orphans) = registry.unregister_alias("ubuntu-26.04").unwrap();
+        assert!(
+            orphans.iter().any(|path| path.ends_with(&ubuntu.kernel)),
+            "the catalog alias still owns its kernel: {orphans:?}"
+        );
+        assert!(
+            orphans.iter().any(|path| path.ends_with(&ubuntu.rootfs)),
+            "the catalog alias still owns its rootfs: {orphans:?}"
+        );
     }
 
     #[test]

--- a/firecrab-e2e/.gitignore
+++ b/firecrab-e2e/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+scratch/

--- a/firecrab-e2e/README.md
+++ b/firecrab-e2e/README.md
@@ -1,0 +1,88 @@
+# OCI import browser E2E
+
+Isolated Playwright suite for [issue #90](https://github.com/SteelCrab/firecrab/issues/90).
+It drives the dashboard against a **local** OCI registry fixture.
+Nothing is pulled from Docker Hub.
+
+Playwright is a test-only dependency of this package.
+It is not added to `firecrab-frontend`.
+
+## What it covers
+
+1. Type `127.0.0.1:15555/firecrab/e2e:ready` on Images.
+2. Inspect — the host must accept the fixture architecture.
+3. Import — poll until the derived alias is registered.
+4. (Optional) Create and start a VM from that alias.
+5. (Optional) Assert `FIRECRAB_NETWORK_READY` and `FIRECRAB_OCI_E2E_READY` on the console.
+
+The guest-boot half is skipped when `FIRECRAB_E2E_SKIP_GUEST_BOOT=1`.
+Inspect and import still run.
+
+## Setup
+
+```sh
+npm install --prefix firecrab-e2e
+npm run install-browsers --prefix firecrab-e2e
+```
+
+Chromium and `python3` are required.
+The fixture script is `scripts/oci-e2e-registry.py` at the repo root.
+
+## Run
+
+Inspect and import only:
+
+```sh
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+```
+
+Expect **1 passed, 1 skipped**.
+
+Full path (KVM, `firecracker` on `PATH`, and a live net helper):
+
+```sh
+./scripts/dev-net-helper.sh    # other terminal; socket /run/firecrab/net-helper.sock
+npm test --prefix firecrab-e2e
+```
+
+Playwright starts `firecrab-api` on `:3000` and Vite on `:8080` unless those
+ports already answer.
+Open the dashboard as `http://localhost:8080`.
+`127.0.0.1:8080` is a different CORS origin and will fail.
+
+The API helper copies the Ubuntu catalog kernel into `images/kernel/` as a
+regular file (import opens it with `O_NOFOLLOW`).
+If a static busybox is already on disk it sets `FIRECRAB_OCI_TOOLBOX_PATH`
+so toolbox install does not reach a public registry.
+
+## Fixture
+
+```sh
+python3 scripts/oci-e2e-registry.py --port 15555
+```
+
+The first stdout line is JSON: `reference`, `alias`, `ready`, `architecture`.
+The image entrypoint prints `FIRECRAB_OCI_E2E_READY` as a guest service,
+not as PID 1.
+
+SIGINT or SIGTERM stops the listener and deletes scratch blobs.
+The Playwright `afterAll` hook also stops the fixture and deletes any VM,
+imported template, or MicroNetwork this suite created.
+
+## Environment
+
+| Variable | Default | Role |
+| --- | --- | --- |
+| `FIRECRAB_E2E_SKIP_GUEST_BOOT` | unset | Skip VM create/start when `1` / `true` / `yes` |
+| `FIRECRAB_OCI_E2E_PORT` | `15555` | Loopback registry port |
+| `FIRECRAB_E2E_BASE_URL` | `http://localhost:8080` | Dashboard origin |
+| `FIRECRAB_E2E_API_URL` | `http://127.0.0.1:3000` | API used for cleanup |
+
+The suite does not infer `/dev/kvm`.
+Unset the skip flag only on a host that can actually boot a guest.
+
+## Related
+
+- [OCI images](../public-docs/oci.md)
+- [Dashboard](../public-docs/dashboard.md)
+- [API](../public-docs/api.md)

--- a/firecrab-e2e/package-lock.json
+++ b/firecrab-e2e/package-lock.json
@@ -1,0 +1,96 @@
+{
+  "name": "firecrab-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "firecrab-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.62.1",
+        "@types/node": "^24.13.2"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/firecrab-e2e/package.json
+++ b/firecrab-e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "firecrab-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "description": "Isolated browser E2E for issue #90 (OCI inspect → import → boot). Playwright is test-only.",
+  "scripts": {
+    "test": "playwright test",
+    "test:import": "FIRECRAB_E2E_SKIP_GUEST_BOOT=1 playwright test",
+    "test:headed": "playwright test --headed",
+    "install-browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1",
+    "@types/node": "^24.13.2"
+  }
+}

--- a/firecrab-e2e/playwright.config.ts
+++ b/firecrab-e2e/playwright.config.ts
@@ -1,0 +1,75 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig, devices } from "@playwright/test";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const frontend = path.join(repoRoot, "firecrab-frontend");
+const skipGuestBoot =
+  process.env.FIRECRAB_E2E_SKIP_GUEST_BOOT === "1" ||
+  process.env.FIRECRAB_E2E_SKIP_GUEST_BOOT === "true" ||
+  process.env.FIRECRAB_E2E_SKIP_GUEST_BOOT === "yes";
+const baseURL = (process.env.FIRECRAB_E2E_BASE_URL ?? "http://localhost:8080").replace(
+  /\/$/,
+  "",
+);
+
+/**
+ * Browser E2E for issue #90 — local OCI fixture only (no Docker Hub pull).
+ *
+ * Commands (from the repo root):
+ *
+ *   # inspect + import in Chromium (no guest boot):
+ *   FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+ *
+ *   # full path: inspect → import → create VM → FIRECRAB_NETWORK_READY →
+ *   # FIRECRAB_OCI_E2E_READY on the console:
+ *   npm test --prefix firecrab-e2e
+ *
+ * Playwright starts firecrab-api (unless :3000 already answers) and Vite
+ * (unless :8080 already answers). Guest boot also needs KVM, firecracker on
+ * PATH, and a *responsive* `./scripts/dev-net-helper.sh` (Unix socket
+ * /run/firecrab/net-helper.sock). Skip guest boot only via
+ * FIRECRAB_E2E_SKIP_GUEST_BOOT=1 — the suite does not infer /dev/kvm.
+ *
+ * The dashboard origin must be http://localhost:8080 (exact CORS allow-list).
+ */
+export default defineConfig({
+  testDir: "tests",
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: !!process.env.CI,
+  timeout: skipGuestBoot ? 240_000 : 420_000,
+  expect: { timeout: 15_000 },
+  reporter: [["list"]],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "off",
+    locale: "en-US",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: [
+    {
+      command: "node firecrab-e2e/scripts/ensure-api.mjs",
+      cwd: repoRoot,
+      url: "http://127.0.0.1:3000/api/host",
+      reuseExistingServer: !process.env.CI,
+      timeout: 180_000,
+    },
+    {
+      command: "npm run dev",
+      cwd: frontend,
+      url: "http://localhost:8080",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/firecrab-e2e/scripts/ensure-api.mjs
+++ b/firecrab-e2e/scripts/ensure-api.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Start firecrab-api from the repo root so Playwright can drive the dashboard.
+ *
+ * Prepares the Ubuntu catalog kernel the OCI import stage pairs with (symlink
+ * only if missing) and points FIRECRAB_OCI_TOOLBOX_PATH at a local static
+ * busybox when present so the import does not pull from Docker Hub.
+ *
+ * Playwright's webServer `reuseExistingServer` skips this script when
+ * http://127.0.0.1:3000/api/host already answers.
+ */
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+function hostKernelRelPath() {
+  const machine = os.machine();
+  if (machine === "aarch64" || machine === "arm64") {
+    return "kernel/Image-ubuntu-26.04-aarch64";
+  }
+  return "kernel/vmlinux-ubuntu-26.04-x86_64";
+}
+
+function isUsableKernel(file) {
+  try {
+    const st = fs.lstatSync(file);
+    // Import opens the kernel with O_NOFOLLOW; a symlink is refused.
+    return st.isFile() && st.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function ensureKernel() {
+  const rel = hostKernelRelPath();
+  const dest = path.join(repoRoot, "images", rel);
+  if (isUsableKernel(dest)) return dest;
+  try {
+    fs.unlinkSync(dest);
+  } catch {
+    /* dest missing or not removable */
+  }
+  const candidates = [path.join(repoRoot, "docs/microregistry/images", rel)];
+  const source = candidates.find((candidate) => isUsableKernel(candidate));
+  if (!source) {
+    console.warn(
+      `[firecrab-e2e] ${rel} is missing; OCI import will fail until the Ubuntu catalog kernel is installed`,
+    );
+    return null;
+  }
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  try {
+    fs.linkSync(source, dest);
+    console.log(`[firecrab-e2e] hardlinked ${dest} <- ${source}`);
+  } catch {
+    fs.copyFileSync(source, dest);
+    console.log(`[firecrab-e2e] copied ${dest} <- ${source}`);
+  }
+  return dest;
+}
+
+function isStaticBusybox(file) {
+  try {
+    const fd = fs.openSync(file, "r");
+    const header = Buffer.alloc(64);
+    fs.readSync(fd, header, 0, 64, 0);
+    fs.closeSync(fd);
+    return header[0] === 0x7f && header[1] === 0x45 && header[2] === 0x4c && header[3] === 0x46;
+  } catch {
+    return false;
+  }
+}
+
+ensureKernel();
+
+const env = { ...process.env };
+if (!env.FIRECRAB_OCI_TOOLBOX_PATH && isStaticBusybox("/usr/bin/busybox")) {
+  env.FIRECRAB_OCI_TOOLBOX_PATH = "/usr/bin/busybox";
+}
+
+const cargo = spawn("cargo", ["run", "-p", "firecrab-api"], {
+  cwd: repoRoot,
+  env,
+  stdio: "inherit",
+});
+cargo.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exit(code ?? 1);
+});

--- a/firecrab-e2e/src/api.ts
+++ b/firecrab-e2e/src/api.ts
@@ -1,0 +1,119 @@
+import { apiUrl, NETWORK_NAME, VM_NAME } from "./constants.js";
+
+interface VmRow {
+  id: string;
+  name: string;
+  state: string;
+  template: string;
+}
+
+interface ImageRow {
+  alias: string;
+  installed: boolean;
+}
+
+interface NetworkRow {
+  id: string;
+  name: string;
+}
+
+export class ApiCleanup {
+  constructor(private readonly base = apiUrl()) {}
+
+  private async request(
+    method: string,
+    pathname: string,
+    body?: unknown,
+  ): Promise<{ status: number; json: unknown }> {
+    const response = await fetch(`${this.base}${pathname}`, {
+      method,
+      headers: body === undefined ? undefined : { "Content-Type": "application/json" },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    let json: unknown = null;
+    const text = await response.text();
+    if (text) {
+      try {
+        json = JSON.parse(text);
+      } catch {
+        json = { raw: text };
+      }
+    }
+    return { status: response.status, json };
+  }
+
+  async listVms(): Promise<VmRow[]> {
+    const { status, json } = await this.request("GET", "/api/vms");
+    if (status >= 400 || !Array.isArray(json)) return [];
+    return json as VmRow[];
+  }
+
+  async listImages(): Promise<ImageRow[]> {
+    const { status, json } = await this.request("GET", "/api/images");
+    if (status >= 400 || !Array.isArray(json)) return [];
+    return json as ImageRow[];
+  }
+
+  async listNetworks(): Promise<NetworkRow[]> {
+    const { status, json } = await this.request("GET", "/api/micro-networks");
+    if (status >= 400 || !Array.isArray(json)) return [];
+    return json as NetworkRow[];
+  }
+
+  async stopVm(id: string): Promise<void> {
+    await this.request("POST", `/api/vms/${id}/stop`);
+  }
+
+  async deleteVm(id: string): Promise<void> {
+    await this.request("DELETE", `/api/vms/${id}`);
+  }
+
+  async deleteImage(alias: string): Promise<void> {
+    await this.request("DELETE", `/api/images/${encodeURIComponent(alias)}`);
+  }
+
+  async deleteNetwork(id: string): Promise<void> {
+    await this.request("DELETE", `/api/micro-networks/${id}`);
+  }
+
+  async waitUntilDeletable(id: string, timeoutMs = 30_000): Promise<VmRow | null> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const vm = (await this.listVms()).find((row) => row.id === id);
+      if (!vm) return null;
+      if (vm.state === "created" || vm.state === "stopped" || vm.state === "error") {
+        return vm;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return (await this.listVms()).find((row) => row.id === id) ?? null;
+  }
+
+  /** Stop + delete every VM this suite owns (by name or imported template). */
+  async deleteOwnedVms(alias: string): Promise<void> {
+    const vms = await this.listVms();
+    const owned = vms.filter((vm) => vm.name === VM_NAME || vm.template === alias);
+    for (const vm of owned) {
+      if (vm.state === "running" || vm.state === "starting" || vm.state === "stopping") {
+        await this.stopVm(vm.id);
+        await this.waitUntilDeletable(vm.id);
+      }
+      await this.deleteVm(vm.id);
+    }
+  }
+
+  /** Remove the imported template if this run (or a previous one) registered it. */
+  async deleteImportedImage(alias: string): Promise<void> {
+    const images = await this.listImages();
+    if (!images.some((image) => image.alias === alias && image.installed)) return;
+    await this.deleteImage(alias);
+  }
+
+  async deleteOwnedNetwork(createdNetworkId: string | null): Promise<void> {
+    if (!createdNetworkId) return;
+    const networks = await this.listNetworks();
+    const row = networks.find((network) => network.id === createdNetworkId);
+    if (!row || row.name !== NETWORK_NAME) return;
+    await this.deleteNetwork(createdNetworkId);
+  }
+}

--- a/firecrab-e2e/src/constants.ts
+++ b/firecrab-e2e/src/constants.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** Repository root (parent of this dedicated e2e package). */
+export const REPO_ROOT = path.resolve(here, "../..");
+
+/** Fixed loopback port used by `scripts/oci-e2e-registry.py` for this E2E. */
+export const REGISTRY_PORT = Number.parseInt(
+  process.env.FIRECRAB_OCI_E2E_PORT ?? "15555",
+  10,
+);
+
+/** Deterministic reference testers type when the fixture binds 15555. */
+export const FIXED_REFERENCE = `127.0.0.1:${REGISTRY_PORT}/firecrab/e2e:ready`;
+
+/** Alias `POST /api/oci/import` claims for {@link FIXED_REFERENCE}. */
+export const FIXED_ALIAS = `127.0.0.1-${REGISTRY_PORT}-firecrab-e2e-ready`;
+
+/** Guest service line printed by the fixture image after boot. */
+export const READY_SENTINEL = "FIRECRAB_OCI_E2E_READY";
+
+/** Guest readiness line the API waits for before reporting `running`. */
+export const NETWORK_READY = "FIRECRAB_NETWORK_READY";
+
+/** VM created by the guest-boot half of the suite. */
+export const VM_NAME = "oci-e2e-ready";
+
+/** Dedicated MicroNetwork for the guest-boot half. */
+export const NETWORK_NAME = "oci-e2e";
+
+/** Isolated subnet so this suite does not share a developer's default net. */
+export const NETWORK_CIDR = "172.30.90.0/24";
+
+export const DEFAULT_API_URL = "http://127.0.0.1:3000";
+export const DEFAULT_BASE_URL = "http://localhost:8080";
+
+export function envFlag(name: string): boolean {
+  const value = process.env[name];
+  return value === "1" || value === "true" || value === "yes";
+}
+
+/**
+ * Skip only the guest-boot half (create VM / start / console sentinels).
+ * Inspect + import still run in the browser against the local fixture.
+ */
+export const SKIP_GUEST_BOOT = envFlag("FIRECRAB_E2E_SKIP_GUEST_BOOT");
+
+export function apiUrl(): string {
+  return (process.env.FIRECRAB_E2E_API_URL ?? DEFAULT_API_URL).replace(/\/$/, "");
+}
+
+export function dashboardUrl(): string {
+  return (process.env.FIRECRAB_E2E_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+}

--- a/firecrab-e2e/src/registry.ts
+++ b/firecrab-e2e/src/registry.ts
@@ -1,0 +1,113 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { REGISTRY_PORT, REPO_ROOT } from "./constants.js";
+
+export interface RegistryAnnouncement {
+  reference: string;
+  ready: string;
+  alias: string;
+  architecture: string;
+}
+
+export interface LocalOciRegistry {
+  announcement: RegistryAnnouncement;
+  stop(): Promise<void>;
+}
+
+function firstStdoutLine(child: ChildProcess, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const stdout = child.stdout;
+    if (!stdout) {
+      reject(new Error("oci-e2e-registry.py has no stdout pipe"));
+      return;
+    }
+    let buffer = "";
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          `oci-e2e-registry.py did not print its JSON announcement within ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) return;
+      cleanup();
+      resolve(buffer.slice(0, newline).trim());
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(new Error(`oci-e2e-registry.py exited ${code} before announcing`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      stdout.off("data", onData);
+      child.off("exit", onExit);
+    };
+    stdout.on("data", onData);
+    child.once("exit", onExit);
+  });
+}
+
+async function terminate(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode) return;
+  child.kill("SIGTERM");
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode) return;
+    await delay(50);
+  }
+  if (child.exitCode === null && !child.signalCode) {
+    child.kill("SIGKILL");
+  }
+}
+
+/**
+ * Spawn `scripts/oci-e2e-registry.py` on the fixed E2E port.
+ * First stdout line is JSON `{reference, ready, alias, architecture}`.
+ */
+export async function startLocalOciRegistry(
+  port = REGISTRY_PORT,
+): Promise<LocalOciRegistry> {
+  const script = path.join(REPO_ROOT, "scripts/oci-e2e-registry.py");
+  const child = spawn("python3", [script, "--port", String(port)], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, FIRECRAB_OCI_E2E_PORT: String(port) },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stderr: string[] = [];
+  child.stderr?.on("data", (chunk: Buffer) => {
+    stderr.push(chunk.toString("utf8"));
+  });
+  child.on("error", (error) => {
+    throw new Error(`failed to spawn oci-e2e-registry.py: ${error.message}`);
+  });
+
+  let announcement: RegistryAnnouncement;
+  try {
+    const line = await firstStdoutLine(child, 10_000);
+    announcement = JSON.parse(line) as RegistryAnnouncement;
+  } catch (error) {
+    await terminate(child);
+    const detail = stderr.join("").trim();
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}${detail ? `\n${detail}` : ""}`,
+    );
+  }
+
+  if (!announcement.reference || !announcement.alias || !announcement.ready) {
+    await terminate(child);
+    throw new Error(`registry announcement missing fields: ${JSON.stringify(announcement)}`);
+  }
+
+  return {
+    announcement,
+    async stop() {
+      await terminate(child);
+    },
+  };
+}

--- a/firecrab-e2e/tests/oci-image-import.spec.ts
+++ b/firecrab-e2e/tests/oci-image-import.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { ApiCleanup } from "../src/api.js";
+import {
+  FIXED_ALIAS,
+  FIXED_REFERENCE,
+  NETWORK_CIDR,
+  NETWORK_NAME,
+  NETWORK_READY,
+  READY_SENTINEL,
+  SKIP_GUEST_BOOT,
+  VM_NAME,
+} from "../src/constants.js";
+import { startLocalOciRegistry, type LocalOciRegistry } from "../src/registry.js";
+
+/**
+ * Issue #90 browser E2E.
+ *
+ *   FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm test --prefix firecrab-e2e
+ *   npm test --prefix firecrab-e2e
+ *
+ * The registry fixture is spawned here (python3 scripts/oci-e2e-registry.py,
+ * FIRECRAB_OCI_E2E_PORT=15555). Cleanup always stops it and deletes any VM
+ * or imported template this file created.
+ */
+test.describe.configure({ mode: "serial" });
+
+let registry: LocalOciRegistry;
+let createdNetworkId: string | null = null;
+const api = new ApiCleanup();
+
+function reference(): string {
+  return registry.announcement.reference;
+}
+
+function alias(): string {
+  return registry.announcement.alias;
+}
+
+function sentinel(): string {
+  return registry.announcement.ready;
+}
+
+async function openEnglish(page: Page, hash: string): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem("firecrab.locale", "en");
+  });
+  await page.goto(hash);
+}
+
+async function cleanupOwned(): Promise<void> {
+  const imported = registry?.announcement.alias ?? FIXED_ALIAS;
+  await api.deleteOwnedVms(imported);
+  await api.deleteImportedImage(imported);
+  await api.deleteOwnedNetwork(createdNetworkId);
+  createdNetworkId = null;
+}
+
+test.beforeAll(async () => {
+  registry = await startLocalOciRegistry();
+  expect(registry.announcement.reference).toBe(FIXED_REFERENCE);
+  expect(registry.announcement.alias).toBe(FIXED_ALIAS);
+  expect(registry.announcement.ready).toBe(READY_SENTINEL);
+  await cleanupOwned();
+});
+
+test.afterAll(async () => {
+  try {
+    await cleanupOwned();
+  } finally {
+    await registry?.stop();
+  }
+});
+
+test("inspects the local fixture and imports it as a registered image", async ({ page }) => {
+  await openEnglish(page, "/#/images");
+  await expect(page.locator("#oci-reference")).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeDisabled();
+
+  await page.locator("#oci-reference").fill(reference());
+  await page.locator("#oci-inspect").click();
+
+  const oci = page.locator("section.panel", { has: page.getByRole("heading", { name: "OCI" }) });
+  await expect(oci.getByText("Compatible with this host.")).toBeVisible({ timeout: 30_000 });
+  await expect(oci.locator("dd", { hasText: alias() }).first()).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeEnabled();
+
+  await page.locator("#oci-import").click();
+  const status = oci.locator(".state-badge");
+  await expect(status).toHaveText(/Imported|Import failed/, { timeout: 180_000 });
+  if ((await status.textContent())?.includes("failed")) {
+    const log = (await oci.locator(".image-install-log").textContent()) ?? "";
+    throw new Error(`OCI import failed for ${reference()}:\n${log}`);
+  }
+
+  await expect(oci.getByText("Registered image")).toBeVisible();
+  await expect(oci.getByText(new RegExp(`${alias()}.*Installed`))).toBeVisible();
+  await expect(page.locator("table.image-table")).toContainText(alias());
+  await expect(page.locator("table.image-table").getByText("Installed").first()).toBeVisible();
+});
+
+test("creates a VM from the imported image and asserts the guest service started", async ({
+  page,
+}) => {
+  test.skip(
+    SKIP_GUEST_BOOT,
+    "FIRECRAB_E2E_SKIP_GUEST_BOOT is set — inspect+import already covered. Unset the flag (and provide KVM + firecracker + ./scripts/dev-net-helper.sh) for the guest-boot half.",
+  );
+
+  await openEnglish(page, "/#/networks");
+  const networkPanel = page.locator("section.panel", {
+    has: page.getByRole("heading", { name: "MicroNetwork" }),
+  });
+  const networkRows = networkPanel.locator("table.vm-table tbody tr");
+  // Prefer an already-provisioned network. Creating one needs the helper and
+  // a free CIDR; a developer host usually already has `default`.
+  if ((await networkRows.count()) === 0) {
+    await page.locator("#mn-name").fill(NETWORK_NAME);
+    await page.locator("#mn-subnet").fill(NETWORK_CIDR);
+    await networkPanel.locator('button[type="submit"]').click();
+    const created = networkRows.filter({ hasText: NETWORK_NAME });
+    const fieldError = networkPanel.locator(".field-error").filter({ hasText: /\S/ });
+    await expect(created.or(fieldError).first()).toBeVisible({ timeout: 30_000 });
+    if ((await created.count()) === 0) {
+      throw new Error(
+        `failed to create MicroNetwork ${NETWORK_NAME}: ${(await fieldError.allTextContents()).join("; ")}`,
+      );
+    }
+    const networks = await api.listNetworks();
+    createdNetworkId = networks.find((network) => network.name === NETWORK_NAME)?.id ?? null;
+  }
+
+  await openEnglish(page, "/#/vms");
+  await expect(page.locator("#vm-image")).toBeEnabled({ timeout: 15_000 });
+  await expect(page.locator(`#vm-image option[value="${alias()}"]`)).toHaveCount(1, {
+    timeout: 15_000,
+  });
+  await page.locator("#vm-name").fill(VM_NAME);
+  await page.locator("#vm-image").selectOption(alias());
+  await expect(page.locator("#vm-micro-network")).not.toHaveValue("");
+  await page.locator("#vm-create-submit").click();
+  await expect(page.getByText(`Created: ${VM_NAME}`)).toBeVisible({ timeout: 30_000 });
+
+  const row = page.locator("table.vm-table tbody tr", { hasText: VM_NAME });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: "start" }).click();
+  await expect(row.locator(".state-badge")).toHaveText(/running|error/, { timeout: 240_000 });
+  if ((await row.locator(".state-badge").textContent()) !== "running") {
+    await row.locator("button.link-button").click();
+    await expect(page.locator(".console-title")).toBeVisible();
+    await expect
+      .poll(async () => (await page.locator("pre.detail-log").textContent())?.trim() ?? "", {
+        timeout: 10_000,
+      })
+      .not.toBe("");
+    const logText = (await page.locator("pre.detail-log").textContent()) ?? "";
+    const banner = (await page.locator(".banner").textContent().catch(() => "")) ?? "";
+    const steps = (await page.locator(".pipeline-step").allTextContents()).join("\n");
+    throw new Error(
+      `VM ${VM_NAME} entered error instead of running.\nbanner: ${banner}\nsteps:\n${steps}\nlog:\n${logText}`,
+    );
+  }
+
+  await row.locator("button.link-button").click();
+  const log = page.locator("pre.detail-log");
+  await expect(log).toContainText(NETWORK_READY, { timeout: 30_000 });
+  await expect(log).toContainText(sentinel(), { timeout: 60_000 });
+});

--- a/firecrab-e2e/tsconfig.json
+++ b/firecrab-e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["playwright.config.ts", "src/**/*.ts", "tests/**/*.ts"]
+}

--- a/firecrab-frontend/README.md
+++ b/firecrab-frontend/README.md
@@ -1,3 +1,11 @@
+# firecrab dashboard
+
+React and TypeScript UI for firecrab.
+Develop it from the repository root as described in [README.md](../README.md).
+OCI inspect → import browser tests live in [firecrab-e2e](../firecrab-e2e/README.md).
+
+---
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some Oxlint rules.

--- a/firecrab-frontend/src/api/client.ts
+++ b/firecrab-frontend/src/api/client.ts
@@ -11,6 +11,8 @@ import type {
   HostStatusResponse,
   ImageInstallResponse,
   ImageResponse,
+  OciImportRequest,
+  OciInspectResponse,
   MicroRegistryRegisterRequest,
   MicroRegistryRegisterResponse,
   MicroRegistryResponse,
@@ -186,6 +188,25 @@ export function startImageInstall(alias: string): Promise<ImageInstallResponse> 
 /** Poll image installation status + log (`GET /api/images/{alias}/install`). */
 export function getImageInstall(alias: string): Promise<ImageInstallResponse> {
   return fetchJson(`/api/images/${encodeURIComponent(alias)}/install`);
+}
+
+/** Resolve whether an OCI reference can run on this host (`GET /api/oci/inspect`). */
+export function inspectOciImage(reference: string): Promise<OciInspectResponse> {
+  return fetchJson(`/api/oci/inspect?${new URLSearchParams({ reference })}`);
+}
+
+/** Start an async OCI import (`POST /api/oci/import`). Returns 202 + ImageInstallResponse. */
+export function startOciImport(request: OciImportRequest): Promise<ImageInstallResponse> {
+  return fetchJson("/api/oci/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+}
+
+/** Poll an OCI import job (`GET /api/oci/import/{alias}`). */
+export function getOciImport(alias: string): Promise<ImageInstallResponse> {
+  return fetchJson(`/api/oci/import/${encodeURIComponent(alias)}`);
 }
 
 /** Unregister template and delete orphan artifact files (`DELETE /api/images/{alias}`). */

--- a/firecrab-frontend/src/bindings/OciImportRequest.ts
+++ b/firecrab-frontend/src/bindings/OciImportRequest.ts
@@ -1,0 +1,5 @@
+/** Body of `POST /api/oci/import`. */
+
+export type OciImportRequest = {
+  reference: string;
+};

--- a/firecrab-frontend/src/bindings/OciInspectResponse.ts
+++ b/firecrab-frontend/src/bindings/OciInspectResponse.ts
@@ -1,0 +1,13 @@
+/** Result of `GET /api/oci/inspect?reference=` (camelCase wire shape). */
+
+export type OciInspectResponse = {
+  registry: string;
+  repository: string;
+  version: string;
+  immutable: boolean;
+  digest: string;
+  architecture: string;
+  singlePlatform: boolean;
+  /** Template alias this host would register on import. */
+  alias: string;
+};

--- a/firecrab-frontend/src/bindings/index.ts
+++ b/firecrab-frontend/src/bindings/index.ts
@@ -16,6 +16,8 @@ export * from "./HostStatusResponse";
 export * from "./ImageInstallResponse";
 export * from "./ImageInstallStatus";
 export * from "./ImageResponse";
+export * from "./OciImportRequest";
+export * from "./OciInspectResponse";
 export * from "./MicroRegistryImageResponse";
 export * from "./MicroRegistryRegisterRequest";
 export * from "./MicroRegistryRegisterResponse";

--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -768,16 +768,20 @@ function OciImportPanel({
   };
 
   const inspectMatchesInput = inspect !== null && inspectedReference === reference.trim();
+  const registered = job?.status === "succeeded"
+    ? images.find((image) => image.alias === job.alias) ?? null
+    : null;
+  // Succeeded only blocks Start Import while the alias is still installed.
+  // After the operator deletes that template the in-memory job stays
+  // `succeeded`, and the same reference must be importable again (E2E
+  // cleanup + a long-lived API process).
   const canStart =
     inspectMatchesInput &&
     Boolean(inspect?.alias) &&
     !inspecting &&
     !starting &&
     job?.status !== "running" &&
-    job?.status !== "succeeded";
-  const registered = job?.status === "succeeded"
-    ? images.find((image) => image.alias === job.alias) ?? null
-    : null;
+    registered === null;
 
   const jobStatusLabel = job
     ? job.status === "running"

--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -7,6 +7,7 @@ import type {
   ImageResponse,
   MicroRegistryRegisterResponse,
   MicroRegistryResponse,
+  OciInspectResponse,
   VmResponse,
 } from "../bindings";
 import {
@@ -21,12 +22,15 @@ import {
   getImagePackage,
   getMicroRegistry,
   getMicroRegistryRegisterJob,
+  getOciImport,
+  inspectOciImage,
   listImages,
   listVms,
   startBootstrap,
   startImageInstall,
   startImagePackage,
   startMicroRegistryRegister,
+  startOciImport,
   stopVm,
 } from "../api/client";
 import { logDownloadFilename } from "../lib/textExport";
@@ -70,7 +74,13 @@ function formatTransferRate(bytesPerSecond: number | null): string {
 }
 
 /** Download-only progress. Terminal states use the normal status badge. */
-function PackageDownloadProgress({ job }: { job: ImageInstallResponse }) {
+function PackageDownloadProgress({
+  job,
+  label = "M2Image package download",
+}: {
+  job: ImageInstallResponse;
+  label?: string;
+}) {
   const measuredPercent = packageDownloadPercent(job);
   const barPercent = measuredPercent ?? 35;
   const sampleRef = useRef({
@@ -105,7 +115,7 @@ function PackageDownloadProgress({ job }: { job: ImageInstallResponse }) {
       <span
         className={`package-progress-track${measuredPercent === null ? " indeterminate" : ""}`}
         role="progressbar"
-        aria-label="M2Image package download"
+        aria-label={label}
         aria-valuenow={measuredPercent ?? undefined}
         aria-valuemin={0}
         aria-valuemax={100}
@@ -374,14 +384,16 @@ function ImageJobLog({
   kind,
 }: {
   job: ImageInstallResponse;
-  kind: "download" | "import" | "register";
+  kind: "download" | "import" | "oci" | "register";
 }) {
   const { t } = useI18n();
   const label = kind === "download"
     ? t("Package download log", "패키지 다운로드 로그")
-    : kind === "register"
-      ? t("Register log", "등록 로그")
-      : t("Image import log", "이미지 가져오기 로그");
+    : kind === "oci"
+      ? t("OCI import log", "OCI 가져오기 로그")
+      : kind === "register"
+        ? t("Register log", "등록 로그")
+        : t("Image import log", "이미지 가져오기 로그");
 
   return (
     <div className="subpanel">
@@ -584,6 +596,13 @@ function MicroBootPanel({
   );
 }
 
+function apiErrorText(error: unknown): string {
+  if (error instanceof ApiClientError) {
+    return error.fieldError("reference") ?? error.message;
+  }
+  return (error as Error).message;
+}
+
 function lastLogLine(log: string, fallback: string): string {
   const line = log.trim().split("\n").filter(Boolean).at(-1);
   return line || fallback;
@@ -597,9 +616,319 @@ function jobStatusClass(status: ImageInstallResponse["status"]): string {
 }
 
 /**
- * M2Image inventory, MicroBoot builder, and MicroRegistry are intentionally
- * separate panels so local images, local builds, and remote packages do not
- * read as one mixed catalog.
+ * Inspect an OCI reference, then start/poll `POST/GET /api/oci/import`
+ * with the same job snapshot the M2Image install path already uses.
+ */
+function OciImportPanel({
+  images,
+  onImported,
+}: {
+  images: ImageResponse[];
+  onImported: (alias: string) => Promise<void>;
+}) {
+  const { t } = useI18n();
+  const [reference, setReference] = useState("");
+  const [inspectedReference, setInspectedReference] = useState<string | null>(null);
+  const [inspect, setInspect] = useState<OciInspectResponse | null>(null);
+  const [inspecting, setInspecting] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [job, setJob] = useState<ImageInstallResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const pollingAliasRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const pollImport = useCallback((alias: string) => {
+    if (pollingAliasRef.current === alias) return;
+    pollingAliasRef.current = alias;
+    const stop = () => {
+      if (pollingAliasRef.current === alias) pollingAliasRef.current = null;
+    };
+    const tick = async () => {
+      if (!mountedRef.current) return stop();
+      try {
+        const latest = await getOciImport(alias);
+        if (!mountedRef.current) return stop();
+        setJob((current) => keepNewestJobSnapshot(current, latest));
+        if (latest.status === "running") {
+          setTimeout(() => void tick(), 500);
+          return;
+        }
+        stop();
+        if (latest.status === "succeeded") {
+          setError(null);
+          setInfo(t(
+            `Imported as ${latest.alias}. It now appears in M2Image.`,
+            `${latest.alias}(으)로 가져왔습니다. M2Image 목록에 나타납니다.`,
+          ));
+          await onImported(latest.alias);
+        } else if (latest.status === "failed") {
+          setInfo(null);
+          setError(lastLogLine(latest.log, t("OCI import failed.", "OCI 가져오기에 실패했습니다.")));
+        }
+      } catch {
+        if (mountedRef.current) setTimeout(() => void tick(), 500);
+        else stop();
+      }
+    };
+    void tick();
+  }, [onImported, t]);
+
+  const resumeImport = useCallback(async (alias: string) => {
+    try {
+      const latest = await getOciImport(alias);
+      if (!mountedRef.current) return;
+      setJob((current) => keepNewestJobSnapshot(current, latest));
+      if (latest.status === "running") {
+        pollImport(alias);
+      } else if (latest.status === "succeeded") {
+        setInfo(t(
+          `Imported as ${latest.alias}. It now appears in M2Image.`,
+          `${latest.alias}(으)로 가져왔습니다. M2Image 목록에 나타납니다.`,
+        ));
+        await onImported(latest.alias);
+      } else if (latest.status === "failed") {
+        setError(lastLogLine(latest.log, t("OCI import failed.", "OCI 가져오기에 실패했습니다.")));
+      }
+    } catch {
+      // Idle or a missing job is the ordinary case after a fresh inspect.
+    }
+  }, [onImported, pollImport, t]);
+
+  const handleInspect = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmed = reference.trim();
+    if (!trimmed) {
+      setInspect(null);
+      setInspectedReference(null);
+      setInfo(null);
+      setError(t("Enter an image reference.", "이미지 참조를 입력하세요."));
+      return;
+    }
+    setInspecting(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const next = await inspectOciImage(trimmed);
+      if (!mountedRef.current) return;
+      setInspect(next);
+      setInspectedReference(trimmed);
+      if (next.alias) await resumeImport(next.alias);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      setInspect(null);
+      setInspectedReference(null);
+      setError(apiErrorText(err));
+    } finally {
+      if (mountedRef.current) setInspecting(false);
+    }
+  };
+
+  const handleStartImport = async () => {
+    if (!inspect || starting || job?.status === "running") return;
+    const trimmed = reference.trim();
+    if (!trimmed || trimmed !== inspectedReference) return;
+    setStarting(true);
+    setError(null);
+    setInfo(null);
+    try {
+      const started = await startOciImport({ reference: trimmed });
+      if (!mountedRef.current) return;
+      setJob((current) => keepNewestJobSnapshot(current, started));
+      pollImport(started.alias);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      const code = err instanceof ApiClientError ? err.apiError?.code : undefined;
+      if (code === "import_in_progress" && inspect.alias) {
+        await resumeImport(inspect.alias);
+        return;
+      }
+      setError(apiErrorText(err));
+    } finally {
+      if (mountedRef.current) setStarting(false);
+    }
+  };
+
+  const handleReferenceChange = (value: string) => {
+    setReference(value);
+    if (inspectedReference !== null && value.trim() !== inspectedReference) {
+      setInspect(null);
+      setInspectedReference(null);
+      setError(null);
+      setInfo(null);
+      if (job && job.status !== "running") setJob(null);
+    }
+  };
+
+  const inspectMatchesInput = inspect !== null && inspectedReference === reference.trim();
+  const canStart =
+    inspectMatchesInput &&
+    Boolean(inspect?.alias) &&
+    !inspecting &&
+    !starting &&
+    job?.status !== "running" &&
+    job?.status !== "succeeded";
+  const registered = job?.status === "succeeded"
+    ? images.find((image) => image.alias === job.alias) ?? null
+    : null;
+
+  const jobStatusLabel = job
+    ? job.status === "running"
+      ? t("Importing…", "가져오는 중…")
+      : job.status === "succeeded"
+        ? t("Imported", "가져옴")
+        : job.status === "failed"
+          ? t("Import failed", "가져오기 실패")
+          : t("Idle", "대기")
+    : null;
+
+  return (
+    <section className="panel">
+      <h2 className="panel-title">OCI</h2>
+      <p className="panel-intro">
+        {t(
+          "Inspect a container image, then import it as a bootable template on this host. The registered alias appears in M2Image.",
+          "컨테이너 이미지를 검사한 뒤 이 호스트의 부팅 가능한 템플릿으로 가져옵니다. 등록된 별칭은 M2Image에 나타납니다.",
+        )}
+      </p>
+      {(error || info) && (
+        <div style={{ marginBottom: "1rem" }}>
+          {error && <Banner kind="error" text={error} onDismiss={() => setError(null)} />}
+          {info && <Banner kind="info" text={info} onDismiss={() => setInfo(null)} />}
+        </div>
+      )}
+      <form className="create-grid" onSubmit={(event) => void handleInspect(event)}>
+        <div className="field" style={{ gridColumn: "1 / -1" }}>
+          <label htmlFor="oci-reference">{t("Reference", "참조")}</label>
+          <input
+            id="oci-reference"
+            name="reference"
+            placeholder="nginx:1.27"
+            value={reference}
+            onChange={(event) => handleReferenceChange(event.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            disabled={inspecting || starting || job?.status === "running"}
+          />
+          <span className="field-error" aria-hidden />
+        </div>
+        <div className="field">
+          <label htmlFor="oci-inspect">&nbsp;</label>
+          <button
+            id="oci-inspect"
+            className="btn"
+            type="submit"
+            disabled={inspecting || starting || job?.status === "running"}
+          >
+            {inspecting ? t("Inspecting…", "검사 중…") : t("Inspect", "검사")}
+          </button>
+          <span className="field-error" aria-hidden />
+        </div>
+        <div className="field">
+          <label htmlFor="oci-import">&nbsp;</label>
+          <button
+            id="oci-import"
+            className="btn primary"
+            type="button"
+            disabled={!canStart}
+            onClick={() => void handleStartImport()}
+          >
+            {starting || job?.status === "running"
+              ? t("Importing…", "가져오는 중…")
+              : t("Start Import", "가져오기 시작")}
+          </button>
+          <span className="field-error" aria-hidden />
+        </div>
+      </form>
+
+      {inspectMatchesInput && inspect && (
+        <div className="subpanel">
+          <dl className="detail-fields mono">
+            <dt>{t("Compatibility", "호환성")}</dt>
+            <dd>
+              {t(
+                "Compatible with this host.",
+                "이 호스트와 호환됩니다.",
+              )}
+              {" "}
+              {inspect.singlePlatform
+                ? t(
+                    `Single-platform image for ${inspect.architecture}.`,
+                    `${inspect.architecture} 단일 플랫폼 이미지입니다.`,
+                  )
+                : t(
+                    `This host selected the ${inspect.architecture} platform from a multi-arch index.`,
+                    `이 호스트가 다중 아키텍처 인덱스에서 ${inspect.architecture} 플랫폼을 선택했습니다.`,
+                  )}
+            </dd>
+            <dt>{t("Digest", "다이제스트")}</dt>
+            <dd>{inspect.digest}</dd>
+            <dt>{t("Architecture", "아키텍처")}</dt>
+            <dd>{inspect.architecture}</dd>
+            <dt>alias</dt>
+            <dd>{inspect.alias}</dd>
+            <dt>{t("Version", "버전")}</dt>
+            <dd>
+              {inspect.version}
+              {inspect.immutable
+                ? ` · ${t("Pinned digest", "고정된 다이제스트")}`
+                : ` · ${t("Tag may move", "태그가 바뀔 수 있음")}`}
+            </dd>
+            <dt>{t("Registry", "레지스트리")}</dt>
+            <dd>{inspect.registry}/{inspect.repository}</dd>
+          </dl>
+        </div>
+      )}
+
+      {job && job.status !== "idle" && (
+        <>
+          <div className="subpanel">
+            <dl className="detail-fields mono">
+              <dt>{t("Import status", "가져오기 상태")}</dt>
+              <dd>
+                <span className={`state-badge${jobStatusClass(job.status)}`}>{jobStatusLabel}</span>
+              </dd>
+              {job.status === "running" && (
+                <>
+                  <dt>{t("Progress", "진행")}</dt>
+                  <dd>
+                    <PackageDownloadProgress
+                      job={job}
+                      label={t("OCI import progress", "OCI 가져오기 진행")}
+                    />
+                  </dd>
+                </>
+              )}
+              {job.status === "succeeded" && (
+                <>
+                  <dt>{t("Registered image", "등록된 이미지")}</dt>
+                  <dd>
+                    {registered
+                      ? `${registered.alias} · ${t("Installed", "설치됨")}${registered.version ? ` · ${registered.version}` : ""}`
+                      : `${job.alias} · ${t("Installed", "설치됨")}`}
+                  </dd>
+                </>
+              )}
+            </dl>
+          </div>
+          <ImageJobLog job={job} kind="oci" />
+        </>
+      )}
+    </section>
+  );
+}
+
+/**
+ * M2Image inventory, MicroBoot builder, MicroRegistry, and OCI import are
+ * intentionally separate panels so local images, local builds, remote
+ * packages, and container imports do not read as one mixed catalog.
  */
 export default function Images() {
   const { t } = useI18n();
@@ -645,6 +974,11 @@ export default function Images() {
       setListError((error as Error).message);
     }
   }, []);
+
+  const handleOciImported = useCallback(async (alias: string) => {
+    await refreshList();
+    setSelectedAlias(alias);
+  }, [refreshList]);
 
   const refreshRegistry = useCallback(async () => {
     try {
@@ -1379,6 +1713,10 @@ export default function Images() {
           />
         )}
       </section>
+      <OciImportPanel
+        images={images ?? []}
+        onImported={handleOciImported}
+      />
       {registryPanel}
       <MicroBootPanel
         images={images ?? []}

--- a/public-docs/README.md
+++ b/public-docs/README.md
@@ -25,6 +25,7 @@ Every page covers one topic.
 | Bridges, DHCP, NAT, and policy | [Networking](networking.md) |
 | VM disk placement | [Storage](storage.md) |
 | Kernel and rootfs templates | [Images](images.md) |
+| OCI inspect and import | [OCI images](oci.md) |
 | Services and maintenance | [Operations](operations.md) |
 | Failure checks | [Troubleshooting](troubleshooting.md) |
 

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -83,6 +83,7 @@ The response has status `201` and includes the VM UUID.
 | MicroStorage | `/api/storage`, `/api/storage/devices`, `/api/micro-storages` |
 | Shells | `/api/shells`, `/{id}`, `POST /{id}/revisions`, `GET /{id}/revisions/{revisionId}`; VM pin `PUT /api/vms/{id}/shells` (Alpine OpenRC + Ubuntu/Rocky systemd; prefer POSIX `/bin/sh`) |
 | Images | `/api/images`, `/package`, `/install`, `/bootstrap` |
+| OCI | `/api/oci/inspect`, `POST /api/oci/import`, `GET /api/oci/import/{alias}` |
 | Host | `/api/host` and `/api/network` |
 
 ## VM states
@@ -117,4 +118,5 @@ Use `requestId` to find the matching server log.
 - [Networking](networking.md)
 - [Storage](storage.md)
 - [Images](images.md)
+- [OCI images](oci.md)
 - [Troubleshooting](troubleshooting.md)

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -35,7 +35,7 @@ Use `localhost` because the development origin is exact.
 | Terminal | Use the serial console |
 | Networks | Manage MicroNetworks |
 | Storage | Manage MicroStorage pools |
-| Images | Install and build M2Images |
+| Images | Install M2Images or import an OCI image |
 | Host | Show host health and capacity |
 
 ## VM workflow
@@ -61,6 +61,11 @@ the guest disk.
 Resource changes are allowed only while the VM is inactive.
 Disk size can grow but cannot shrink.
 
+## Images
+
+The Images screen can inspect an OCI reference and start an import.
+Poll the job until the alias appears in the local catalog and can create a VM.
+
 ## Production
 
 Build the dashboard and let the API serve it.
@@ -84,5 +89,6 @@ The host installer configures this mode.
 ## Related
 
 - [API](api.md)
+- [OCI images](oci.md)
 - [Networking](networking.md)
 - [Troubleshooting](troubleshooting.md)

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -2,6 +2,7 @@
 
 An M2Image contains a kernel and root filesystem.
 It is the source template for new VM disks.
+A container image from a registry is imported separately; see [OCI images](oci.md).
 
 Supported aliases are `alpine-3.24.1`, `ubuntu-26.04`, and `rocky-9.8`.
 All three support x86_64 and ARM64. Rocky is exposed only through the

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -113,12 +113,13 @@ when it no longer passes. Operators can name a mirror with
 
 ## Guest activation
 
-Activation installs an init at `/sbin/init`, so the image boots on the same
-kernel command line every other template uses. It also installs a boot script
-that mounts `/proc`, `/sys`, `/dev` and `/run`, brings the interface up before
-asking for a lease, reports `FIRECRAB_NETWORK_READY` with the address it
-received or `FIRECRAB_NETWORK_FAILED` with a reason, and starts the metrics
-agent that reports guest CPU and memory. `/etc/firecrab/services.d` is created
+Activation installs an init at `/sbin/init` and the toolbox at
+`/etc/firecrab/busybox` (basename `busybox`, so the multiplexer runs), so the
+image boots on the same kernel command line every other template uses. It also
+installs a boot script that mounts `/proc`, `/sys`, `/dev` and `/run`, brings
+the interface up before asking for a lease, reports `FIRECRAB_NETWORK_READY`
+with the address it received or `FIRECRAB_NETWORK_FAILED` with a reason, and
+starts the metrics agent that reports guest CPU and memory. `/etc/firecrab/services.d` is created
 empty for the image's own entrypoint, which a later stage translates into an
 ordinary service under that init rather than PID 1.
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -1,10 +1,8 @@
 # OCI images
 
-firecrab can read a container image from a registry and report whether this
-host can run it.
-The internal pipeline can size a provisioned tree into an ext4 image, pair
-it with an architecture-matched kernel, and derive an alias from the reference.
-Registering a template is still separate work.
+firecrab can inspect a container image and import it as a bootable template.
+The pipeline caches layers, merges them, injects a guest runtime, writes ext4,
+pairs a kernel, and registers an alias.
 
 ## Inspect
 
@@ -15,30 +13,35 @@ config or layers.
 curl -s 'http://127.0.0.1:3000/api/oci/inspect?reference=nginx:1.27'
 ```
 
-The reference is written as at `docker pull`, so a bare name resolves to Docker
-Hub's `library` namespace at `latest`.
-The answer is the manifest digest this host would pull; an image offering no
-manifest for this architecture is rejected, naming the ones it does offer.
-
-OCI platforms use Go's names, so x86_64 appears as `amd64` — not the label the
-MicroRegistry catalog uses.
+The reference is written as at `docker pull`, so a bare name resolves to Docker Hub's `library` namespace at `latest`.
+The answer is the manifest digest this host would pull; a missing architecture is rejected.
+OCI platforms use Go's names, so x86_64 appears as `amd64`.
 Registries are reached over HTTPS, except `localhost` and `127.0.0.1`.
-This endpoint reads registry metadata only. It neither imports the image nor
-populates the blob cache.
+This endpoint reads metadata only and includes the alias a later import will claim.
+
+## Import
+
+Import is a background job because REST requests time out at 10 seconds.
+
+```sh
+curl -s -X POST http://127.0.0.1:3000/api/oci/import \
+  -H 'Content-Type: application/json' \
+  -d '{"reference":"nginx:1.27"}'
+```
+
+Poll `GET /api/oci/import/{alias}` for the same `ImageInstallResponse` package install uses.
+A bad reference is `400 validation_failed`.
+A catalog or installed alias is `409 alias_collision`.
+A running job for that alias is `409 import_in_progress`.
+Success adds the alias to `GET /api/images`.
 
 ## Blob cache
 
 Internal OCI pulls cache image configs and layers by their SHA-256 digest at
 `<FIRECRAB_IMAGE_ROOT>/.oci/blobs/sha256/<hex>`.
-Entries contain the raw bytes returned by the registry and are never replaced
-with decompressed data.
-
-Every cache lookup streams the complete entry and verifies both its expected
-size and SHA-256 digest before reuse. A corrupt entry is discarded and fetched
-again, and a download becomes visible at its final path only after the same
-checks succeed.
-One config or layer download is limited to 16 GiB by default; operators can
-change this with `FIRECRAB_OCI_MAX_BLOB_BYTES`.
+Entries contain the raw bytes returned by the registry and are never replaced with decompressed data.
+Every cache lookup verifies size and SHA-256 before reuse; a corrupt entry is discarded and fetched again.
+One config or layer download is limited to 16 GiB by default (`FIRECRAB_OCI_MAX_BLOB_BYTES`).
 
 ## Layer decompression
 
@@ -48,31 +51,25 @@ Each result keeps the manifest descriptor, whose digest covers the registry
 bytes, separate from the matching config `rootfs.diff_ids` entry, whose digest
 covers the uncompressed tar stream.
 
-The decoder streams output while calculating that diff ID and publishes a tar
-only after it matches. Cache hits are rehashed, corrupt entries are rebuilt
-from the verified blob, and failed work leaves no partial tar. Decoder output
-is limited to 64 GiB per layer by default; change it with
-`FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`. At most two layer decoders run
-process-wide, and each zstd decoder has a 128 MiB window limit.
+The decoder publishes a tar only after the diff ID matches.
+Cache hits are rehashed and corrupt entries are rebuilt from the verified blob.
+Decoder output is limited to 64 GiB per layer (`FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`).
+At most two layer decoders run process-wide, and each zstd decoder has a 128 MiB window.
 
 ## Layer safety preflight
 
 Before extraction, the internal pipeline scans every decompressed tar using
 GNU long-name/link metadata and PAX overrides. Member names must be relative
 paths without parent components; only a directory may name the archive root
-as `.` or `./`. Character and block devices are rejected, as are unsupported
-special entries. Links must name a target;
-hard-link targets are archive-root-relative and cannot be absolute or contain
-parent components. Regular whiteout files remain valid for the later merge
-stage.
+as `.` or `./`. Character and block devices are rejected, as are unsupported special entries.
+Links must name a target; hard-link targets stay archive-root-relative.
+Regular whiteout files remain valid for the later merge stage.
 
 Malformed headers, repeated PAX path/link records, sparse extensions,
-missing end records, and truncated member bodies stop the import before any
-filesystem tree is created. PAX `size` overrides and global PAX path/link/size
-overrides are rejected to avoid different tar parsers disagreeing about member
-boundaries or destinations. Each GNU or PAX metadata entry is limited to 1
-MiB. Rejection does not delete the already verified compressed blob or
-decompressed tar: both remain valid content-addressed cache entries.
+missing end records, and truncated member bodies stop the import.
+PAX `size` overrides and global PAX path/link/size overrides are rejected.
+Each GNU or PAX metadata entry is limited to 1 MiB.
+Rejection keeps the verified blob and decompressed tar as cache entries.
 
 ## Layer merge
 
@@ -153,8 +150,7 @@ This stage still pairs no kernel and registers nothing.
 
 The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
 The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
-A catalog or installed alias is refused.
-The ext4 is copied to `rootfs/<alias>.ext4` and registered; a failure deletes that file.
+A catalog or installed alias is refused; the ext4 is copied to `rootfs/<alias>.ext4`.
 
 ## Service
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -160,5 +160,6 @@ The injected init starts it after the sentinel. It is never PID 1.
 ## Related
 
 - [Images](images.md)
+- [Dashboard](dashboard.md)
 - [API](api.md)
 - [Storage](storage.md)

--- a/scripts/oci-e2e-registry.py
+++ b/scripts/oci-e2e-registry.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Isolated loopback OCI registry for import tests and the browser E2E.
+
+Serves one tiny Linux image for this host (amd64 or arm64) on 127.0.0.1.
+Nothing is pulled from Docker Hub. Stop the process (SIGINT/SIGTERM) or
+leave the context manager to close the listener and delete scratch blobs.
+
+Usage:
+    python3 scripts/oci-e2e-registry.py
+    python3 scripts/oci-e2e-registry.py --port 15555
+
+The first stdout line is JSON with the reference testers type:
+
+    127.0.0.1:<port>/firecrab/e2e:ready
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import signal
+import sys
+import tarfile
+import tempfile
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Optional
+from urllib.parse import unquote
+
+READY_SENTINEL = "FIRECRAB_OCI_E2E_READY"
+REPOSITORY = "firecrab/e2e"
+TAG = "ready"
+ENTRYPOINT = ["/sbin/firecrab-busybox", "sh", "-c"]
+MANIFEST_TYPE = "application/vnd.oci.image.manifest.v1+json"
+CONFIG_TYPE = "application/vnd.oci.image.config.v1+json"
+LAYER_TYPE = "application/vnd.oci.image.layer.v1.tar+gzip"
+READY_COMMAND = (
+    f"while true; do echo {READY_SENTINEL}; /sbin/firecrab-busybox sleep 2; done"
+)
+
+
+def host_oci_arch() -> str:
+    machine = os.uname().machine
+    return "arm64" if machine in ("aarch64", "arm64") else "amd64"
+
+
+def sha256_digest(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def descriptor(media_type: str, digest: str, size: int) -> dict:
+    return {"mediaType": media_type, "digest": digest, "size": size}
+
+
+def build_layer_tar() -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w") as archive:
+        directory = tarfile.TarInfo("etc")
+        directory.type = tarfile.DIRTYPE
+        directory.mode = 0o755
+        archive.addfile(directory)
+        payload = f"{READY_SENTINEL}\n".encode()
+        member = tarfile.TarInfo("etc/firecrab-e2e")
+        member.size = len(payload)
+        member.mode = 0o644
+        archive.addfile(member, io.BytesIO(payload))
+    return buffer.getvalue()
+
+
+class LocalOciRegistry:
+    """In-process distribution v2 server. Safe to use as a context manager."""
+
+    def __init__(self, port: int = 0) -> None:
+        self._port = port
+        self._httpd: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._scratch: Optional[tempfile.TemporaryDirectory[str]] = None
+        self.reference = ""
+        self.alias = ""
+        self.architecture = host_oci_arch()
+
+    def start(self) -> "LocalOciRegistry":
+        scratch = tempfile.TemporaryDirectory(prefix="firecrab-oci-e2e-")
+        image = _Image.materialize(Path(scratch.name), self.architecture)
+        handler = _handler_for(image)
+        httpd = _LoopbackServer(("127.0.0.1", self._port), handler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        port = httpd.server_address[1]
+        self._scratch = scratch
+        self._httpd = httpd
+        self._thread = thread
+        self.reference = f"127.0.0.1:{port}/{REPOSITORY}:{TAG}"
+        self.alias = f"127.0.0.1-{port}-firecrab-e2e-ready"
+        return self
+
+    def stop(self) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+        if self._scratch is not None:
+            self._scratch.cleanup()
+            self._scratch = None
+
+    def __enter__(self) -> "LocalOciRegistry":
+        return self.start()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()
+
+    def announcement(self) -> dict[str, str]:
+        return {
+            "reference": self.reference,
+            "ready": READY_SENTINEL,
+            "alias": self.alias,
+            "architecture": self.architecture,
+        }
+
+
+class _Image:
+    def __init__(
+        self,
+        manifest: bytes,
+        manifest_digest: str,
+        blobs: dict[str, bytes],
+    ) -> None:
+        self.manifest = manifest
+        self.manifest_digest = manifest_digest
+        self.blobs = blobs
+
+    @classmethod
+    def materialize(cls, scratch: Path, architecture: str) -> "_Image":
+        layer_tar = build_layer_tar()
+        (scratch / "layer.tar").write_bytes(layer_tar)
+        compressed = gzip.compress(layer_tar)
+        (scratch / "layer.tar.gz").write_bytes(compressed)
+        config = json.dumps(
+            {
+                "architecture": architecture,
+                "os": "linux",
+                "config": {"Entrypoint": ENTRYPOINT, "Cmd": [READY_COMMAND]},
+                "rootfs": {
+                    "type": "layers",
+                    "diff_ids": [sha256_digest(layer_tar)],
+                },
+            },
+            separators=(",", ":"),
+        ).encode()
+        (scratch / "config.json").write_bytes(config)
+        config_digest = sha256_digest(config)
+        layer_digest = sha256_digest(compressed)
+        manifest = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": MANIFEST_TYPE,
+                "config": descriptor(CONFIG_TYPE, config_digest, len(config)),
+                "layers": [descriptor(LAYER_TYPE, layer_digest, len(compressed))],
+            },
+            separators=(",", ":"),
+        ).encode()
+        (scratch / "manifest.json").write_bytes(manifest)
+        return cls(
+            manifest,
+            sha256_digest(manifest),
+            {config_digest: config, layer_digest: compressed},
+        )
+
+
+class _LoopbackServer(ThreadingHTTPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def _handler_for(image: _Image):
+    prefix = f"/v2/{REPOSITORY}"
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args) -> None:
+            return
+
+        def do_GET(self) -> None:
+            path = unquote(self.path.split("?", 1)[0])
+            if path in ("/v2", "/v2/"):
+                self._send(200, b"{}", "application/json", extra={
+                    "Docker-Distribution-API-Version": "registry/2.0",
+                })
+                return
+            if path.startswith(f"{prefix}/manifests/"):
+                selector = path.rsplit("/", 1)[-1]
+                if selector in (TAG, image.manifest_digest):
+                    self._send(
+                        200,
+                        image.manifest,
+                        MANIFEST_TYPE,
+                        extra={"Docker-Content-Digest": image.manifest_digest},
+                    )
+                    return
+            if path.startswith(f"{prefix}/blobs/"):
+                digest = path.rsplit("/", 1)[-1]
+                blob = image.blobs.get(digest)
+                if blob is not None:
+                    self._send(
+                        200,
+                        blob,
+                        "application/octet-stream",
+                        extra={"Docker-Content-Digest": digest},
+                    )
+                    return
+            self.send_error(404, "not found")
+
+        def _send(
+            self,
+            status: int,
+            body: bytes,
+            content_type: str,
+            extra: Optional[dict[str, str]] = None,
+        ) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            for key, value in (extra or {}).items():
+                self.send_header(key, value)
+            self.end_headers()
+            self.wfile.write(body)
+
+    return Handler
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("FIRECRAB_OCI_E2E_PORT", "0")),
+        help="loopback port (0 = ephemeral, also FIRECRAB_OCI_E2E_PORT)",
+    )
+    args = parser.parse_args(argv)
+    registry = LocalOciRegistry(port=args.port)
+    registry.start()
+    stop = threading.Event()
+
+    def request_stop(_signum=None, _frame=None) -> None:
+        stop.set()
+
+    signal.signal(signal.SIGINT, request_stop)
+    signal.signal(signal.SIGTERM, request_stop)
+    try:
+        print(json.dumps(registry.announcement()), flush=True)
+        print(
+            f"type this reference: {registry.reference}",
+            file=sys.stderr,
+            flush=True,
+        )
+        stop.wait()
+    finally:
+        registry.stop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/oci-e2e-registry.py
+++ b/scripts/oci-e2e-registry.py
@@ -35,12 +35,12 @@ from urllib.parse import unquote
 READY_SENTINEL = "FIRECRAB_OCI_E2E_READY"
 REPOSITORY = "firecrab/e2e"
 TAG = "ready"
-ENTRYPOINT = ["/sbin/firecrab-busybox", "sh", "-c"]
+ENTRYPOINT = ["/etc/firecrab/busybox", "sh", "-c"]
 MANIFEST_TYPE = "application/vnd.oci.image.manifest.v1+json"
 CONFIG_TYPE = "application/vnd.oci.image.config.v1+json"
 LAYER_TYPE = "application/vnd.oci.image.layer.v1.tar+gzip"
 READY_COMMAND = (
-    f"while true; do echo {READY_SENTINEL}; /sbin/firecrab-busybox sleep 2; done"
+    f"while true; do echo {READY_SENTINEL}; /etc/firecrab/busybox sleep 2; done"
 )
 
 


### PR DESCRIPTION
## Summary

Import an OCI image from a registry and turn it into a bootable `rootfs.ext4`.

This is the remaining #90 slice on `main`: inspect and import from the Images dashboard, a deterministic local-registry E2E, and the guest-boot fixes that make the acceptance criteria hold.

## Motivation

- OCI is the format most existing application images ship in.
- A container rootfs has no PID 1, no DHCP client and no readiness sentinel, so it cannot boot as a MicroVM as-is. Guest enablement is part of importing, not a separate feature.
- The injected toolbox was named `firecrab-busybox`. busybox treats `argv[0]`'s basename as the applet, so every inittab and shebang printed `firecrab-busybox: applet not found` and DHCP never ran.
- An OCI import borrows the Ubuntu catalog kernel. Unregistering that alias must not delete the kernel or the next import cannot pair.

## What landed

- `POST /api/oci/import` + `GET /api/oci/import/{alias}` and `GET /api/oci/inspect`, with the Images flow to enter a reference, inspect compatibility, start the import, show progress and errors, and display the registered image.
- Docker Hub `token` + `access_token`, a local OCI registry fixture, and a browser-driven E2E.
- Inject the toolbox at `/etc/firecrab/busybox` (basename `busybox`) and point init, inittab, and the DHCP shebang at that path.
- Keep a catalog kernel when an OCI alias that borrowed it is unregistered. Deleting the catalog alias itself still removes its own kernel and rootfs.

## Acceptance

- Importing a published image produces a registered image that boots, gets an IPv4 address, and reports ready.
- The image's original entrypoint runs as a service under the guest's init.
- The web frontend can inspect an OCI reference, start an import, show progress or a useful failure, and display the registered image when complete.
- A deterministic E2E test drives the web frontend against a local registry fixture and proves the imported image is registered, boots with IPv4, reports ready, and starts its configured service.

Out of scope (same as #90): pushing images, private registry credentials, multi-arch emulation, applying an updated image to existing VM disks.

## Testing

- `cargo test -p firecrab-api oci::provision_tests` — 13 passed
- `cargo test -p firecrab-api unregistering` — 3 passed (includes borrowed-kernel and catalog-owner cases)
- `cargo fmt --all -- --check`
- `tsc -b` and `npm run lint` in `firecrab-frontend` (0 errors; existing `i18n.tsx` Fast Refresh warning)

Related to #90.