### PR TITLE
feat(api): persist local MicroRegistry catalog rows in SQLite

### DIFF
--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -6,9 +6,9 @@
 //! on the existing `/api/images/{alias}/package` endpoint, which verifies the
 //! per-distribution checksum before an archive becomes installable.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use axum::Json;
@@ -23,8 +23,9 @@ use serde::Deserialize;
 use crate::error::AppError;
 use crate::extract::ValidatedJson;
 use crate::image_install::{self, Architecture, ImageInstallTracker};
+use crate::persistence::{LocalCatalogEntry, Store};
 use crate::server::RequestId;
-use crate::state::{AppState, LocalCatalogEntry};
+use crate::state::AppState;
 use crate::templates::TemplateRegistry;
 
 const CATALOG_MAX_BYTES: usize = 256 * 1024;
@@ -62,11 +63,6 @@ where
             "version must be a non-empty string or unsigned integer",
         )),
     }
-}
-
-fn unavailable(request_id: RequestId, detail: impl std::fmt::Display) -> AppError {
-    tracing::warn!(request_id = %request_id.0, error = %detail, "MicroRegistry catalog request failed");
-    AppError::unavailable("MicroRegistry catalog is unavailable", request_id.0)
 }
 
 /// Smallest disk (GiB) that can hold `rootfs_bytes`, matching `images.rs`.
@@ -121,95 +117,44 @@ fn is_leap_year(year: u64) -> bool {
     year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
 }
 
+fn catalog_source_url(base_url: &str) -> String {
+    format!("{}/catalog.json", base_url.trim_end_matches('/'))
+}
+
 fn local_catalog_image(
     templates: &TemplateRegistry,
     image_root: &Path,
     entry: &LocalCatalogEntry,
 ) -> MicroRegistryImageResponse {
-    let installed = templates.resolve_alias(&entry.alias);
-    let min_disk_gb = installed
-        .as_ref()
-        .map(|template| min_disk_gb_for(template.rootfs.length()))
-        .unwrap_or(0);
     MicroRegistryImageResponse {
-        installed: installed.is_some(),
+        installed: templates.resolve_alias(&entry.alias).is_some(),
         package_staged: image_install::staged_package_exists(image_root, &entry.alias),
         package_origin: image_install::staged_package_origin(image_root, &entry.alias),
-        downloadable: false,
+        downloadable: !entry.package.is_empty() && !entry.sha256.is_empty(),
         alias: entry.alias.clone(),
         version: entry.version.clone(),
-        package: String::new(),
-        sha256: String::new(),
-        min_disk_gb,
+        package: entry.package.clone(),
+        sha256: entry.sha256.clone(),
+        min_disk_gb: entry.min_disk_gb,
         published_at: entry.published_at.clone(),
     }
 }
 
-/// `GET /api/microregistry`: supported published packages plus this host's
-/// local install/cache state. Entries outside the release manifest are hidden
-/// because this Firecrab build cannot validate or install them. Locally
-/// registered custom aliases are appended after the public filters so a
-/// catalog refresh cannot drop them.
-pub async fn list_microregistry(
-    State(state): State<AppState>,
-    axum::Extension(request_id): axum::Extension<RequestId>,
-) -> Result<Json<MicroRegistryResponse>, AppError> {
-    let Some(base_url) = state.image_packages.base_url().map(str::to_owned) else {
-        return Err(AppError::unavailable(
-            "MicroRegistry is disabled by FIRECRAB_IMAGE_BASE_URL",
-            request_id.0,
-        ));
-    };
-    let source = format!("{}/catalog.json", base_url.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .connect_timeout(Duration::from_secs(3))
-        .timeout(Duration::from_secs(8))
-        .build()
-        .map_err(|error| unavailable(request_id, error))?;
-    let mut response = client
-        .get(&source)
-        .send()
-        .await
-        .map_err(|error| unavailable(request_id, error))?
-        .error_for_status()
-        .map_err(|error| unavailable(request_id, error))?;
-
-    if response
-        .content_length()
-        .is_some_and(|length| length > CATALOG_MAX_BYTES as u64)
-    {
-        return Err(unavailable(
-            request_id,
-            "catalog content-length exceeds limit",
-        ));
-    }
-
-    let mut body = Vec::new();
-    while let Some(chunk) = response
-        .chunk()
-        .await
-        .map_err(|error| unavailable(request_id, error))?
-    {
-        if body.len().saturating_add(chunk.len()) > CATALOG_MAX_BYTES {
-            return Err(unavailable(request_id, "catalog body exceeds limit"));
-        }
-        body.extend_from_slice(&chunk);
-    }
-    let catalog: Catalog =
-        serde_json::from_slice(&body).map_err(|error| unavailable(request_id, error))?;
-
-    let templates = state.templates.clone();
-    let image_root = templates.image_root_path().to_owned();
-    let mut images = catalog
+fn public_catalog_images(
+    catalog: Catalog,
+    templates: &TemplateRegistry,
+    image_root: &Path,
+) -> Vec<MicroRegistryImageResponse> {
+    catalog
         .images
         .into_iter()
         .filter(|image| image.architecture == Architecture::HOST)
         .filter(|image| TemplateRegistry::known_spec(&image.alias).is_some())
         .map(|image| {
-            let package_origin = image_install::staged_package_origin(&image_root, &image.alias);
+            let package_origin = image_install::staged_package_origin(image_root, &image.alias);
             MicroRegistryImageResponse {
                 installed: templates.resolve_alias(&image.alias).is_some(),
-                package_staged: image_install::staged_package_exists(&image_root, &image.alias),
+                package_staged: image_install::staged_package_exists(image_root, &image.alias),
                 package_origin,
                 downloadable: true,
                 alias: image.alias,
@@ -220,22 +165,124 @@ pub async fn list_microregistry(
                 published_at: image.published_at,
             }
         })
-        .collect::<Vec<_>>();
+        .collect()
+}
 
-    let locals: Vec<LocalCatalogEntry> = state
-        .microregistry_local
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner())
-        .values()
-        .cloned()
-        .collect();
+fn merge_catalog_images(
+    mut images: Vec<MicroRegistryImageResponse>,
+    locals: Vec<LocalCatalogEntry>,
+    templates: &TemplateRegistry,
+    image_root: &Path,
+) -> Vec<MicroRegistryImageResponse> {
     for entry in locals {
         if images.iter().any(|image| image.alias == entry.alias) {
             continue;
         }
-        images.push(local_catalog_image(&templates, &image_root, &entry));
+        images.push(local_catalog_image(templates, image_root, &entry));
     }
     images.sort_by(|left, right| left.alias.cmp(&right.alias));
+    images
+}
+
+fn load_host_local_rows(
+    store: &Store,
+    request_id: RequestId,
+) -> Result<Vec<LocalCatalogEntry>, AppError> {
+    store
+        .list_microregistry_local(Some(Architecture::HOST.as_str()))
+        .map_err(|error| {
+            tracing::error!(request_id = %request_id.0, %error, "failed to list local MicroRegistry rows");
+            AppError::internal(request_id.0)
+        })
+}
+
+async fn fetch_public_catalog(source: &str) -> Result<Catalog, String> {
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(3))
+        .timeout(Duration::from_secs(8))
+        .build()
+        .map_err(|error| error.to_string())?;
+    let mut response = client
+        .get(source)
+        .send()
+        .await
+        .map_err(|error| error.to_string())?
+        .error_for_status()
+        .map_err(|error| error.to_string())?;
+
+    if response
+        .content_length()
+        .is_some_and(|length| length > CATALOG_MAX_BYTES as u64)
+    {
+        return Err("catalog content-length exceeds limit".to_owned());
+    }
+
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| error.to_string())? {
+        if body.len().saturating_add(chunk.len()) > CATALOG_MAX_BYTES {
+            return Err("catalog body exceeds limit".to_owned());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&body).map_err(|error| error.to_string())
+}
+
+/// `GET /api/microregistry`: supported published packages plus this host's
+/// local install/cache state. Entries outside the release manifest are hidden
+/// because this Firecrab build cannot validate or install them. Locally
+/// registered custom aliases are appended after the public filters so a
+/// catalog refresh cannot drop them. If the public catalog is unreachable or
+/// consume is disabled, HOST local rows still return 200; with none, 503.
+pub async fn list_microregistry(
+    State(state): State<AppState>,
+    axum::Extension(request_id): axum::Extension<RequestId>,
+) -> Result<Json<MicroRegistryResponse>, AppError> {
+    let base_url = state.image_packages.base_url().map(str::to_owned);
+    let source = base_url
+        .as_deref()
+        .map(catalog_source_url)
+        .unwrap_or_default();
+    let public = match base_url.as_deref() {
+        Some(_) => match fetch_public_catalog(&source).await {
+            Ok(catalog) => Some(catalog),
+            Err(detail) => {
+                tracing::warn!(
+                    request_id = %request_id.0,
+                    error = %detail,
+                    "MicroRegistry catalog request failed"
+                );
+                None
+            }
+        },
+        None => None,
+    };
+
+    let store = state.store.clone();
+    let locals = tokio::task::spawn_blocking(move || load_host_local_rows(&store, request_id))
+        .await
+        .map_err(|_| AppError::internal(request_id.0))??;
+
+    let templates = state.templates.clone();
+    let image_root = templates.image_root_path().to_owned();
+    let images = match public {
+        Some(catalog) => merge_catalog_images(
+            public_catalog_images(catalog, &templates, &image_root),
+            locals,
+            &templates,
+            &image_root,
+        ),
+        None if locals.is_empty() => {
+            return Err(if base_url.is_none() {
+                AppError::unavailable(
+                    "MicroRegistry is disabled by FIRECRAB_IMAGE_BASE_URL",
+                    request_id.0,
+                )
+            } else {
+                AppError::unavailable("MicroRegistry catalog is unavailable", request_id.0)
+            });
+        }
+        None => merge_catalog_images(Vec::new(), locals, &templates, &image_root),
+    };
 
     Ok(Json(MicroRegistryResponse { source, images }))
 }
@@ -261,7 +308,7 @@ pub async fn start_microregistry_register(
         return Err(AppError::not_found(request_id.0));
     }
 
-    if TemplateRegistry::known_spec(&body.alias).is_some() {
+    if public_alias_collides(&state, &body.alias).await {
         return Err(AppError::conflict(
             "alias_collision",
             "alias is already published in the catalog",
@@ -269,18 +316,23 @@ pub async fn start_microregistry_register(
         ));
     }
 
-    {
-        let local = state
-            .microregistry_local
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if local.contains_key(&body.alias) {
-            return Err(AppError::conflict(
-                "alias_collision",
-                "alias is already published in the catalog",
-                request_id.0,
-            ));
-        }
+    let store = state.store.clone();
+    let alias = body.alias.clone();
+    let existing = tokio::task::spawn_blocking(move || {
+        store.microregistry_local(&alias, Architecture::HOST.as_str())
+    })
+    .await
+    .map_err(|_| AppError::internal(request_id.0))?
+    .map_err(|error| {
+        tracing::error!(request_id = %request_id.0, %error, "failed to load local MicroRegistry row");
+        AppError::internal(request_id.0)
+    })?;
+    if existing.is_some() {
+        return Err(AppError::conflict(
+            "alias_collision",
+            "alias is already published in the catalog",
+            request_id.0,
+        ));
     }
 
     if state.templates.resolve_alias(&body.alias).is_none() {
@@ -304,14 +356,27 @@ pub async fn start_microregistry_register(
 
     let tracker = state.microregistry_registers.clone();
     let templates = state.templates.clone();
-    let catalog = Arc::clone(&state.microregistry_local);
+    let store = state.store.clone();
     let alias = body.alias.clone();
     let version = body.version.clone();
     tokio::spawn(async move {
-        run_microregistry_register(tracker, templates, catalog, alias, version).await;
+        run_microregistry_register(tracker, templates, store, alias, version).await;
     });
 
     Ok((StatusCode::ACCEPTED, Json(response)))
+}
+
+async fn public_alias_collides(state: &AppState, alias: &str) -> bool {
+    match state.image_packages.base_url() {
+        Some(base_url) => match fetch_public_catalog(&catalog_source_url(base_url)).await {
+            Ok(catalog) => catalog
+                .images
+                .iter()
+                .any(|image| image.alias == alias && image.architecture == Architecture::HOST),
+            Err(_) => TemplateRegistry::known_spec(alias).is_some(),
+        },
+        None => TemplateRegistry::known_spec(alias).is_some(),
+    }
 }
 
 /// `GET /api/microregistry/register/{alias}` — latest snapshot, including idle.
@@ -326,29 +391,28 @@ pub async fn get_microregistry_register(
 async fn run_microregistry_register(
     tracker: ImageInstallTracker,
     templates: Arc<TemplateRegistry>,
-    catalog: Arc<Mutex<HashMap<String, LocalCatalogEntry>>>,
+    store: Store,
     alias: String,
     version: String,
 ) {
     tracker.append_log(&alias, "checking installed template");
-    if templates.resolve_alias(&alias).is_none() {
+    let Some(template) = templates.resolve_alias(&alias) else {
         tracker.finish_err_with(&alias, "register failed: template is not installed");
         return;
-    }
+    };
     tracker.append_log(&alias, "updating catalog");
-    let published_at = rfc3339_utc_now();
-    {
-        let mut catalog = catalog
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        catalog.insert(
-            alias.clone(),
-            LocalCatalogEntry {
-                alias: alias.clone(),
-                version,
-                published_at,
-            },
-        );
+    let entry = LocalCatalogEntry {
+        alias: alias.clone(),
+        architecture: Architecture::HOST.as_str().to_owned(),
+        version,
+        package: String::new(),
+        sha256: String::new(),
+        min_disk_gb: min_disk_gb_for(template.rootfs.length()),
+        published_at: rfc3339_utc_now(),
+    };
+    if let Err(error) = store.insert_microregistry_local(&entry) {
+        tracker.finish_err_with(&alias, format!("register failed: {error}"));
+        return;
     }
     tracker.finish_ok_with(&alias, "register succeeded — catalog updated");
 }
@@ -360,6 +424,8 @@ mod tests {
     use crate::image_install::ImageInstallTracker;
     use crate::state::AppState;
     use crate::templates::TemplateSpec;
+    use std::sync::{Arc, Mutex};
+
     use axum::Json;
     use axum::extract::{Path, State};
     use axum::response::IntoResponse;
@@ -371,9 +437,11 @@ mod tests {
 
     async fn empty_state(root: &std::path::Path) -> AppState {
         let templates = TemplateRegistry::from_specs(root, std::iter::empty()).unwrap();
-        AppState::with_db_file(templates, root.join("state.db"))
+        let mut state = AppState::with_db_file(templates, root.join("state.db"))
             .await
-            .unwrap()
+            .unwrap();
+        state.image_packages = ImageInstallTracker::disabled();
+        state
     }
 
     fn install_custom(state: &AppState, alias: &str) {
@@ -434,13 +502,23 @@ mod tests {
     }
 
     fn local_aliases(state: &AppState) -> Vec<String> {
-        let local = state
-            .microregistry_local
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut aliases: Vec<String> = local.keys().cloned().collect();
+        let mut aliases: Vec<String> = state
+            .store
+            .list_microregistry_local(Some(Architecture::HOST.as_str()))
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.alias)
+            .collect();
         aliases.sort();
         aliases
+    }
+
+    fn local_row(state: &AppState, alias: &str) -> LocalCatalogEntry {
+        state
+            .store
+            .microregistry_local(alias, Architecture::HOST.as_str())
+            .unwrap()
+            .unwrap_or_else(|| panic!("local row {alias}"))
     }
 
     async fn state_with_catalog(
@@ -610,15 +688,12 @@ mod tests {
             finished.log
         );
         assert_eq!(local_aliases(&state), ["nginx-1.27"]);
-        let published_at = state
-            .microregistry_local
-            .lock()
-            .unwrap()
-            .get("nginx-1.27")
-            .expect("local row")
-            .published_at
-            .clone();
-        assert!(published_at.contains('T') && published_at.ends_with('Z'));
+        let row = local_row(&state, "nginx-1.27");
+        assert_eq!(row.architecture, Architecture::HOST.as_str());
+        assert_eq!(row.package, "");
+        assert_eq!(row.sha256, "");
+        assert_eq!(row.min_disk_gb, 1);
+        assert!(row.published_at.contains('T') && row.published_at.ends_with('Z'));
     }
 
     #[tokio::test]
@@ -709,6 +784,25 @@ mod tests {
         assert_eq!(status, StatusCode::CONFLICT);
         assert_eq!(json["error"]["code"], "alias_collision");
         assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+
+        let db_file = directory.path().join("state.db");
+        let templates = TemplateRegistry::from_specs(directory.path(), std::iter::empty()).unwrap();
+        let mut reopened = AppState::with_db_file(templates, db_file).await.unwrap();
+        reopened.image_packages = ImageInstallTracker::disabled();
+        assert_eq!(local_aliases(&reopened), ["nginx-1.27"]);
+        let (status, json) = error_json(
+            start_microregistry_register(
+                State(reopened.clone()),
+                Extension(request_id()),
+                register_body("nginx-1.27", "1"),
+            )
+            .await
+            .unwrap_err(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(json["error"]["code"], "alias_collision");
+        assert_eq!(local_aliases(&reopened), ["nginx-1.27"]);
     }
 
     #[tokio::test]
@@ -883,7 +977,7 @@ mod tests {
         run_microregistry_register(
             state.microregistry_registers.clone(),
             state.templates.clone(),
-            Arc::clone(&state.microregistry_local),
+            state.store.clone(),
             "nginx-1.27".to_owned(),
             "1".to_owned(),
         )
@@ -918,5 +1012,211 @@ mod tests {
         assert_eq!(snapshot.alias, "never-seen");
         assert_eq!(snapshot.status, ImageInstallStatus::Idle);
         assert!(snapshot.log.is_empty());
+    }
+
+    #[tokio::test]
+    async fn start_microregistry_register_rejects_a_live_catalog_host_alias() {
+        let (state, _directory, _source) = state_with_catalog(json!([
+            {
+                "alias": "ubuntu-26.04",
+                "architecture": image_install::host_architecture(),
+                "version": 3,
+                "package": "ubuntu/26.04/ubuntu-26.04.tar.zst",
+                "sha256": "aabb",
+                "minDiskGb": 2,
+                "publishedAt": "2026-08-09T10:00:00Z"
+            },
+            {
+                "alias": "custom-remote",
+                "architecture": image_install::host_architecture(),
+                "version": "9",
+                "package": "custom/remote.tar.zst",
+                "sha256": "ffff",
+                "minDiskGb": 1,
+                "publishedAt": "2026-08-09T10:00:00Z"
+            }
+        ]))
+        .await;
+
+        for alias in ["ubuntu-26.04", "custom-remote"] {
+            let (status, json) = error_json(
+                start_microregistry_register(
+                    State(state.clone()),
+                    Extension(request_id()),
+                    register_body(alias, "1"),
+                )
+                .await
+                .unwrap_err(),
+            )
+            .await;
+            assert_eq!(status, StatusCode::CONFLICT, "{alias}");
+            assert_eq!(json["error"]["code"], "alias_collision", "{alias}");
+            assert_eq!(
+                state.microregistry_registers.snapshot(alias).status,
+                ImageInstallStatus::Idle,
+                "{alias}"
+            );
+            assert!(
+                state
+                    .store
+                    .microregistry_local(alias, Architecture::HOST.as_str())
+                    .unwrap()
+                    .is_none(),
+                "{alias}"
+            );
+        }
+        assert!(local_aliases(&state).is_empty());
+    }
+
+    fn host_ubuntu_catalog() -> serde_json::Value {
+        json!([{
+            "alias": "ubuntu-26.04",
+            "architecture": image_install::host_architecture(),
+            "version": 3,
+            "package": format!(
+                "ubuntu/26.04/{}/ubuntu-26.04.tar.zst",
+                image_install::host_architecture()
+            ),
+            "sha256": "aabb",
+            "minDiskGb": 2,
+            "publishedAt": "2026-08-09T10:00:00Z"
+        }])
+    }
+
+    async fn state_with_mutable_catalog(
+        images: Arc<Mutex<serde_json::Value>>,
+    ) -> (AppState, tempfile::TempDir, String) {
+        let app = Router::new().route(
+            "/catalog.json",
+            get({
+                let images = Arc::clone(&images);
+                move || {
+                    let images = Arc::clone(&images);
+                    async move {
+                        let images = images.lock().unwrap().clone();
+                        Json(json!({ "images": images }))
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let directory = tempdir().unwrap();
+        let mut state = empty_state(directory.path()).await;
+        state.image_packages = ImageInstallTracker::with_base_url(format!("http://{address}"));
+        (state, directory, format!("http://{address}/catalog.json"))
+    }
+
+    #[tokio::test]
+    async fn list_microregistry_keeps_local_rows_when_the_catalog_changes() {
+        let images = Arc::new(Mutex::new(host_ubuntu_catalog()));
+        let (state, _directory, source) = state_with_mutable_catalog(Arc::clone(&images)).await;
+        install_custom(&state, "nginx-1.27");
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("local register");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+
+        let Json(first) = list_microregistry(State(state.clone()), Extension(request_id()))
+            .await
+            .unwrap();
+        assert_eq!(first.source, source);
+        let first_aliases: Vec<&str> = first
+            .images
+            .iter()
+            .map(|image| image.alias.as_str())
+            .collect();
+        assert_eq!(first_aliases, ["nginx-1.27", "ubuntu-26.04"]);
+
+        *images.lock().unwrap() = json!([{
+            "alias": "ubuntu-26.04",
+            "architecture": image_install::host_architecture(),
+            "version": 4,
+            "package": "ubuntu/26.04/ubuntu-26.04.tar.zst",
+            "sha256": "updated",
+            "minDiskGb": 2,
+            "publishedAt": "2026-08-15T00:00:00Z"
+        }, {
+            "alias": "custom-remote",
+            "architecture": image_install::host_architecture(),
+            "version": "9",
+            "package": "custom/remote.tar.zst",
+            "sha256": "ffff",
+            "minDiskGb": 1,
+            "publishedAt": "2026-08-09T10:00:00Z"
+        }]);
+
+        let Json(second) = list_microregistry(State(state), Extension(request_id()))
+            .await
+            .unwrap();
+        let nginx = second
+            .images
+            .iter()
+            .find(|image| image.alias == "nginx-1.27")
+            .expect("local row survives a catalog refresh");
+        assert_eq!(nginx.version, "1");
+        assert!(!nginx.downloadable);
+        assert_eq!(nginx.package, "");
+        let ubuntu = second
+            .images
+            .iter()
+            .find(|image| image.alias == "ubuntu-26.04")
+            .unwrap();
+        assert_eq!(ubuntu.version, "4");
+        assert!(
+            !second
+                .images
+                .iter()
+                .any(|image| image.alias == "custom-remote")
+        );
+    }
+
+    #[tokio::test]
+    async fn list_microregistry_returns_local_rows_when_the_catalog_is_unreachable() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("local register");
+        wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+
+        let app = Router::new().route(
+            "/catalog.json",
+            get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let mut failing = state.clone();
+        failing.image_packages = ImageInstallTracker::with_base_url(format!("http://{address}"));
+        let Json(response) = list_microregistry(State(failing), Extension(request_id()))
+            .await
+            .expect("local rows must survive a catalog 5xx");
+        assert_eq!(response.source, format!("http://{address}/catalog.json"));
+        assert_eq!(response.images.len(), 1);
+        assert_eq!(response.images[0].alias, "nginx-1.27");
+        assert!(!response.images[0].downloadable);
+
+        let mut disabled = state;
+        disabled.image_packages = ImageInstallTracker::disabled();
+        let Json(disabled_response) = list_microregistry(State(disabled), Extension(request_id()))
+            .await
+            .expect("local rows must survive a disabled consume URL");
+        assert_eq!(disabled_response.source, "");
+        assert_eq!(disabled_response.images.len(), 1);
+        assert_eq!(disabled_response.images[0].alias, "nginx-1.27");
     }
 }

--- a/firecrab-api/src/persistence.rs
+++ b/firecrab-api/src/persistence.rs
@@ -107,6 +107,34 @@ const CREATE_SHELLS_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS shells (
     updated_at_ms INTEGER NOT NULL
 ) STRICT";
 
+/// Host-local MicroRegistry rows from a successful register job.
+/// Uniqueness is the composite PK so a concurrent double-register cannot
+/// insert two rows for the same alias and architecture.
+const CREATE_MICROREGISTRY_LOCAL_TABLE_SQL: &str =
+    "CREATE TABLE IF NOT EXISTS microregistry_local (
+    alias TEXT NOT NULL,
+    architecture TEXT NOT NULL,
+    version TEXT NOT NULL,
+    package TEXT NOT NULL DEFAULT '',
+    sha256 TEXT NOT NULL DEFAULT '',
+    min_disk_gb INTEGER NOT NULL,
+    published_at TEXT NOT NULL,
+    PRIMARY KEY (alias, architecture)
+) STRICT";
+
+const SELECT_MICROREGISTRY_LOCAL_ALL_SQL: &str = "SELECT alias, architecture, version, package, \
+    sha256, min_disk_gb, published_at FROM microregistry_local ORDER BY alias";
+
+const SELECT_MICROREGISTRY_LOCAL_BY_ARCH_SQL: &str = "SELECT alias, architecture, version, package, \
+    sha256, min_disk_gb, published_at FROM microregistry_local WHERE architecture = ?1 ORDER BY alias";
+
+const SELECT_MICROREGISTRY_LOCAL_ONE_SQL: &str = "SELECT alias, architecture, version, package, \
+    sha256, min_disk_gb, published_at FROM microregistry_local WHERE alias = ?1 AND architecture = ?2";
+
+const INSERT_MICROREGISTRY_LOCAL_SQL: &str = "INSERT INTO microregistry_local \
+    (alias, architecture, version, package, sha256, min_disk_gb, published_at) \
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)";
+
 const CREATE_SHELL_REVISIONS_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS shell_revisions (
     id TEXT PRIMARY KEY,
     shell_id TEXT NOT NULL,
@@ -379,6 +407,14 @@ pub enum PersistenceError {
         /// The conflicting path.
         path: String,
     },
+    /// A local MicroRegistry alias is already registered for this architecture.
+    #[error("MicroRegistry local alias {alias} is already registered for {architecture}")]
+    DuplicateMicroRegistryLocal {
+        /// Conflicting catalog alias.
+        alias: String,
+        /// Catalog architecture label (`x86_64` or `aarch64`).
+        architecture: String,
+    },
     /// A host port/protocol is already forwarded to another VM.
     #[error("host port {host_port}/{protocol} is already in use by another VM")]
     DuplicatePortForward {
@@ -432,6 +468,20 @@ pub fn default_db_file() -> PathBuf {
     PathBuf::from(DB_FILE)
 }
 
+/// One locally registered MicroRegistry row (`microregistry_local`).
+/// Written only by a successful register job; listing never invents these
+/// from installed aliases or disk.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LocalCatalogEntry {
+    pub alias: String,
+    pub architecture: String,
+    pub version: String,
+    pub package: String,
+    pub sha256: String,
+    pub min_disk_gb: u16,
+    pub published_at: String,
+}
+
 /// Handle to the VM records SQLite database. Cheaply `Clone`able; all
 /// clones share one connection behind a mutex.
 #[derive(Debug, Clone)]
@@ -480,6 +530,7 @@ impl Store {
         migrate_internet_enabled_column(&conn)?;
         conn.execute(CREATE_MICRO_STORAGES_TABLE_SQL, [])?;
         conn.execute(CREATE_SHELLS_TABLE_SQL, [])?;
+        conn.execute(CREATE_MICROREGISTRY_LOCAL_TABLE_SQL, [])?;
         conn.execute(CREATE_SHELL_REVISIONS_TABLE_SQL, [])?;
         conn.execute(CREATE_VM_SHELLS_TABLE_SQL, [])?;
         conn.execute(CREATE_PORT_FORWARDS_TABLE_SQL, [])?;
@@ -715,6 +766,72 @@ impl Store {
             return Err(PersistenceError::MissingMicroStorage { id });
         }
         Ok(())
+    }
+
+    /// Local MicroRegistry rows, optionally filtered by catalog architecture.
+    pub fn list_microregistry_local(
+        &self,
+        architecture: Option<&str>,
+    ) -> Result<Vec<LocalCatalogEntry>, PersistenceError> {
+        let conn = self.lock();
+        let mut statement = match architecture {
+            Some(_) => conn.prepare(SELECT_MICROREGISTRY_LOCAL_BY_ARCH_SQL)?,
+            None => conn.prepare(SELECT_MICROREGISTRY_LOCAL_ALL_SQL)?,
+        };
+        let mut rows = match architecture {
+            Some(architecture) => statement.query(params![architecture])?,
+            None => statement.query([])?,
+        };
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(map_local_catalog_entry(row)?);
+        }
+        Ok(out)
+    }
+
+    /// One local MicroRegistry row by alias and architecture.
+    pub fn microregistry_local(
+        &self,
+        alias: &str,
+        architecture: &str,
+    ) -> Result<Option<LocalCatalogEntry>, PersistenceError> {
+        let conn = self.lock();
+        let mut statement = conn.prepare(SELECT_MICROREGISTRY_LOCAL_ONE_SQL)?;
+        Ok(statement
+            .query_row(params![alias, architecture], map_local_catalog_entry)
+            .optional()?)
+    }
+
+    /// Inserts a local MicroRegistry row. A composite-PK clash is
+    /// [`PersistenceError::DuplicateMicroRegistryLocal`].
+    pub fn insert_microregistry_local(
+        &self,
+        entry: &LocalCatalogEntry,
+    ) -> Result<(), PersistenceError> {
+        let result = self.lock().execute(
+            INSERT_MICROREGISTRY_LOCAL_SQL,
+            params![
+                entry.alias,
+                entry.architecture,
+                entry.version,
+                entry.package,
+                entry.sha256,
+                i64::from(entry.min_disk_gb),
+                entry.published_at,
+            ],
+        );
+        match result {
+            Ok(_) => Ok(()),
+            Err(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::ConstraintViolation =>
+            {
+                Err(PersistenceError::DuplicateMicroRegistryLocal {
+                    alias: entry.alias.clone(),
+                    architecture: entry.architecture.clone(),
+                })
+            }
+            Err(error) => Err(PersistenceError::Database(error)),
+        }
     }
 
     /// How many VMs still point at `storage_root` (id string).
@@ -1382,6 +1499,18 @@ impl Store {
     }
 }
 
+fn map_local_catalog_entry(row: &rusqlite::Row<'_>) -> rusqlite::Result<LocalCatalogEntry> {
+    Ok(LocalCatalogEntry {
+        alias: row.get(0)?,
+        architecture: row.get(1)?,
+        version: row.get(2)?,
+        package: row.get(3)?,
+        sha256: row.get(4)?,
+        min_disk_gb: row.get::<_, i64>(5)? as u16,
+        published_at: row.get(6)?,
+    })
+}
+
 /// Binds `vm`'s fields as parameters and executes `sql` (shared by insert,
 /// update, and legacy import, which differ only in which SQL they run).
 fn execute_record(conn: &Connection, sql: &str, vm: &VmRecord) -> Result<usize, rusqlite::Error> {
@@ -1989,6 +2118,101 @@ mod tests {
         };
         assert_eq!(unique_ip_count, 16, "duplicate IPs handed out: {ips:?}");
         assert_eq!(unique_mac_count, 16, "duplicate MACs handed out: {macs:?}");
+    }
+
+    fn local_catalog_entry(alias: &str, architecture: &str) -> LocalCatalogEntry {
+        LocalCatalogEntry {
+            alias: alias.to_owned(),
+            architecture: architecture.to_owned(),
+            version: "1".to_owned(),
+            package: String::new(),
+            sha256: String::new(),
+            min_disk_gb: 1,
+            published_at: "2026-08-15T00:00:00Z".to_owned(),
+        }
+    }
+
+    #[test]
+    fn microregistry_local_round_trips_through_insert_list_and_get() {
+        let directory = tempdir().unwrap();
+        let store = Store::open(&directory.path().join("firecrab.db")).unwrap();
+        let entry = local_catalog_entry("nginx-1.27", "x86_64");
+
+        store.insert_microregistry_local(&entry).unwrap();
+        assert_eq!(
+            store
+                .microregistry_local("nginx-1.27", "x86_64")
+                .unwrap()
+                .as_ref(),
+            Some(&entry)
+        );
+        assert_eq!(
+            store.list_microregistry_local(Some("x86_64")).unwrap(),
+            std::slice::from_ref(&entry)
+        );
+        assert!(
+            store
+                .list_microregistry_local(Some("aarch64"))
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(store.list_microregistry_local(None).unwrap(), [entry]);
+    }
+
+    #[test]
+    fn microregistry_local_rejects_a_duplicate_alias_architecture_pair() {
+        let directory = tempdir().unwrap();
+        let store = Store::open(&directory.path().join("firecrab.db")).unwrap();
+        let entry = local_catalog_entry("nginx-1.27", "x86_64");
+        store.insert_microregistry_local(&entry).unwrap();
+
+        let result = store.insert_microregistry_local(&entry);
+        assert!(
+            matches!(
+                &result,
+                Err(PersistenceError::DuplicateMicroRegistryLocal { alias, architecture })
+                    if alias == "nginx-1.27" && architecture == "x86_64"
+            ),
+            "expected a typed constraint conflict, got {result:?}"
+        );
+
+        let other_arch = local_catalog_entry("nginx-1.27", "aarch64");
+        store.insert_microregistry_local(&other_arch).unwrap();
+        assert_eq!(store.list_microregistry_local(None).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn opening_an_existing_database_creates_microregistry_local() {
+        let directory = tempdir().unwrap();
+        let db_file = directory.path().join("firecrab.db");
+        let store = Store::open(&db_file).unwrap();
+        store
+            .lock()
+            .execute("DROP TABLE microregistry_local", [])
+            .unwrap();
+        drop(store);
+
+        let reopened = Store::open(&db_file).unwrap();
+        let exists: bool = reopened
+            .lock()
+            .prepare(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'microregistry_local'",
+            )
+            .unwrap()
+            .exists([])
+            .unwrap();
+        assert!(exists, "upgrade must CREATE TABLE IF NOT EXISTS");
+        reopened
+            .insert_microregistry_local(&local_catalog_entry("nginx-1.27", "x86_64"))
+            .unwrap();
+        assert_eq!(
+            reopened
+                .microregistry_local("nginx-1.27", "x86_64")
+                .unwrap()
+                .unwrap()
+                .alias,
+            "nginx-1.27"
+        );
     }
 
     #[test]

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -108,20 +108,8 @@ pub struct AppState {
     pub(crate) oci_imports: ImageInstallTracker,
     /// Async MicroRegistry register jobs (`POST /api/microregistry/register`).
     pub(crate) microregistry_registers: ImageInstallTracker,
-    /// In-memory local catalog rows from successful register jobs (not persisted).
-    pub(crate) microregistry_local: Arc<Mutex<HashMap<String, LocalCatalogEntry>>>,
     /// Previous `/proc` jiffy samples used to derive host-process CPU %.
     pub(crate) process_metrics: Arc<Mutex<ProcessMetricsTracker>>,
-}
-
-/// One locally registered MicroRegistry row. Filled only by a successful
-/// register job; listing never invents these from `list_aliases()` or disk.
-#[derive(Debug, Clone)]
-pub(crate) struct LocalCatalogEntry {
-    pub alias: String,
-    pub version: String,
-    /// RFC 3339 UTC timestamp recorded when the register job succeeded.
-    pub published_at: String,
 }
 
 impl AppState {
@@ -165,7 +153,6 @@ impl AppState {
             bootstraps: crate::bootstrap::BootstrapTracker::default(),
             oci_imports: ImageInstallTracker::default(),
             microregistry_registers: ImageInstallTracker::default(),
-            microregistry_local: Arc::new(Mutex::new(HashMap::new())),
             process_metrics: Arc::new(Mutex::new(ProcessMetricsTracker::default())),
         })
     }

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -90,6 +90,8 @@ The response has status `201` and includes the VM UUID.
 ## MicroRegistry
 
 `GET /api/microregistry` lists published packages for this host plus locally registered custom aliases.
+A successful register is stored in SQLite and survives restart.
+If the public catalog is unreachable or consume is disabled, GET still returns those local rows. `source` is the attempted catalog URL, or empty when the URL is unset. With no local rows the response stays 503.
 
 Register an already-installed custom image.
 

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -65,7 +65,7 @@ Disk size can grow but cannot shrink.
 
 The Images screen can inspect an OCI reference and start an import.
 Poll the job until the alias appears in the local catalog and can create a VM.
-A locally installed custom alias can also be registered into this host's MicroRegistry catalog.
+A locally installed custom alias can also be registered into this host's MicroRegistry catalog; the row is stored in SQLite and survives restart.
 
 ## Production
 

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -150,8 +150,8 @@ Restart the API after replacing files outside the API workflow.
 
 ## Register
 
-A locally installed custom alias can join this host's catalog via `POST /api/microregistry/register`.
-Poll `GET /api/microregistry/register/{alias}`; a success appears on `GET /api/microregistry` without a remote package key.
+A locally installed custom alias can join this host's SQLite catalog via `POST /api/microregistry/register`.
+Poll `GET /api/microregistry/register/{alias}`; a success survives restart. A catalog outage still lists local rows (`source` is the attempted URL, or empty if unset); with none, GET stays 503.
 
 ## Add an alias
 


### PR DESCRIPTION
## Summary

A locally registered image survives a restart and a public `catalog.json` refresh. The register job writes a durable SQLite row; `GET /api/microregistry` reads public entries and local rows together.

This is **#108 L3 only**. It does not change the L2 job wire contract, does not build `{alias}.tar.zst` (L4), and does not add kernel-arch verification (L5).

## Motivation

- L2 stored local rows in memory. A process restart dropped them, so the dashboard lost custom aliases such as an OCI import (`nginx-1.27`).
- `GET /api/microregistry` used to 503 when the public catalog was unreachable, hiding any local rows that did exist.
- `known_spec` must keep filtering public entries, but must not erase local custom aliases this issue exists to add.

## Position

```text
#108 MicroRegistry register
├─ L1 Dashboard     have  (#109)
├─ L2 API           have  (#113)
├─ L3 Catalog       this  persist rows across refresh/restart
├─ L4 Package       later {alias}.tar.zst
└─ L5 Verify        later kernel arch (#89 / #94)
```

## Schema

One STRICT table `microregistry_local` in `persistence.rs`, created in the existing schema-init block (`CREATE TABLE IF NOT EXISTS`).

- Columns: `alias`, `version`, `architecture`, `package`, `sha256`, `min_disk_gb`, `published_at`
- Primary key: `(alias, architecture)` — the same alias on another arch is a different artifact

## Merge and conflicts

- Public listing is unchanged: fetch `catalog.json`, filter to `Architecture::HOST` and `known_spec`.
- Local rows come from SQLite for this host architecture. `known_spec` does **not** apply to them.
- A public refresh replaces only the public half. Local rows stay.
- If the catalog fetch fails, GET still returns local rows (`source` is the attempted URL, or empty when unset). With no local rows the response stays 503.
- **409** via `AppError::conflict`:
  - `alias_collision` — public catalog already has this alias+arch (e.g. `ubuntu-26.04`), or a local row already exists
  - `register_in_progress` — a register job for that alias is already running

Merged listing stays `MicroRegistryImageResponse`, sorted by alias. Local rows report real host state and do not carry a fabricated remote package key.

## Acceptance

- Register an installed custom alias, restart the API, `GET /api/microregistry` still lists that row.
- Refreshing the public catalog keeps the local row. A second register of the same alias+arch is 409. Dashboard cannot overwrite `ubuntu-26.04`.
- An unreachable public catalog still returns local rows. A custom alias is not dropped by `known_spec`.
- A failed register job leaves no local row.

Out of scope:

- L1 dashboard edits
- L2 job path / tracker changes
- L4 `{alias}.tar.zst` package build
- L5 kernel-arch verification
- Push to `registry.firecrab.dev` / R2

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace` — 534 + 25 + 17 + 69 passed (includes persistence round-trip, duplicate PK, merge, refresh, catalog outage, 409 cases)
- `python3 scripts/check-doc-links.py`
- `cargo clippy --all-targets --all-features -- -D warnings` fails on pre-existing warnings only (not in the L3 files)

Related to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom MicroRegistry entries now persist across restarts.
  * Catalog listings include locally registered entries and filter results by supported architecture.
  * Local catalog entries remain available when the remote catalog is unavailable or disabled.
  * Registration now stores package metadata, checksums, disk requirements, and publication details.

* **Bug Fixes**
  * Improved handling of duplicate aliases and remote catalog conflicts.

* **Documentation**
  * Updated API, dashboard, and image documentation to describe persistence and catalog fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->