### PR TITLE
feat(api): add MicroRegistry register job and merge local catalog entries

### DIFF
--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -904,6 +904,16 @@ pub struct OciImportRequest {
     pub reference: String,
 }
 
+/// Request body for `POST /api/microregistry/register`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MicroRegistryRegisterRequest {
+    /// Installed template alias to publish into this host's catalog.
+    pub alias: String,
+    /// Operator-supplied catalog version for this registration.
+    pub version: String,
+}
+
 /// Lifecycle of one from-scratch distro bootstrap session (`handlers::bootstrap`).
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -1327,6 +1337,20 @@ mod tests {
         assert_eq!(json, r#"{"reference":"nginx:1.27"}"#);
         assert_eq!(
             serde_json::from_str::<OciImportRequest>(&json).unwrap(),
+            request
+        );
+    }
+
+    #[test]
+    fn microregistry_register_request_round_trips_camel_case() {
+        let request = MicroRegistryRegisterRequest {
+            alias: "nginx-1.27".to_owned(),
+            version: "1".to_owned(),
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert_eq!(json, r#"{"alias":"nginx-1.27","version":"1"}"#);
+        assert_eq!(
+            serde_json::from_str::<MicroRegistryRegisterRequest>(&json).unwrap(),
             request
         );
     }

--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -6,17 +6,25 @@
 //! on the existing `/api/images/{alias}/package` endpoint, which verifies the
 //! per-distribution checksum before an archive becomes installable.
 
-use std::time::Duration;
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::Json;
-use axum::extract::State;
-use firecrab_api_types::{MicroRegistryImageResponse, MicroRegistryResponse};
+use axum::extract::{Path as AliasPath, State};
+use axum::http::StatusCode;
+use firecrab_api_types::{
+    ImageInstallResponse, MicroRegistryImageResponse, MicroRegistryRegisterRequest,
+    MicroRegistryResponse,
+};
 use serde::Deserialize;
 
 use crate::error::AppError;
-use crate::image_install::{self, Architecture};
+use crate::extract::ValidatedJson;
+use crate::image_install::{self, Architecture, ImageInstallTracker};
 use crate::server::RequestId;
-use crate::state::AppState;
+use crate::state::{AppState, LocalCatalogEntry};
 use crate::templates::TemplateRegistry;
 
 const CATALOG_MAX_BYTES: usize = 256 * 1024;
@@ -61,9 +69,87 @@ fn unavailable(request_id: RequestId, detail: impl std::fmt::Display) -> AppErro
     AppError::unavailable("MicroRegistry catalog is unavailable", request_id.0)
 }
 
+/// Smallest disk (GiB) that can hold `rootfs_bytes`, matching `images.rs`.
+fn min_disk_gb_for(rootfs_bytes: u64) -> u16 {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    rootfs_bytes.div_ceil(GIB).try_into().unwrap_or(u16::MAX)
+}
+
+fn rfc3339_utc_now() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0);
+    unix_secs_to_rfc3339(secs)
+}
+
+fn unix_secs_to_rfc3339(secs: u64) -> String {
+    const MONTH_DAYS: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut days = secs / 86_400;
+    let rem = secs % 86_400;
+    let hour = rem / 3600;
+    let min = (rem % 3600) / 60;
+    let sec = rem % 60;
+    let mut year = 1970_u64;
+    loop {
+        let length = if is_leap_year(year) { 366 } else { 365 };
+        if days < length {
+            break;
+        }
+        days -= length;
+        year += 1;
+    }
+    let mut month = 1_u64;
+    while month <= 12 {
+        let mut dim = MONTH_DAYS[(month - 1) as usize];
+        if month == 2 && is_leap_year(year) {
+            dim = 29;
+        }
+        if days < dim {
+            break;
+        }
+        days -= dim;
+        month += 1;
+    }
+    format!(
+        "{year:04}-{month:02}-{:02}T{hour:02}:{min:02}:{sec:02}Z",
+        days + 1
+    )
+}
+
+fn is_leap_year(year: u64) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn local_catalog_image(
+    templates: &TemplateRegistry,
+    image_root: &Path,
+    entry: &LocalCatalogEntry,
+) -> MicroRegistryImageResponse {
+    let installed = templates.resolve_alias(&entry.alias);
+    let min_disk_gb = installed
+        .as_ref()
+        .map(|template| min_disk_gb_for(template.rootfs.length()))
+        .unwrap_or(0);
+    MicroRegistryImageResponse {
+        installed: installed.is_some(),
+        package_staged: image_install::staged_package_exists(image_root, &entry.alias),
+        package_origin: image_install::staged_package_origin(image_root, &entry.alias),
+        downloadable: false,
+        alias: entry.alias.clone(),
+        version: entry.version.clone(),
+        package: String::new(),
+        sha256: String::new(),
+        min_disk_gb,
+        published_at: entry.published_at.clone(),
+    }
+}
+
 /// `GET /api/microregistry`: supported published packages plus this host's
 /// local install/cache state. Entries outside the release manifest are hidden
-/// because this Firecrab build cannot validate or install them.
+/// because this Firecrab build cannot validate or install them. Locally
+/// registered custom aliases are appended after the public filters so a
+/// catalog refresh cannot drop them.
 pub async fn list_microregistry(
     State(state): State<AppState>,
     axum::Extension(request_id): axum::Extension<RequestId>,
@@ -135,27 +221,246 @@ pub async fn list_microregistry(
             }
         })
         .collect::<Vec<_>>();
+
+    let locals: Vec<LocalCatalogEntry> = state
+        .microregistry_local
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .values()
+        .cloned()
+        .collect();
+    for entry in locals {
+        if images.iter().any(|image| image.alias == entry.alias) {
+            continue;
+        }
+        images.push(local_catalog_image(&templates, &image_root, &entry));
+    }
     images.sort_by(|left, right| left.alias.cmp(&right.alias));
 
     Ok(Json(MicroRegistryResponse { source, images }))
 }
 
+/// `POST /api/microregistry/register` — claim the alias and start the job.
+pub async fn start_microregistry_register(
+    State(state): State<AppState>,
+    axum::Extension(request_id): axum::Extension<RequestId>,
+    ValidatedJson(body): ValidatedJson<MicroRegistryRegisterRequest>,
+) -> Result<(StatusCode, Json<ImageInstallResponse>), AppError> {
+    let mut fields = BTreeMap::new();
+    if body.alias.trim().is_empty() {
+        fields.insert("alias".to_owned(), "must not be empty".to_owned());
+    }
+    if body.version.trim().is_empty() {
+        fields.insert("version".to_owned(), "must not be empty".to_owned());
+    }
+    if !fields.is_empty() {
+        return Err(AppError::validation(fields, request_id.0));
+    }
+
+    if body.alias == crate::microboot::MICROBOOT_ALIAS {
+        return Err(AppError::not_found(request_id.0));
+    }
+
+    if TemplateRegistry::known_spec(&body.alias).is_some() {
+        return Err(AppError::conflict(
+            "alias_collision",
+            "alias is already published in the catalog",
+            request_id.0,
+        ));
+    }
+
+    {
+        let local = state
+            .microregistry_local
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if local.contains_key(&body.alias) {
+            return Err(AppError::conflict(
+                "alias_collision",
+                "alias is already published in the catalog",
+                request_id.0,
+            ));
+        }
+    }
+
+    if state.templates.resolve_alias(&body.alias).is_none() {
+        return Err(AppError::not_found(request_id.0));
+    }
+
+    let response = match state
+        .microregistry_registers
+        .begin_with(&body.alias, "register started")
+    {
+        Ok(snapshot) => snapshot,
+        Err("running") => {
+            return Err(AppError::conflict(
+                "register_in_progress",
+                "a register is already running for this image",
+                request_id.0,
+            ));
+        }
+        Err(_) => return Err(AppError::internal(request_id.0)),
+    };
+
+    let tracker = state.microregistry_registers.clone();
+    let templates = state.templates.clone();
+    let catalog = Arc::clone(&state.microregistry_local);
+    let alias = body.alias.clone();
+    let version = body.version.clone();
+    tokio::spawn(async move {
+        run_microregistry_register(tracker, templates, catalog, alias, version).await;
+    });
+
+    Ok((StatusCode::ACCEPTED, Json(response)))
+}
+
+/// `GET /api/microregistry/register/{alias}` — latest snapshot, including idle.
+pub async fn get_microregistry_register(
+    State(state): State<AppState>,
+    AliasPath(alias): AliasPath<String>,
+    axum::Extension(_request_id): axum::Extension<RequestId>,
+) -> Result<Json<ImageInstallResponse>, AppError> {
+    Ok(Json(state.microregistry_registers.snapshot(&alias)))
+}
+
+async fn run_microregistry_register(
+    tracker: ImageInstallTracker,
+    templates: Arc<TemplateRegistry>,
+    catalog: Arc<Mutex<HashMap<String, LocalCatalogEntry>>>,
+    alias: String,
+    version: String,
+) {
+    tracker.append_log(&alias, "checking installed template");
+    if templates.resolve_alias(&alias).is_none() {
+        tracker.finish_err_with(&alias, "register failed: template is not installed");
+        return;
+    }
+    tracker.append_log(&alias, "updating catalog");
+    let published_at = rfc3339_utc_now();
+    {
+        let mut catalog = catalog
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        catalog.insert(
+            alias.clone(),
+            LocalCatalogEntry {
+                alias: alias.clone(),
+                version,
+                published_at,
+            },
+        );
+    }
+    tracker.finish_ok_with(&alias, "register succeeded — catalog updated");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::extract::ValidatedJson;
     use crate::image_install::ImageInstallTracker;
     use crate::state::AppState;
+    use crate::templates::TemplateSpec;
+    use axum::Json;
+    use axum::extract::{Path, State};
+    use axum::response::IntoResponse;
     use axum::routing::get;
     use axum::{Extension, Router};
+    use firecrab_api_types::ImageInstallStatus;
     use serde_json::json;
     use tempfile::tempdir;
-    use tokio::net::TcpListener;
 
     async fn empty_state(root: &std::path::Path) -> AppState {
         let templates = TemplateRegistry::from_specs(root, std::iter::empty()).unwrap();
         AppState::with_db_file(templates, root.join("state.db"))
             .await
             .unwrap()
+    }
+
+    fn install_custom(state: &AppState, alias: &str) {
+        let root = state.templates.image_root_path();
+        std::fs::create_dir_all(root.join("kernel")).unwrap();
+        std::fs::write(root.join("kernel/vmlinux"), b"kernel").unwrap();
+        std::fs::write(root.join(format!("{alias}.ext4")), vec![0_u8; 64]).unwrap();
+        state
+            .templates
+            .register_spec(TemplateSpec {
+                alias: alias.to_owned(),
+                version: format!("{alias}-local"),
+                kernel: std::path::PathBuf::from("kernel/vmlinux"),
+                initrd: None,
+                rootfs: std::path::PathBuf::from(format!("{alias}.ext4")),
+                boot_args: "console=ttyS0 root=/dev/vda rw".to_owned(),
+            })
+            .unwrap();
+    }
+
+    fn request_id() -> RequestId {
+        RequestId(uuid::Uuid::nil())
+    }
+
+    fn register_body(alias: &str, version: &str) -> ValidatedJson<MicroRegistryRegisterRequest> {
+        ValidatedJson(MicroRegistryRegisterRequest {
+            alias: alias.to_owned(),
+            version: version.to_owned(),
+        })
+    }
+
+    async fn error_json(error: AppError) -> (StatusCode, serde_json::Value) {
+        let response = error.into_response();
+        let status = response.status();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (
+            status,
+            serde_json::from_slice(&body).expect("error body is json"),
+        )
+    }
+
+    async fn wait_for_status(
+        state: &AppState,
+        alias: &str,
+        want: ImageInstallStatus,
+    ) -> ImageInstallResponse {
+        let mut snapshot = state.microregistry_registers.snapshot(alias);
+        for _ in 0..80 {
+            if snapshot.status == want {
+                return snapshot;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            snapshot = state.microregistry_registers.snapshot(alias);
+        }
+        snapshot
+    }
+
+    fn local_aliases(state: &AppState) -> Vec<String> {
+        let local = state
+            .microregistry_local
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut aliases: Vec<String> = local.keys().cloned().collect();
+        aliases.sort();
+        aliases
+    }
+
+    async fn state_with_catalog(
+        images: serde_json::Value,
+    ) -> (AppState, tempfile::TempDir, String) {
+        let app = Router::new().route(
+            "/catalog.json",
+            get(move || {
+                let images = images.clone();
+                async move { Json(json!({ "images": images })) }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let directory = tempdir().unwrap();
+        let mut state = empty_state(directory.path()).await;
+        state.image_packages = ImageInstallTracker::with_base_url(format!("http://{address}"));
+        (state, directory, format!("http://{address}/catalog.json"))
     }
 
     #[tokio::test]
@@ -195,7 +500,7 @@ mod tests {
                 }))
             }),
         );
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
@@ -257,5 +562,361 @@ mod tests {
             assert!(message.contains("x86_64"), "{message}");
             assert!(message.contains("aarch64"), "{message}");
         }
+    }
+
+    #[test]
+    fn unix_secs_to_rfc3339_formats_utc() {
+        assert_eq!(unix_secs_to_rfc3339(0), "1970-01-01T00:00:00Z");
+        assert_eq!(unix_secs_to_rfc3339(1_702_080_000), "2023-12-09T00:00:00Z");
+        assert_eq!(unix_secs_to_rfc3339(1_709_164_800), "2024-02-29T00:00:00Z");
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_accepts_an_installed_custom_alias() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        let (status, Json(response)) = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("installed custom alias must be accepted");
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(response.alias, "nginx-1.27");
+        assert_eq!(response.status, ImageInstallStatus::Running);
+        assert!(response.log.contains("register started"));
+
+        let Json(polled) = get_microregistry_register(
+            State(state.clone()),
+            Path("nginx-1.27".to_owned()),
+            Extension(request_id()),
+        )
+        .await
+        .expect("accepted job must have a snapshot");
+        assert_eq!(polled.alias, response.alias);
+        assert_eq!(polled.status, ImageInstallStatus::Running);
+
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+        assert!(
+            finished
+                .log
+                .contains("register succeeded — catalog updated"),
+            "succeeded job must record the catalog update: {}",
+            finished.log
+        );
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+        let published_at = state
+            .microregistry_local
+            .lock()
+            .unwrap()
+            .get("nginx-1.27")
+            .expect("local row")
+            .published_at
+            .clone();
+        assert!(published_at.contains('T') && published_at.ends_with('Z'));
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_an_in_progress_job() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        state
+            .microregistry_registers
+            .begin_with("nginx-1.27", "register started")
+            .unwrap();
+
+        let (status, json) = error_json(
+            start_microregistry_register(
+                State(state.clone()),
+                Extension(request_id()),
+                register_body("nginx-1.27", "1"),
+            )
+            .await
+            .unwrap_err(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], "register_in_progress");
+        assert!(local_aliases(&state).is_empty());
+        assert_eq!(
+            state.microregistry_registers.snapshot("nginx-1.27").status,
+            ImageInstallStatus::Running
+        );
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_a_public_alias() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+
+        let (status, json) = error_json(
+            start_microregistry_register(
+                State(state.clone()),
+                Extension(request_id()),
+                register_body("ubuntu-26.04", "3"),
+            )
+            .await
+            .unwrap_err(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], "alias_collision");
+        assert_eq!(
+            state
+                .microregistry_registers
+                .snapshot("ubuntu-26.04")
+                .status,
+            ImageInstallStatus::Idle
+        );
+        assert!(local_aliases(&state).is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_a_local_duplicate() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        let _first = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("first register");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+
+        let (status, json) = error_json(
+            start_microregistry_register(
+                State(state.clone()),
+                Extension(request_id()),
+                register_body("nginx-1.27", "1"),
+            )
+            .await
+            .unwrap_err(),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], "alias_collision");
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_empty_fields_without_a_job() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        for (alias, version, field) in [
+            ("", "1", "alias"),
+            ("   ", "1", "alias"),
+            ("nginx-1.27", "", "version"),
+            ("nginx-1.27", "  ", "version"),
+        ] {
+            let (status, json) = error_json(
+                start_microregistry_register(
+                    State(state.clone()),
+                    Extension(request_id()),
+                    register_body(alias, version),
+                )
+                .await
+                .unwrap_err(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{alias:?} {version:?}");
+            assert_eq!(json["error"]["code"], "validation_failed");
+            assert!(
+                json["error"]["fields"][field].is_string(),
+                "expected field {field}: {json}"
+            );
+            assert_eq!(
+                state.microregistry_registers.snapshot("nginx-1.27").status,
+                ImageInstallStatus::Idle
+            );
+            assert!(local_aliases(&state).is_empty());
+        }
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_unknown_uninstalled_and_microboot() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+
+        for alias in [
+            "does-not-exist",
+            "nginx-1.27",
+            crate::microboot::MICROBOOT_ALIAS,
+        ] {
+            let (status, json) = error_json(
+                start_microregistry_register(
+                    State(state.clone()),
+                    Extension(request_id()),
+                    register_body(alias, "1"),
+                )
+                .await
+                .unwrap_err(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{alias}");
+            assert_eq!(json["error"]["code"], "not_found");
+            assert_eq!(
+                state.microregistry_registers.snapshot(alias).status,
+                ImageInstallStatus::Idle
+            );
+        }
+        assert!(local_aliases(&state).is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_microregistry_merges_public_and_local_rows() {
+        let package = format!(
+            "ubuntu/26.04/{}/ubuntu-26.04.tar.zst",
+            image_install::host_architecture()
+        );
+        let (state, _directory, source) = state_with_catalog(json!([
+            {
+                "alias": "ubuntu-26.04",
+                "architecture": image_install::host_architecture(),
+                "version": 3,
+                "package": package,
+                "sha256": "aabb",
+                "minDiskGb": 2,
+                "publishedAt": "2026-08-09T10:00:00Z"
+            },
+            {
+                "alias": "wrong-architecture",
+                "architecture": Architecture::HOST.other().as_str(),
+                "version": "1",
+                "package": "wrong/package.tar.zst",
+                "sha256": "eeff",
+                "minDiskGb": 1,
+                "publishedAt": "2026-08-09T10:00:00Z"
+            },
+            {
+                "alias": "custom-remote",
+                "architecture": image_install::host_architecture(),
+                "version": "9",
+                "package": "custom/remote.tar.zst",
+                "sha256": "ffff",
+                "minDiskGb": 1,
+                "publishedAt": "2026-08-09T10:00:00Z"
+            }
+        ]))
+        .await;
+        install_custom(&state, "nginx-1.27");
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("local register");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+
+        let Json(response) = list_microregistry(State(state.clone()), Extension(request_id()))
+            .await
+            .unwrap();
+        assert_eq!(response.source, source);
+        let aliases: Vec<&str> = response
+            .images
+            .iter()
+            .map(|image| image.alias.as_str())
+            .collect();
+        assert_eq!(aliases, ["nginx-1.27", "ubuntu-26.04"]);
+
+        let ubuntu = response
+            .images
+            .iter()
+            .find(|image| image.alias == "ubuntu-26.04")
+            .unwrap();
+        assert!(ubuntu.downloadable);
+        assert_eq!(ubuntu.package, package);
+        assert_eq!(ubuntu.sha256, "aabb");
+        assert_eq!(ubuntu.version, "3");
+
+        let local = response
+            .images
+            .iter()
+            .find(|image| image.alias == "nginx-1.27")
+            .unwrap();
+        assert!(!local.downloadable);
+        assert_eq!(local.package, "");
+        assert_eq!(local.sha256, "");
+        assert_eq!(local.version, "1");
+        assert!(local.installed);
+        assert_eq!(local.min_disk_gb, 1);
+
+        let Json(again) = list_microregistry(State(state), Extension(request_id()))
+            .await
+            .unwrap();
+        assert!(
+            again
+                .images
+                .iter()
+                .any(|image| image.alias == "nginx-1.27" && !image.downloadable)
+        );
+    }
+
+    #[tokio::test]
+    async fn a_failed_register_job_leaves_no_local_row() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        state
+            .microregistry_registers
+            .begin_with("nginx-1.27", "register started")
+            .unwrap();
+        state.templates.unregister_alias("nginx-1.27");
+
+        run_microregistry_register(
+            state.microregistry_registers.clone(),
+            state.templates.clone(),
+            Arc::clone(&state.microregistry_local),
+            "nginx-1.27".to_owned(),
+            "1".to_owned(),
+        )
+        .await;
+
+        assert_eq!(
+            state.microregistry_registers.snapshot("nginx-1.27").status,
+            ImageInstallStatus::Failed
+        );
+        assert!(
+            state
+                .microregistry_registers
+                .snapshot("nginx-1.27")
+                .log
+                .contains("register failed"),
+            "failed job must record why"
+        );
+        assert!(local_aliases(&state).is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_microregistry_register_returns_idle_for_an_unknown_alias() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        let Json(snapshot) = get_microregistry_register(
+            State(state),
+            Path("never-seen".to_owned()),
+            Extension(request_id()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(snapshot.alias, "never-seen");
+        assert_eq!(snapshot.status, ImageInstallStatus::Idle);
+        assert!(snapshot.log.is_empty());
     }
 }

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -194,6 +194,14 @@ pub fn build_router(state: AppState, config: &HttpConfig) -> Router {
             "/api/microregistry",
             get(handlers::microregistry::list_microregistry),
         )
+        .route(
+            "/api/microregistry/register",
+            post(handlers::microregistry::start_microregistry_register),
+        )
+        .route(
+            "/api/microregistry/register/{alias}",
+            get(handlers::microregistry::get_microregistry_register),
+        )
         .route("/api/oci/inspect", get(handlers::oci::inspect_oci_image))
         .route("/api/oci/import", post(handlers::oci::start_oci_import))
         .route(

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -106,8 +106,22 @@ pub struct AppState {
     pub(crate) bootstraps: crate::bootstrap::BootstrapTracker,
     /// Async OCI import jobs (`POST /api/oci/import`).
     pub(crate) oci_imports: ImageInstallTracker,
+    /// Async MicroRegistry register jobs (`POST /api/microregistry/register`).
+    pub(crate) microregistry_registers: ImageInstallTracker,
+    /// In-memory local catalog rows from successful register jobs (not persisted).
+    pub(crate) microregistry_local: Arc<Mutex<HashMap<String, LocalCatalogEntry>>>,
     /// Previous `/proc` jiffy samples used to derive host-process CPU %.
     pub(crate) process_metrics: Arc<Mutex<ProcessMetricsTracker>>,
+}
+
+/// One locally registered MicroRegistry row. Filled only by a successful
+/// register job; listing never invents these from `list_aliases()` or disk.
+#[derive(Debug, Clone)]
+pub(crate) struct LocalCatalogEntry {
+    pub alias: String,
+    pub version: String,
+    /// RFC 3339 UTC timestamp recorded when the register job succeeded.
+    pub published_at: String,
 }
 
 impl AppState {
@@ -150,6 +164,8 @@ impl AppState {
             image_packages: ImageInstallTracker::from_env(),
             bootstraps: crate::bootstrap::BootstrapTracker::default(),
             oci_imports: ImageInstallTracker::default(),
+            microregistry_registers: ImageInstallTracker::default(),
+            microregistry_local: Arc::new(Mutex::new(HashMap::new())),
             process_metrics: Arc::new(Mutex::new(ProcessMetricsTracker::default())),
         })
     }

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -84,7 +84,27 @@ The response has status `201` and includes the VM UUID.
 | Shells | `/api/shells`, `/{id}`, `POST /{id}/revisions`, `GET /{id}/revisions/{revisionId}`; VM pin `PUT /api/vms/{id}/shells` (Alpine OpenRC + Ubuntu/Rocky systemd; prefer POSIX `/bin/sh`) |
 | Images | `/api/images`, `/package`, `/install`, `/bootstrap` |
 | OCI | `/api/oci/inspect`, `POST /api/oci/import`, `GET /api/oci/import/{alias}` |
+| MicroRegistry | `/api/microregistry`, `POST /register`, `GET /register/{alias}` |
 | Host | `/api/host` and `/api/network` |
+
+## MicroRegistry
+
+`GET /api/microregistry` lists published packages for this host plus locally registered custom aliases.
+
+Register an already-installed custom image.
+
+```sh
+curl -s -X POST http://127.0.0.1:3000/api/microregistry/register \
+  -H 'Content-Type: application/json' \
+  -d '{"alias":"nginx-1.27","version":"1"}'
+```
+
+Poll `GET /api/microregistry/register/{alias}` for the same `ImageInstallResponse` package install uses.
+An empty alias or version is `400 validation_failed`.
+An unknown, uninstalled, or internal alias is `404`.
+A catalog alias or a second register of the same local alias is `409 alias_collision`.
+A running job for that alias is `409 register_in_progress`.
+Local rows have an empty package key and are not downloadable.
 
 ## VM states
 

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -65,6 +65,7 @@ Disk size can grow but cannot shrink.
 
 The Images screen can inspect an OCI reference and start an import.
 Poll the job until the alias appears in the local catalog and can create a VM.
+A locally installed custom alias can also be registered into this host's MicroRegistry catalog.
 
 ## Production
 

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -148,6 +148,11 @@ Deleting an installed image does not delete its staged package.
 The API validates paths and artifacts before use.
 Restart the API after replacing files outside the API workflow.
 
+## Register
+
+A locally installed custom alias can join this host's catalog via `POST /api/microregistry/register`.
+Poll `GET /api/microregistry/register/{alias}`; a success appears on `GET /api/microregistry` without a remote package key.
+
 ## Add an alias
 
 For a new distribution family, add its manifest entry and builder, then update:


### PR DESCRIPTION
## Summary

An operator can register an already-installed image into **this host's** MicroRegistry catalog through the API. `POST` starts a background job and returns **202** immediately; `GET` polls the same snapshot until `succeeded` or `failed`. `GET /api/microregistry` then lists that image alongside the public entries.

This is **#108 L2 only**. It is not the L1 dashboard form (already in #109), not durable catalog rows (L3), not `{alias}.tar.zst` packaging (L4), and not kernel-arch verification (L5). It is not the operator rclone push to `registry.firecrab.dev`.

## Motivation

- #108 L1 can POST `{alias, version}` from the dashboard, but the endpoints 404 until this layer exists.
- Consume already exists (`GET /api/microregistry` → package → install). A custom alias still never appears in that listing.
- `GET /api/microregistry` drops anything outside `known_spec`, so an OCI import (`nginx-1.27`) cannot show up even if packaged by hand.
- REST times out before a register can finish, so the job must follow the existing `ImageInstallResponse` tracker used by package install and OCI import.

## Position

```text
#108 MicroRegistry register
├─ L1 Dashboard     have  (#109)
├─ L2 API           this  POST 202 job + GET poll + public ∪ local listing
├─ L3 Catalog       later persist rows across refresh/restart
├─ L4 Package       later {alias}.tar.zst
└─ L5 Verify        later kernel arch (#89 / #94)
```

## Precedent

Copy `handlers/oci.rs` `start_oci_import` + `get_oci_import`. Claim a name, call `tracker.begin_with(alias, message)`, spawn the work, return `(StatusCode::ACCEPTED, Json(ImageInstallResponse))`. Do not invent a second tracker type.

Jobs are keyed by **alias** on a dedicated `AppState` tracker (`microregistry_registers`) so a register job cannot collide with an install or import of the same alias.

L1 currently polls `GET /api/microregistry/jobs/{jobId}`. That is an L1/L2 mismatch. This PR implements the alias-keyed path; it does not add a `jobId` tracker. Correct L1 in a follow-up.

## Scope (MVP)

- [x] `POST /api/microregistry/register` JSON `{alias, version}` → **202** `ImageInstallResponse`. `status` is `idle|running|succeeded|failed`.
- [x] `GET /api/microregistry/register/{alias}` returns the same snapshot. An unknown alias returns the idle snapshot, like `get_oci_import`.
- [x] Reject **400** (`AppError::validation`) when `alias` or `version` is empty or whitespace.
- [x] Reject **409** (`AppError::conflict`) when:
  - the alias is not installed on this host (`not_installed`)
  - the alias is already in the catalog (`already_registered`)
  - a register job is already running for that alias (`register_in_progress`)
- [x] Spawn the job after `begin_with`. Log through `append_log`; finish with `finish_ok_with` / `finish_err`.
- [x] `GET /api/microregistry` keeps its public path unchanged and also emits locally registered images the public catalog does not contain.
- [x] Local rows use `MicroRegistryImageResponse` from real host state. No fabricated remote object key or publisher sha256.
- [x] Merged listing is sorted by alias.
- [x] Unit tests for 409 cases, 202 snapshot shape, idle GET, and merged listing.

## Acceptance

- `POST /api/microregistry/register` for an installed alias returns 202 and a running/succeeded snapshot; `GET /api/microregistry/register/{alias}` polls the same job.
- A second POST for the same alias while the job is running is 409. An alias that is not installed, or that is already in the catalog, is 409.
- `GET /api/microregistry` lists release images **and** the new local-only row. The public filter (`HOST` + `known_spec`) is unchanged. Local rows have no fabricated package key.

Out of scope:

- L1 dashboard edits (`firecrab-frontend/`)
- L3 SQLite/disk catalog persist
- L4 `{alias}.tar.zst` package build
- L5 kernel-arch verification
- Push to `registry.firecrab.dev` / R2; object-store credentials in the API
- A `jobId`-keyed tracker or a second snapshot type

## Notes

- Parent: #108. Sibling L1: #109.
- Local rows live in memory for this slice (`microregistry_local`). A process restart drops them; that is L3.
- `FIRECRAB_IMAGE_BASE_URL` stays the consume pointer.

Related to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for registering installed custom image aliases in the local MicroRegistry catalog.
  - Added registration progress tracking and status retrieval.
  - Catalog listings now include validated locally registered entries with installation and staging details.
  - Added validation, duplicate-alias protection, timestamps, and failure reporting.

- **Documentation**
  - Documented MicroRegistry listing, registration, status polling, validation responses, and custom image registration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->