### PR TITLE
feat(api): pack an installed template into a MicroRegistry archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/firecrab-api/Cargo.toml
+++ b/firecrab-api/Cargo.toml
@@ -25,6 +25,7 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4"] }
+zstd = "0.13"
 
 [dev-dependencies]
 http-body-util = "0.1.3"

--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -400,6 +400,14 @@ async fn run_microregistry_register(
         tracker.finish_err_with(&alias, "register failed: template is not installed");
         return;
     };
+    // Unrecognized stays Ok because pre-#89/#94 artifacts cannot be classified.
+    if let Err(error) = crate::templates::verify_kernel_architecture(
+        templates.image_root(),
+        template.kernel.relative_path(),
+    ) {
+        tracker.finish_err_with(&alias, format!("register failed: {error}"));
+        return;
+    }
     tracker.append_log(&alias, "packing archive");
     let packed = match crate::package::pack_registered_template(
         &tracker,
@@ -415,6 +423,8 @@ async fn run_microregistry_register(
             return;
         }
     };
+    let published =
+        crate::package::StagedPackageGuard::after_publish(templates.image_root_path(), &alias);
     tracker.append_log(&alias, "updating catalog");
     let entry = LocalCatalogEntry {
         alias: alias.clone(),
@@ -429,6 +439,7 @@ async fn run_microregistry_register(
         tracker.finish_err_with(&alias, format!("register failed: {error}"));
         return;
     }
+    published.keep();
     tracker.finish_ok_with(&alias, "register succeeded — catalog updated");
 }
 
@@ -438,7 +449,7 @@ mod tests {
     use crate::extract::ValidatedJson;
     use crate::image_install::ImageInstallTracker;
     use crate::state::AppState;
-    use crate::templates::TemplateSpec;
+    use crate::templates::{TemplateError, TemplateSpec};
     use std::sync::{Arc, Mutex};
 
     use axum::Json;
@@ -471,6 +482,7 @@ mod tests {
         {
             std::fs::create_dir_all(root.join(parent)).unwrap();
         }
+        // Unrecognized placeholder; register must keep accepting it.
         std::fs::write(root.join("kernel/vmlinux"), b"kernel").unwrap();
         std::fs::write(root.join(rootfs), vec![0_u8; 64]).unwrap();
         state
@@ -523,6 +535,50 @@ mod tests {
             snapshot = state.microregistry_registers.snapshot(alias);
         }
         snapshot
+    }
+
+    fn elf_machine_fixture(machine: u16) -> Vec<u8> {
+        let mut header = vec![0_u8; 64];
+        header[..4].copy_from_slice(b"\x7fELF");
+        header[18..20].copy_from_slice(&machine.to_le_bytes());
+        header
+    }
+
+    fn kernel_fixture_for(architecture: Architecture) -> Vec<u8> {
+        match architecture {
+            Architecture::X86_64 => elf_machine_fixture(0x3e),
+            Architecture::Aarch64 => {
+                let mut header = vec![0_u8; 64];
+                header[..2].copy_from_slice(b"MZ");
+                header[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+                header
+            }
+        }
+    }
+
+    fn overwrite_kernel(state: &AppState, bytes: &[u8]) {
+        std::fs::write(
+            state.templates.image_root_path().join("kernel/vmlinux"),
+            bytes,
+        )
+        .unwrap();
+    }
+
+    fn assert_register_left_no_artifacts(state: &AppState, alias: &str) {
+        assert!(
+            local_aliases(state).is_empty(),
+            "refusal must not write a catalog row"
+        );
+        let image_root = state.templates.image_root_path();
+        assert!(!image_install::staged_package_exists(image_root, alias));
+        assert!(!crate::package::building_package_path(image_root, alias).exists());
+        assert!(image_install::staged_package_origin(image_root, alias).is_none());
+        assert!(
+            !image_root
+                .join(".packages")
+                .join(format!("{alias}.tar.zst.origin"))
+                .exists()
+        );
     }
 
     fn local_aliases(state: &AppState) -> Vec<String> {
@@ -704,6 +760,7 @@ mod tests {
 
         let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
         assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+        // b"kernel" is Unrecognized; this happy path must stay Succeeded.
         assert!(
             finished
                 .log
@@ -1098,6 +1155,141 @@ mod tests {
             "nginx-1.27"
         ));
         assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+    }
+
+    #[tokio::test]
+    async fn register_job_refuses_a_foreign_architecture_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        overwrite_kernel(&state, &kernel_fixture_for(Architecture::HOST.other()));
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("job starts");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Failed).await;
+        assert_eq!(finished.status, ImageInstallStatus::Failed);
+        let expected = TemplateError::KernelArchitectureMismatch {
+            path: std::path::PathBuf::from("kernel/vmlinux"),
+            found: Architecture::HOST.other(),
+            host: Architecture::HOST,
+        }
+        .to_string();
+        assert!(
+            finished.log.contains(&expected),
+            "failed job must carry KernelArchitectureMismatch Display: {}",
+            finished.log
+        );
+        assert_register_left_no_artifacts(&state, "nginx-1.27");
+    }
+
+    #[tokio::test]
+    async fn register_job_refuses_an_unsupported_architecture_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        overwrite_kernel(&state, &elf_machine_fixture(0xf3));
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("job starts");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Failed).await;
+        assert_eq!(finished.status, ImageInstallStatus::Failed);
+        let expected = TemplateError::UnsupportedKernelArchitecture {
+            path: std::path::PathBuf::from("kernel/vmlinux"),
+            machine: 0xf3,
+        }
+        .to_string();
+        assert!(
+            finished.log.contains(&expected),
+            "failed job must carry UnsupportedKernelArchitecture Display: {}",
+            finished.log
+        );
+        assert_register_left_no_artifacts(&state, "nginx-1.27");
+    }
+
+    #[tokio::test]
+    async fn register_job_accepts_an_unrecognized_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("unrecognized kernel must still start");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+        let image_root = state.templates.image_root_path();
+        assert!(image_install::staged_package_exists(
+            image_root,
+            "nginx-1.27"
+        ));
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+    }
+
+    #[tokio::test]
+    async fn register_job_discards_archive_when_catalog_insert_fails() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        state
+            .store
+            .insert_microregistry_local(&LocalCatalogEntry {
+                alias: "nginx-1.27".to_owned(),
+                architecture: Architecture::HOST.as_str().to_owned(),
+                version: "pre".to_owned(),
+                package: String::new(),
+                sha256: String::new(),
+                min_disk_gb: 1,
+                published_at: rfc3339_utc_now(),
+            })
+            .unwrap();
+
+        state
+            .microregistry_registers
+            .begin_with("nginx-1.27", "register started")
+            .unwrap();
+        run_microregistry_register(
+            state.microregistry_registers.clone(),
+            state.templates.clone(),
+            state.store.clone(),
+            "nginx-1.27".to_owned(),
+            "1".to_owned(),
+        )
+        .await;
+
+        assert_eq!(
+            state.microregistry_registers.snapshot("nginx-1.27").status,
+            ImageInstallStatus::Failed
+        );
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+        assert_eq!(local_row(&state, "nginx-1.27").version, "pre");
+        let image_root = state.templates.image_root_path();
+        assert!(!image_install::staged_package_exists(
+            image_root,
+            "nginx-1.27"
+        ));
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+        assert!(image_install::staged_package_origin(image_root, "nginx-1.27").is_none());
+        assert!(
+            !image_root
+                .join(".packages")
+                .join("nginx-1.27.tar.zst.origin")
+                .exists()
+        );
     }
 
     fn file_sha256(path: &std::path::Path) -> String {

--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -719,8 +719,8 @@ mod tests {
         assert_eq!(local_aliases(&state), ["nginx-1.27"]);
         let row = local_row(&state, "nginx-1.27");
         assert_eq!(row.architecture, Architecture::HOST.as_str());
-        assert_eq!(row.package, "");
-        assert_eq!(row.sha256, "");
+        assert_eq!(row.package, "nginx-1.27.tar.zst");
+        assert_eq!(row.sha256.len(), 64);
         assert_eq!(row.min_disk_gb, 1);
         assert!(row.published_at.contains('T') && row.published_at.ends_with('Z'));
     }

--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -138,8 +138,8 @@ fn local_catalog_image(
         downloadable: false,
         alias: entry.alias.clone(),
         version: entry.version.clone(),
-        package: String::new(),
-        sha256: String::new(),
+        package: entry.package.clone(),
+        sha256: entry.sha256.clone(),
         min_disk_gb,
         published_at: entry.published_at.clone(),
     }
@@ -335,6 +335,21 @@ async fn run_microregistry_register(
         tracker.finish_err_with(&alias, "register failed: template is not installed");
         return;
     }
+    tracker.append_log(&alias, "packing archive");
+    let packed = match crate::package::pack_registered_template(
+        &tracker,
+        templates.as_ref(),
+        &alias,
+        &version,
+    )
+    .await
+    {
+        Ok(packed) => packed,
+        Err(error) => {
+            tracker.finish_err_with(&alias, format!("register failed: {error}"));
+            return;
+        }
+    };
     tracker.append_log(&alias, "updating catalog");
     let published_at = rfc3339_utc_now();
     {
@@ -347,6 +362,8 @@ async fn run_microregistry_register(
                 alias: alias.clone(),
                 version,
                 published_at,
+                package: packed.package,
+                sha256: packed.sha256,
             },
         );
     }
@@ -377,10 +394,19 @@ mod tests {
     }
 
     fn install_custom(state: &AppState, alias: &str) {
+        install_custom_with_rootfs(state, alias, &format!("rootfs/{alias}.ext4"));
+    }
+
+    fn install_custom_with_rootfs(state: &AppState, alias: &str, rootfs: &str) {
         let root = state.templates.image_root_path();
         std::fs::create_dir_all(root.join("kernel")).unwrap();
+        if let Some(parent) = std::path::Path::new(rootfs).parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(root.join(parent)).unwrap();
+        }
         std::fs::write(root.join("kernel/vmlinux"), b"kernel").unwrap();
-        std::fs::write(root.join(format!("{alias}.ext4")), vec![0_u8; 64]).unwrap();
+        std::fs::write(root.join(rootfs), vec![0_u8; 64]).unwrap();
         state
             .templates
             .register_spec(TemplateSpec {
@@ -388,7 +414,7 @@ mod tests {
                 version: format!("{alias}-local"),
                 kernel: std::path::PathBuf::from("kernel/vmlinux"),
                 initrd: None,
-                rootfs: std::path::PathBuf::from(format!("{alias}.ext4")),
+                rootfs: std::path::PathBuf::from(rootfs),
                 boot_args: "console=ttyS0 root=/dev/vda rw".to_owned(),
             })
             .unwrap();
@@ -607,6 +633,11 @@ mod tests {
                 .log
                 .contains("register succeeded — catalog updated"),
             "succeeded job must record the catalog update: {}",
+            finished.log
+        );
+        assert!(
+            finished.log.contains("[packer:package] complete"),
+            "succeeded job must record packer progress: {}",
             finished.log
         );
         assert_eq!(local_aliases(&state), ["nginx-1.27"]);
@@ -852,10 +883,11 @@ mod tests {
             .find(|image| image.alias == "nginx-1.27")
             .unwrap();
         assert!(!local.downloadable);
-        assert_eq!(local.package, "");
-        assert_eq!(local.sha256, "");
+        assert_eq!(local.package, "nginx-1.27.tar.zst");
+        assert_eq!(local.sha256.len(), 64);
         assert_eq!(local.version, "1");
         assert!(local.installed);
+        assert!(local.package_staged);
         assert_eq!(local.min_disk_gb, 1);
 
         let Json(again) = list_microregistry(State(state), Extension(request_id()))
@@ -902,6 +934,100 @@ mod tests {
             "failed job must record why"
         );
         assert!(local_aliases(&state).is_empty());
+    }
+
+    #[tokio::test]
+    async fn register_job_fills_package_sha256_and_stages_the_file() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("installed custom alias must be accepted");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+
+        let image_root = state.templates.image_root_path();
+        let staged = crate::image_install::staged_package_path(image_root, "nginx-1.27");
+        assert!(staged.is_file(), "register must stage {}", staged.display());
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+
+        let entry = state
+            .microregistry_local
+            .lock()
+            .unwrap()
+            .get("nginx-1.27")
+            .cloned()
+            .expect("local row");
+        assert_eq!(entry.package, "nginx-1.27.tar.zst");
+        assert_eq!(entry.sha256.len(), 64);
+        assert_eq!(entry.sha256, file_sha256(&staged));
+        assert_eq!(
+            crate::image_install::staged_package_origin(image_root, "nginx-1.27"),
+            Some(firecrab_api_types::PackageOrigin::MicroRegistry)
+        );
+    }
+
+    #[tokio::test]
+    async fn register_job_refuses_unsafe_rootfs_without_archive_or_row() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom_with_rootfs(&state, "nginx-1.27", "nginx-1.27.ext4");
+
+        state
+            .microregistry_registers
+            .begin_with("nginx-1.27", "register started")
+            .unwrap();
+        run_microregistry_register(
+            state.microregistry_registers.clone(),
+            state.templates.clone(),
+            Arc::clone(&state.microregistry_local),
+            "nginx-1.27".to_owned(),
+            "1".to_owned(),
+        )
+        .await;
+
+        assert_eq!(
+            state.microregistry_registers.snapshot("nginx-1.27").status,
+            ImageInstallStatus::Failed
+        );
+        assert!(
+            state
+                .microregistry_registers
+                .snapshot("nginx-1.27")
+                .log
+                .contains("nginx-1.27.ext4"),
+            "failed job must name the unsafe rootfs: {}",
+            state.microregistry_registers.snapshot("nginx-1.27").log
+        );
+        assert!(local_aliases(&state).is_empty());
+        let image_root = state.templates.image_root_path();
+        assert!(!crate::image_install::staged_package_exists(
+            image_root,
+            "nginx-1.27"
+        ));
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+    }
+
+    fn file_sha256(path: &std::path::Path) -> String {
+        use sha2::{Digest, Sha256};
+        use std::io::Read;
+        let mut file = std::fs::File::open(path).unwrap();
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        format!("{:x}", hasher.finalize())
     }
 
     #[tokio::test]

--- a/firecrab-api/src/main.rs
+++ b/firecrab-api/src/main.rs
@@ -14,6 +14,7 @@ mod model;
 mod network;
 mod network_policy;
 mod oci;
+mod package;
 mod persistence;
 mod process_metrics;
 mod rootfs;

--- a/firecrab-api/src/package.rs
+++ b/firecrab-api/src/package.rs
@@ -1,0 +1,659 @@
+//! In-process packer: stream a registered template into `.packages/{alias}.tar.zst`.
+//!
+//! Members are the registered relative kernel and rootfs paths, the registered
+//! initrd path when present, and [`TEMPLATE_SPEC_MEMBER`]. Every member must
+//! pass [`crate::image_install::is_safe_archive_member`].
+
+use std::fs::{self, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::image_install::{
+    ImageInstallTracker, is_safe_archive_member, package_name, staged_package_path,
+    write_staged_package_origin,
+};
+use crate::templates::{TemplateRegistry, TemplateSpec, TemplateVersion};
+use firecrab_api_types::PackageOrigin;
+
+/// CamelCase [`TemplateSpec`] carried beside the kernel so custom aliases keep
+/// boot args and the initrd flag. Already under `kernel/`, so the member rule
+/// does not need an exception.
+pub const TEMPLATE_SPEC_MEMBER: &str = "kernel/.firecrab-template.json";
+
+/// Result of publishing `{alias}.tar.zst` into the local package cache.
+#[derive(Debug)]
+pub struct PackedPackage {
+    /// `{alias}.tar.zst`.
+    pub package: String,
+    /// SHA-256 of the compressed archive bytes.
+    pub sha256: String,
+}
+
+/// Temporary path used while the archive is still being written.
+pub fn building_package_path(image_root: &Path, alias: &str) -> PathBuf {
+    image_root
+        .join(".packages")
+        .join(format!("{}.tar.zst.building", alias))
+}
+
+/// Pack the installed template for `alias` using the register request's version.
+pub async fn pack_registered_template(
+    tracker: &ImageInstallTracker,
+    templates: &TemplateRegistry,
+    alias: &str,
+    request_version: &str,
+) -> Result<PackedPackage, String> {
+    let Some(template) = templates.resolve_alias(alias) else {
+        return Err("template is not installed".to_owned());
+    };
+    let spec = spec_from_registered(&template, request_version);
+    let image_root = templates.image_root_path().to_path_buf();
+    let tracker = tracker.clone();
+    tokio::task::spawn_blocking(move || pack_spec_blocking(&tracker, &image_root, &spec))
+        .await
+        .map_err(|error| format!("pack task panicked: {error}"))?
+}
+
+/// Read the [`TemplateSpec`] stored at [`TEMPLATE_SPEC_MEMBER`].
+#[cfg(test)]
+pub fn read_packed_template_spec(archive: &Path) -> Result<TemplateSpec, String> {
+    let file =
+        File::open(archive).map_err(|error| format!("open {}: {error}", archive.display()))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|error| format!("zstd decoder {}: {error}", archive.display()))?;
+    let mut tar = tar::Archive::new(decoder);
+    for entry in tar
+        .entries()
+        .map_err(|error| format!("tar entries: {error}"))?
+    {
+        let mut entry = entry.map_err(|error| format!("tar entry: {error}"))?;
+        let name = entry
+            .path()
+            .map_err(|error| format!("tar member path: {error}"))?;
+        let name = name.to_string_lossy().replace('\\', "/");
+        if name == TEMPLATE_SPEC_MEMBER {
+            return serde_json::from_reader(&mut entry)
+                .map_err(|error| format!("parse {TEMPLATE_SPEC_MEMBER}: {error}"));
+        }
+    }
+    Err(format!(
+        "archive missing required member `{TEMPLATE_SPEC_MEMBER}`"
+    ))
+}
+
+/// List archive member paths in the order they were written.
+#[cfg(test)]
+pub fn list_packed_members(archive: &Path) -> Result<Vec<String>, String> {
+    let file =
+        File::open(archive).map_err(|error| format!("open {}: {error}", archive.display()))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|error| format!("zstd decoder {}: {error}", archive.display()))?;
+    let mut tar = tar::Archive::new(decoder);
+    let mut members = Vec::new();
+    for entry in tar
+        .entries()
+        .map_err(|error| format!("tar entries: {error}"))?
+    {
+        let entry = entry.map_err(|error| format!("tar entry: {error}"))?;
+        let name = entry
+            .path()
+            .map_err(|error| format!("tar member path: {error}"))?;
+        members.push(name.to_string_lossy().replace('\\', "/"));
+    }
+    Ok(members)
+}
+
+fn spec_from_registered(template: &TemplateVersion, request_version: &str) -> TemplateSpec {
+    TemplateSpec {
+        alias: template.name.clone(),
+        version: request_version.to_owned(),
+        kernel: template.kernel.relative_path().to_path_buf(),
+        initrd: template
+            .initrd
+            .as_ref()
+            .map(|artifact| artifact.relative_path().to_path_buf()),
+        rootfs: template.rootfs.relative_path().to_path_buf(),
+        boot_args: template.boot_args.clone(),
+    }
+}
+
+fn pack_spec_blocking(
+    tracker: &ImageInstallTracker,
+    image_root: &Path,
+    spec: &TemplateSpec,
+) -> Result<PackedPackage, String> {
+    let kernel = archive_member_name(&spec.kernel, "kernel/")?;
+    let rootfs = archive_member_name(&spec.rootfs, "rootfs/")?;
+    let initrd = spec
+        .initrd
+        .as_ref()
+        .map(|path| archive_member_name(path, "kernel/"))
+        .transpose()?;
+    if !is_safe_archive_member(TEMPLATE_SPEC_MEMBER) {
+        return Err(format!(
+            "refusing archive member `{TEMPLATE_SPEC_MEMBER}` (only kernel/ and rootfs/ relative paths allowed)"
+        ));
+    }
+
+    tracker.append_log(
+        &spec.alias,
+        format!("[packer:source] packing registered template {}", spec.alias),
+    );
+    tracker.append_log(&spec.alias, "[packer:source] complete");
+
+    let dest = staged_package_path(image_root, &spec.alias);
+    let building_path = building_package_path(image_root, &spec.alias);
+    let (building, file) = BuildingFile::create(building_path)?;
+    let sha256 = write_archive(
+        tracker,
+        image_root,
+        spec,
+        &kernel,
+        initrd.as_deref(),
+        &rootfs,
+        file,
+    )?;
+    building.publish(&dest)?;
+    if let Err(error) =
+        write_staged_package_origin(image_root, &spec.alias, PackageOrigin::MicroRegistry)
+    {
+        let _ = fs::remove_file(&dest);
+        return Err(format!("publish package origin: {error}"));
+    }
+    tracker.append_log(
+        &spec.alias,
+        format!("[packer:package] published {}", package_name(&spec.alias)),
+    );
+    tracker.append_log(&spec.alias, "[packer:package] complete");
+    Ok(PackedPackage {
+        package: package_name(&spec.alias),
+        sha256,
+    })
+}
+
+fn write_archive(
+    tracker: &ImageInstallTracker,
+    image_root: &Path,
+    spec: &TemplateSpec,
+    kernel: &str,
+    initrd: Option<&str>,
+    rootfs: &str,
+    file: File,
+) -> Result<String, String> {
+    let hasher = HashingWriter::new(file);
+    let encoder = zstd::stream::write::Encoder::new(hasher, 0)
+        .map_err(|error| format!("zstd encoder: {error}"))?;
+    let mut builder = tar::Builder::new(encoder);
+
+    append_template_spec(&mut builder, spec)?;
+    tracker.append_log(&spec.alias, format!("[packer:kernel] packing {kernel}"));
+    append_regular_file(&mut builder, image_root, kernel)?;
+    if let Some(initrd) = initrd {
+        tracker.append_log(&spec.alias, format!("[packer:kernel] packing {initrd}"));
+        append_regular_file(&mut builder, image_root, initrd)?;
+    }
+    tracker.append_log(&spec.alias, "[packer:kernel] complete");
+    tracker.append_log(&spec.alias, format!("[packer:rootfs] streaming {rootfs}"));
+    append_regular_file(&mut builder, image_root, rootfs)?;
+    tracker.append_log(&spec.alias, "[packer:rootfs] complete");
+
+    let encoder = builder
+        .into_inner()
+        .map_err(|error| format!("finish tar: {error}"))?;
+    let hasher = encoder
+        .finish()
+        .map_err(|error| format!("finish zstd: {error}"))?;
+    let (file, digest) = hasher.finalize();
+    file.sync_all()
+        .map_err(|error| format!("sync package: {error}"))?;
+    Ok(digest)
+}
+
+fn append_template_spec<W: Write>(
+    builder: &mut tar::Builder<W>,
+    spec: &TemplateSpec,
+) -> Result<(), String> {
+    let mut bytes = serde_json::to_vec(spec)
+        .map_err(|error| format!("serialize {TEMPLATE_SPEC_MEMBER}: {error}"))?;
+    bytes.push(b'\n');
+    let mut header = tar::Header::new_gnu();
+    header.set_size(bytes.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    builder
+        .append_data(&mut header, TEMPLATE_SPEC_MEMBER, bytes.as_slice())
+        .map_err(|error| format!("append {TEMPLATE_SPEC_MEMBER}: {error}"))
+}
+
+fn append_regular_file<W: Write>(
+    builder: &mut tar::Builder<W>,
+    image_root: &Path,
+    member: &str,
+) -> Result<(), String> {
+    let path = image_root.join(member);
+    let mut file =
+        File::open(&path).map_err(|error| format!("open {}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("stat {}: {error}", path.display()))?;
+    if !metadata.is_file() {
+        return Err(format!("template artifact is not a regular file: {member}"));
+    }
+    builder
+        .append_file(member, &mut file)
+        .map_err(|error| format!("append {member}: {error}"))
+}
+
+fn archive_member_name(path: &Path, required_prefix: &str) -> Result<String, String> {
+    let name = path
+        .to_str()
+        .ok_or_else(|| "template artifact path must be utf-8".to_owned())?
+        .replace('\\', "/");
+    if !is_safe_archive_member(&name) {
+        return Err(format!(
+            "refusing archive member `{name}` (only kernel/ and rootfs/ relative paths allowed)"
+        ));
+    }
+    if !name.starts_with(required_prefix) {
+        return Err(format!(
+            "registered path `{name}` must be under {required_prefix}"
+        ));
+    }
+    Ok(name)
+}
+
+struct BuildingFile {
+    path: PathBuf,
+    persist: bool,
+}
+
+impl BuildingFile {
+    fn create(path: PathBuf) -> Result<(Self, File), String> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("mkdir {}: {error}", parent.display()))?;
+        }
+        let _ = fs::remove_file(&path);
+        let file =
+            File::create(&path).map_err(|error| format!("create {}: {error}", path.display()))?;
+        Ok((
+            Self {
+                path,
+                persist: false,
+            },
+            file,
+        ))
+    }
+
+    fn publish(mut self, dest: &Path) -> Result<(), String> {
+        fs::rename(&self.path, dest)
+            .map_err(|error| format!("publish {}: {error}", dest.display()))?;
+        self.persist = true;
+        Ok(())
+    }
+}
+
+impl Drop for BuildingFile {
+    fn drop(&mut self) {
+        if !self.persist {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+struct HashingWriter<W> {
+    inner: W,
+    hasher: Sha256,
+}
+
+impl<W: Write> HashingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn finalize(self) -> (W, String) {
+        (self.inner, format!("{:x}", self.hasher.finalize()))
+    }
+}
+
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.hasher.update(&buf[..written]);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::image_install::{run_image_install, staged_package_exists};
+    use crate::templates::TemplateRegistry;
+    use firecrab_api_types::ImageInstallStatus;
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+    use tempfile::tempdir;
+
+    fn write_file(path: &Path, bytes: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn nginx_spec(version: &str) -> TemplateSpec {
+        TemplateSpec {
+            alias: "nginx-1.27".to_owned(),
+            version: version.to_owned(),
+            kernel: PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64"),
+            initrd: None,
+            rootfs: PathBuf::from("rootfs/nginx-1.27.ext4"),
+            boot_args: "console=ttyS0 root=/dev/vda rw".to_owned(),
+        }
+    }
+
+    fn alpine_spec() -> TemplateSpec {
+        TemplateSpec {
+            alias: "alpine-3.24.1".to_owned(),
+            version: "5".to_owned(),
+            kernel: PathBuf::from("kernel/vmlinux-alpine-virt-x86_64"),
+            initrd: Some(PathBuf::from("kernel/initramfs-alpine-virt-x86_64")),
+            rootfs: PathBuf::from("rootfs/alpine-rootfs-3.24.1-x86_64.ext4"),
+            boot_args: "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rootfstype=ext4 rw"
+                .to_owned(),
+        }
+    }
+
+    fn register_layout(root: &Path, spec: &TemplateSpec) -> TemplateRegistry {
+        write_file(&root.join(&spec.kernel), b"kernel-bytes");
+        if let Some(initrd) = &spec.initrd {
+            write_file(&root.join(initrd), b"initrd-bytes");
+        }
+        write_file(&root.join(&spec.rootfs), b"rootfs-bytes");
+        TemplateRegistry::from_specs(root, [spec.clone()]).unwrap()
+    }
+
+    fn file_sha256(path: &Path) -> String {
+        let mut file = File::open(path).unwrap();
+        let mut hasher = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer).unwrap();
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        format!("{:x}", hasher.finalize())
+    }
+
+    #[test]
+    fn template_spec_member_is_safe_and_top_level_manifest_is_not() {
+        assert!(is_safe_archive_member(TEMPLATE_SPEC_MEMBER));
+        assert!(is_safe_archive_member("kernel/vmlinux-ubuntu-26.04-x86_64"));
+        assert!(is_safe_archive_member("rootfs/nginx-1.27.ext4"));
+        assert!(!is_safe_archive_member("manifest.json"));
+        assert!(!is_safe_archive_member("kernel/../x"));
+        assert!(!is_safe_archive_member("/kernel/x"));
+        assert!(!is_safe_archive_member("nginx-1.27.ext4"));
+    }
+
+    #[tokio::test]
+    async fn packed_members_all_pass_is_safe_archive_member() {
+        let directory = tempdir().unwrap();
+        let spec = nginx_spec("1");
+        let templates = register_layout(directory.path(), &spec);
+        let tracker = ImageInstallTracker::disabled();
+        let packed = pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap();
+
+        let archive = staged_package_path(templates.image_root_path(), &spec.alias);
+        let members = list_packed_members(&archive).unwrap();
+        assert!(!members.is_empty());
+        for member in &members {
+            assert!(
+                is_safe_archive_member(member),
+                "member `{member}` must pass is_safe_archive_member"
+            );
+            assert_ne!(member, "manifest.json");
+            assert!(!member.starts_with("manifest.json"));
+        }
+        assert!(members.iter().any(|member| member == TEMPLATE_SPEC_MEMBER));
+        assert!(
+            members
+                .iter()
+                .any(|member| member == "kernel/vmlinux-ubuntu-26.04-x86_64")
+        );
+        assert!(
+            members
+                .iter()
+                .any(|member| member == "rootfs/nginx-1.27.ext4")
+        );
+        assert_eq!(packed.package, "nginx-1.27.tar.zst");
+    }
+
+    #[tokio::test]
+    async fn packs_oci_shaped_archive_without_initrd() {
+        let directory = tempdir().unwrap();
+        let spec = nginx_spec("1");
+        let templates = register_layout(directory.path(), &spec);
+        let tracker = ImageInstallTracker::disabled();
+        pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap();
+
+        let archive = staged_package_path(templates.image_root_path(), &spec.alias);
+        let members = list_packed_members(&archive).unwrap();
+        assert_eq!(
+            members,
+            [
+                TEMPLATE_SPEC_MEMBER,
+                "kernel/vmlinux-ubuntu-26.04-x86_64",
+                "rootfs/nginx-1.27.ext4",
+            ]
+        );
+
+        let packed_spec = read_packed_template_spec(&archive).unwrap();
+        assert_eq!(packed_spec.alias, "nginx-1.27");
+        assert_eq!(packed_spec.version, "1");
+        assert_eq!(
+            packed_spec.kernel,
+            PathBuf::from("kernel/vmlinux-ubuntu-26.04-x86_64")
+        );
+        assert_eq!(packed_spec.initrd, None);
+        assert_eq!(packed_spec.rootfs, PathBuf::from("rootfs/nginx-1.27.ext4"));
+        assert_eq!(packed_spec.boot_args, spec.boot_args);
+
+        let raw = raw_template_spec_json(&archive);
+        let value: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        assert!(value.get("bootArgs").is_some());
+        assert!(value.get("initrd").unwrap().is_null());
+    }
+
+    #[tokio::test]
+    async fn packs_alpine_shaped_archive_with_initrd() {
+        let directory = tempdir().unwrap();
+        let spec = alpine_spec();
+        let templates = register_layout(directory.path(), &spec);
+        let tracker = ImageInstallTracker::disabled();
+        pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap();
+
+        let archive = staged_package_path(templates.image_root_path(), &spec.alias);
+        let members = list_packed_members(&archive).unwrap();
+        assert_eq!(
+            members,
+            [
+                TEMPLATE_SPEC_MEMBER,
+                "kernel/vmlinux-alpine-virt-x86_64",
+                "kernel/initramfs-alpine-virt-x86_64",
+                "rootfs/alpine-rootfs-3.24.1-x86_64.ext4",
+            ]
+        );
+        for member in &members {
+            assert!(is_safe_archive_member(member), "{member}");
+        }
+
+        let packed_spec = read_packed_template_spec(&archive).unwrap();
+        assert_eq!(
+            packed_spec.initrd,
+            Some(PathBuf::from("kernel/initramfs-alpine-virt-x86_64"))
+        );
+        assert_eq!(packed_spec.boot_args, spec.boot_args);
+        assert_eq!(
+            packed_spec.kernel,
+            PathBuf::from("kernel/vmlinux-alpine-virt-x86_64")
+        );
+        assert_eq!(
+            packed_spec.rootfs,
+            PathBuf::from("rootfs/alpine-rootfs-3.24.1-x86_64.ext4")
+        );
+    }
+
+    #[tokio::test]
+    async fn round_trip_custom_alias_installs_through_existing_path() {
+        let source = tempdir().unwrap();
+        let spec = nginx_spec("1");
+        let templates = register_layout(source.path(), &spec);
+        let tracker = ImageInstallTracker::disabled();
+        pack_registered_template(&tracker, &templates, &spec.alias, "1")
+            .await
+            .unwrap();
+
+        let archive = staged_package_path(templates.image_root_path(), &spec.alias);
+        let packed_spec = read_packed_template_spec(&archive).unwrap();
+        assert_eq!(packed_spec.boot_args, spec.boot_args);
+        assert_eq!(packed_spec.version, "1");
+
+        let dest = tempdir().unwrap();
+        let dest_templates = TemplateRegistry::from_specs(dest.path(), std::iter::empty()).unwrap();
+        let staged = staged_package_path(dest_templates.image_root_path(), &packed_spec.alias);
+        fs::create_dir_all(staged.parent().unwrap()).unwrap();
+        fs::copy(&archive, &staged).unwrap();
+
+        let install_tracker = ImageInstallTracker::disabled();
+        install_tracker.begin(&packed_spec.alias).unwrap();
+        run_image_install(
+            install_tracker.clone(),
+            dest_templates.clone(),
+            packed_spec.clone(),
+        )
+        .await;
+        let snapshot = install_tracker.snapshot(&packed_spec.alias);
+        assert_eq!(
+            snapshot.status,
+            ImageInstallStatus::Succeeded,
+            "log:\n{}",
+            snapshot.log
+        );
+
+        let installed = dest_templates
+            .resolve_alias(&packed_spec.alias)
+            .expect("round-trip must register the alias");
+        assert_eq!(installed.boot_args, spec.boot_args);
+        assert_eq!(installed.version, "1");
+        assert_eq!(
+            installed.kernel.relative_path(),
+            Path::new("kernel/vmlinux-ubuntu-26.04-x86_64")
+        );
+        assert!(installed.initrd.is_none());
+        assert_eq!(
+            installed.rootfs.relative_path(),
+            Path::new("rootfs/nginx-1.27.ext4")
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_leaves_no_staged_package_or_building_file() {
+        let directory = tempdir().unwrap();
+        let spec = nginx_spec("1");
+        let templates = register_layout(directory.path(), &spec);
+        fs::remove_file(templates.image_root_path().join(&spec.rootfs)).unwrap();
+
+        let tracker = ImageInstallTracker::disabled();
+        let error = pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap_err();
+        assert!(
+            error.contains("open") || error.contains("rootfs"),
+            "{error}"
+        );
+        assert!(!staged_package_exists(
+            templates.image_root_path(),
+            &spec.alias
+        ));
+        assert!(!staged_package_path(templates.image_root_path(), &spec.alias).exists());
+        assert!(!building_package_path(templates.image_root_path(), &spec.alias).exists());
+    }
+
+    #[tokio::test]
+    async fn unsafe_registered_rootfs_is_refused_without_archive() {
+        let directory = tempdir().unwrap();
+        let spec = TemplateSpec {
+            alias: "nginx-1.27".to_owned(),
+            version: "1".to_owned(),
+            kernel: PathBuf::from("kernel/vmlinux"),
+            initrd: None,
+            rootfs: PathBuf::from("nginx-1.27.ext4"),
+            boot_args: "console=ttyS0 root=/dev/vda rw".to_owned(),
+        };
+        write_file(&directory.path().join(&spec.kernel), b"kernel-bytes");
+        write_file(&directory.path().join(&spec.rootfs), b"rootfs-bytes");
+        let templates = TemplateRegistry::from_specs(directory.path(), [spec.clone()]).unwrap();
+
+        let tracker = ImageInstallTracker::disabled();
+        let error = pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap_err();
+        assert!(
+            error.contains("nginx-1.27.ext4"),
+            "unsafe rootfs must be named in the error: {error}"
+        );
+        assert!(!staged_package_exists(
+            templates.image_root_path(),
+            &spec.alias
+        ));
+        assert!(!building_package_path(templates.image_root_path(), &spec.alias).exists());
+    }
+
+    #[tokio::test]
+    async fn packer_digest_matches_published_archive_sha256() {
+        let directory = tempdir().unwrap();
+        let spec = nginx_spec("1");
+        let templates = register_layout(directory.path(), &spec);
+        let tracker = ImageInstallTracker::disabled();
+        let packed = pack_registered_template(&tracker, &templates, &spec.alias, &spec.version)
+            .await
+            .unwrap();
+        let archive = staged_package_path(templates.image_root_path(), &spec.alias);
+        assert_eq!(packed.sha256, file_sha256(&archive));
+        assert_eq!(packed.sha256.len(), 64);
+    }
+
+    fn raw_template_spec_json(archive: &Path) -> Vec<u8> {
+        let file = File::open(archive).unwrap();
+        let decoder = zstd::stream::read::Decoder::new(file).unwrap();
+        let mut tar = tar::Archive::new(decoder);
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let name = entry.path().unwrap().to_string_lossy().replace('\\', "/");
+            if name == TEMPLATE_SPEC_MEMBER {
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).unwrap();
+                return bytes;
+            }
+        }
+        panic!("missing {TEMPLATE_SPEC_MEMBER}");
+    }
+}

--- a/firecrab-api/src/package.rs
+++ b/firecrab-api/src/package.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::image_install::{
-    ImageInstallTracker, is_safe_archive_member, package_name, staged_package_path,
-    write_staged_package_origin,
+    ImageInstallTracker, clear_staged_package_origin, is_safe_archive_member, package_name,
+    staged_package_path, write_staged_package_origin,
 };
 use crate::templates::{TemplateRegistry, TemplateSpec, TemplateVersion};
 use firecrab_api_types::PackageOrigin;
@@ -36,6 +36,44 @@ pub fn building_package_path(image_root: &Path, alias: &str) -> PathBuf {
     image_root
         .join(".packages")
         .join(format!("{}.tar.zst.building", alias))
+}
+
+/// Delete a published `{alias}.tar.zst` and its `.origin` sidecar.
+///
+/// Used when pack has already published and a later catalog insert fails.
+pub(crate) fn discard_staged_package(image_root: &Path, alias: &str) {
+    let dest = staged_package_path(image_root, alias);
+    let _ = fs::remove_file(dest);
+    let _ = clear_staged_package_origin(image_root, alias);
+}
+
+/// Discards a published archive unless [`Self::keep`] is called after insert.
+pub(crate) struct StagedPackageGuard {
+    image_root: PathBuf,
+    alias: String,
+    keep: bool,
+}
+
+impl StagedPackageGuard {
+    pub(crate) fn after_publish(image_root: &Path, alias: &str) -> Self {
+        Self {
+            image_root: image_root.to_path_buf(),
+            alias: alias.to_owned(),
+            keep: false,
+        }
+    }
+
+    pub(crate) fn keep(mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for StagedPackageGuard {
+    fn drop(&mut self) {
+        if !self.keep {
+            discard_staged_package(&self.image_root, &self.alias);
+        }
+    }
 }
 
 /// Pack the installed template for `alias` using the register request's version.

--- a/firecrab-api/src/state.rs
+++ b/firecrab-api/src/state.rs
@@ -122,6 +122,10 @@ pub(crate) struct LocalCatalogEntry {
     pub version: String,
     /// RFC 3339 UTC timestamp recorded when the register job succeeded.
     pub published_at: String,
+    /// `{alias}.tar.zst`, filled by the register packer.
+    pub package: String,
+    /// SHA-256 of the compressed package archive.
+    pub sha256: String,
 }
 
 impl AppState {

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -396,6 +396,11 @@ impl TemplateRegistry {
         &self.image_root_path
     }
 
+    /// Pinned image-root directory fd for `openat2` checks.
+    pub(crate) fn image_root(&self) -> &File {
+        self.image_root.as_ref()
+    }
+
     /// Built-in template specs the project knows about (installed or not).
     pub fn known_specs() -> Vec<TemplateSpec> {
         default_specs()
@@ -898,7 +903,7 @@ pub(crate) fn kernel_architecture(header: &[u8]) -> KernelFormat {
 /// Rejects a kernel this host cannot boot. Firecracker's own failure mode
 /// there is a silent hang with no console output, so the cost of letting one
 /// through is an unbootable VM with nothing to diagnose.
-fn verify_kernel_architecture(root: &File, path: &Path) -> Result<(), TemplateError> {
+pub(crate) fn verify_kernel_architecture(root: &File, path: &Path) -> Result<(), TemplateError> {
     let mut file = open_beneath(root, path)?;
     let mut header = Vec::new();
     // A kernel shorter than one header is simply unclassifiable, so read

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -104,7 +104,7 @@ An empty alias or version is `400 validation_failed`.
 An unknown, uninstalled, or internal alias is `404`.
 A catalog alias or a second register of the same local alias is `409 alias_collision`.
 A running job for that alias is `409 register_in_progress`.
-Local rows have an empty package key and are not downloadable.
+Local rows carry `{alias}.tar.zst` and its SHA-256, and are not downloadable.
 
 ## VM states
 

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -107,6 +107,8 @@ An unknown, uninstalled, or internal alias is `404`.
 A catalog alias or a second register of the same local alias is `409 alias_collision`.
 A running job for that alias is `409 register_in_progress`.
 Local rows carry `{alias}.tar.zst` and its SHA-256 after a successful pack.
+A foreign-architecture or unsupported ELF kernel fails the job: no catalog row and no staged archive.
+An unclassifiable kernel is still accepted.
 
 ## VM states
 

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -151,7 +151,7 @@ Restart the API after replacing files outside the API workflow.
 ## Register
 
 A locally installed custom alias can join this host's catalog via `POST /api/microregistry/register`.
-Poll `GET /api/microregistry/register/{alias}`; a success appears on `GET /api/microregistry` without a remote package key.
+Success packs `{alias}.tar.zst` (`kernel/…`, `rootfs/…`, optional initrd, `kernel/.firecrab-template.json`) and lists it on `GET /api/microregistry`.
 
 ## Add an alias
 

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -151,7 +151,7 @@ Restart the API after replacing files outside the API workflow.
 ## Register
 
 A locally installed custom alias can join this host's SQLite catalog via `POST /api/microregistry/register`.
-Success packs `{alias}.tar.zst` (`kernel/…`, `rootfs/…`, optional initrd, `kernel/.firecrab-template.json`).
+Success packs `{alias}.tar.zst` (`kernel/…`, `rootfs/…`, optional initrd, `kernel/.firecrab-template.json`). A foreign or unsupported kernel fails the job with no row or archive; an unclassifiable kernel is still accepted.
 Poll `GET /api/microregistry/register/{alias}`; a success survives restart. A catalog outage still lists local rows (`source` is the attempted URL, or empty if unset); with none, GET stays 503.
 
 ## Add an alias


### PR DESCRIPTION
## Summary

A successful MicroRegistry register now builds `{alias}.tar.zst` **in-process** from the installed template's own kernel, optional initrd, rootfs, and boot args. The archive is hashed as it is written and published by rename. The L3 SQLite row stores `package` and `sha256`.

This is **#108 L4 only**. It does not change the L2 job routes, does not rewrite the L3 table, and does not add kernel-arch verification (L5). It does not shell out to `package-m2images.sh`.

## Motivation

- L3 persisted a catalog row but left `package`/`sha256` empty, so Download could not work.
- Operator packaging (`package-m2images.sh`) is root/chroot/mount. The API must not do that.
- The install pipeline already consumes `{alias}.tar.zst` with `kernel/` + `rootfs/` members. Register must emit that shape.

## Position

```text
#108 MicroRegistry register
├─ L1 Dashboard     have  (#109)
├─ L2 API           have  (#113)
├─ L3 Catalog       have  (#114)
├─ L4 Package       this  installed template → {alias}.tar.zst
└─ L5 Verify        later kernel arch (#89 / #94)
```

## What landed

- `firecrab-api/src/package.rs` streams the registered artifacts plus `kernel/.firecrab-template.json` (camelCase `TemplateSpec`) through tar+zstd.
- Every member must pass `is_safe_archive_member`. An unsafe rootfs fails the job and leaves no staged or `.building` file.
- SHA-256 is computed over the compressed bytes. Publish is `rename` from `.packages/{alias}.tar.zst.building`.
- `run_microregistry_register` packs first, then inserts the L3 row with `package` + `sha256`.
- No sudo, chroot, mount, or `package-m2images.sh`.

## Acceptance

- Register an installed custom alias (including an OCI import). `.packages/{alias}.tar.zst` exists and its digest matches the catalog row.
- The archive members are the template's kernel, optional initrd, rootfs, and `kernel/.firecrab-template.json`. All pass `is_safe_archive_member`.
- A failed pack leaves no staged package, no `.building` file, and no catalog row.
- `GET /api/microregistry` lists the row with `package`/`sha256` filled. The job API is unchanged.

Out of scope:

- L1 dashboard edits
- L2 route / tracker changes
- L3 schema changes
- L5 kernel-arch verification
- Push to `registry.firecrab.dev` / R2

## Testing

- `cargo test -p firecrab-api microregistry` — 21 passed
- `cargo test -p firecrab-api package` — packer + install round-trip passed
- `cargo fmt --all -- --check`
- `python3 scripts/check-doc-links.py`

Related to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local image registration now creates downloadable `.tar.zst` packages containing image files and metadata.
  * Packages include a SHA-256 checksum for integrity verification.
* **Bug Fixes**
  * Registration rejects foreign-architecture or unsupported kernels without creating catalog entries or leftover archives.
  * Unclassifiable kernels remain accepted.
* **Documentation**
  * Updated API and image documentation to describe packaging, validation, and registration outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->