### PR TITLE
feat(api): refuse a foreign kernel before MicroRegistry pack

### DIFF
--- a/firecrab-api/src/handlers/microregistry.rs
+++ b/firecrab-api/src/handlers/microregistry.rs
@@ -400,6 +400,14 @@ async fn run_microregistry_register(
         tracker.finish_err_with(&alias, "register failed: template is not installed");
         return;
     };
+    // Unrecognized stays Ok because pre-#89/#94 artifacts cannot be classified.
+    if let Err(error) = crate::templates::verify_kernel_architecture(
+        templates.image_root(),
+        template.kernel.relative_path(),
+    ) {
+        tracker.finish_err_with(&alias, format!("register failed: {error}"));
+        return;
+    }
     tracker.append_log(&alias, "packing archive");
     let packed = match crate::package::pack_registered_template(
         &tracker,
@@ -415,6 +423,8 @@ async fn run_microregistry_register(
             return;
         }
     };
+    let published =
+        crate::package::StagedPackageGuard::after_publish(templates.image_root_path(), &alias);
     tracker.append_log(&alias, "updating catalog");
     let entry = LocalCatalogEntry {
         alias: alias.clone(),
@@ -429,6 +439,7 @@ async fn run_microregistry_register(
         tracker.finish_err_with(&alias, format!("register failed: {error}"));
         return;
     }
+    published.keep();
     tracker.finish_ok_with(&alias, "register succeeded — catalog updated");
 }
 
@@ -438,7 +449,7 @@ mod tests {
     use crate::extract::ValidatedJson;
     use crate::image_install::ImageInstallTracker;
     use crate::state::AppState;
-    use crate::templates::TemplateSpec;
+    use crate::templates::{TemplateError, TemplateSpec};
     use std::sync::{Arc, Mutex};
 
     use axum::Json;
@@ -471,6 +482,7 @@ mod tests {
         {
             std::fs::create_dir_all(root.join(parent)).unwrap();
         }
+        // Unrecognized placeholder; register must keep accepting it.
         std::fs::write(root.join("kernel/vmlinux"), b"kernel").unwrap();
         std::fs::write(root.join(rootfs), vec![0_u8; 64]).unwrap();
         state
@@ -523,6 +535,50 @@ mod tests {
             snapshot = state.microregistry_registers.snapshot(alias);
         }
         snapshot
+    }
+
+    fn elf_machine_fixture(machine: u16) -> Vec<u8> {
+        let mut header = vec![0_u8; 64];
+        header[..4].copy_from_slice(b"\x7fELF");
+        header[18..20].copy_from_slice(&machine.to_le_bytes());
+        header
+    }
+
+    fn kernel_fixture_for(architecture: Architecture) -> Vec<u8> {
+        match architecture {
+            Architecture::X86_64 => elf_machine_fixture(0x3e),
+            Architecture::Aarch64 => {
+                let mut header = vec![0_u8; 64];
+                header[..2].copy_from_slice(b"MZ");
+                header[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+                header
+            }
+        }
+    }
+
+    fn overwrite_kernel(state: &AppState, bytes: &[u8]) {
+        std::fs::write(
+            state.templates.image_root_path().join("kernel/vmlinux"),
+            bytes,
+        )
+        .unwrap();
+    }
+
+    fn assert_register_left_no_artifacts(state: &AppState, alias: &str) {
+        assert!(
+            local_aliases(state).is_empty(),
+            "refusal must not write a catalog row"
+        );
+        let image_root = state.templates.image_root_path();
+        assert!(!image_install::staged_package_exists(image_root, alias));
+        assert!(!crate::package::building_package_path(image_root, alias).exists());
+        assert!(image_install::staged_package_origin(image_root, alias).is_none());
+        assert!(
+            !image_root
+                .join(".packages")
+                .join(format!("{alias}.tar.zst.origin"))
+                .exists()
+        );
     }
 
     fn local_aliases(state: &AppState) -> Vec<String> {
@@ -704,6 +760,7 @@ mod tests {
 
         let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
         assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+        // b"kernel" is Unrecognized; this happy path must stay Succeeded.
         assert!(
             finished
                 .log
@@ -1098,6 +1155,141 @@ mod tests {
             "nginx-1.27"
         ));
         assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+    }
+
+    #[tokio::test]
+    async fn register_job_refuses_a_foreign_architecture_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        overwrite_kernel(&state, &kernel_fixture_for(Architecture::HOST.other()));
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("job starts");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Failed).await;
+        assert_eq!(finished.status, ImageInstallStatus::Failed);
+        let expected = TemplateError::KernelArchitectureMismatch {
+            path: std::path::PathBuf::from("kernel/vmlinux"),
+            found: Architecture::HOST.other(),
+            host: Architecture::HOST,
+        }
+        .to_string();
+        assert!(
+            finished.log.contains(&expected),
+            "failed job must carry KernelArchitectureMismatch Display: {}",
+            finished.log
+        );
+        assert_register_left_no_artifacts(&state, "nginx-1.27");
+    }
+
+    #[tokio::test]
+    async fn register_job_refuses_an_unsupported_architecture_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        overwrite_kernel(&state, &elf_machine_fixture(0xf3));
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("job starts");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Failed).await;
+        assert_eq!(finished.status, ImageInstallStatus::Failed);
+        let expected = TemplateError::UnsupportedKernelArchitecture {
+            path: std::path::PathBuf::from("kernel/vmlinux"),
+            machine: 0xf3,
+        }
+        .to_string();
+        assert!(
+            finished.log.contains(&expected),
+            "failed job must carry UnsupportedKernelArchitecture Display: {}",
+            finished.log
+        );
+        assert_register_left_no_artifacts(&state, "nginx-1.27");
+    }
+
+    #[tokio::test]
+    async fn register_job_accepts_an_unrecognized_kernel() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+
+        let _started = start_microregistry_register(
+            State(state.clone()),
+            Extension(request_id()),
+            register_body("nginx-1.27", "1"),
+        )
+        .await
+        .expect("unrecognized kernel must still start");
+        let finished = wait_for_status(&state, "nginx-1.27", ImageInstallStatus::Succeeded).await;
+        assert_eq!(finished.status, ImageInstallStatus::Succeeded);
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+        let image_root = state.templates.image_root_path();
+        assert!(image_install::staged_package_exists(
+            image_root,
+            "nginx-1.27"
+        ));
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+    }
+
+    #[tokio::test]
+    async fn register_job_discards_archive_when_catalog_insert_fails() {
+        let directory = tempdir().unwrap();
+        let state = empty_state(directory.path()).await;
+        install_custom(&state, "nginx-1.27");
+        state
+            .store
+            .insert_microregistry_local(&LocalCatalogEntry {
+                alias: "nginx-1.27".to_owned(),
+                architecture: Architecture::HOST.as_str().to_owned(),
+                version: "pre".to_owned(),
+                package: String::new(),
+                sha256: String::new(),
+                min_disk_gb: 1,
+                published_at: rfc3339_utc_now(),
+            })
+            .unwrap();
+
+        state
+            .microregistry_registers
+            .begin_with("nginx-1.27", "register started")
+            .unwrap();
+        run_microregistry_register(
+            state.microregistry_registers.clone(),
+            state.templates.clone(),
+            state.store.clone(),
+            "nginx-1.27".to_owned(),
+            "1".to_owned(),
+        )
+        .await;
+
+        assert_eq!(
+            state.microregistry_registers.snapshot("nginx-1.27").status,
+            ImageInstallStatus::Failed
+        );
+        assert_eq!(local_aliases(&state), ["nginx-1.27"]);
+        assert_eq!(local_row(&state, "nginx-1.27").version, "pre");
+        let image_root = state.templates.image_root_path();
+        assert!(!image_install::staged_package_exists(
+            image_root,
+            "nginx-1.27"
+        ));
+        assert!(!crate::package::building_package_path(image_root, "nginx-1.27").exists());
+        assert!(image_install::staged_package_origin(image_root, "nginx-1.27").is_none());
+        assert!(
+            !image_root
+                .join(".packages")
+                .join("nginx-1.27.tar.zst.origin")
+                .exists()
+        );
     }
 
     fn file_sha256(path: &std::path::Path) -> String {

--- a/firecrab-api/src/package.rs
+++ b/firecrab-api/src/package.rs
@@ -11,8 +11,8 @@ use std::path::{Path, PathBuf};
 use sha2::{Digest, Sha256};
 
 use crate::image_install::{
-    ImageInstallTracker, is_safe_archive_member, package_name, staged_package_path,
-    write_staged_package_origin,
+    ImageInstallTracker, clear_staged_package_origin, is_safe_archive_member, package_name,
+    staged_package_path, write_staged_package_origin,
 };
 use crate::templates::{TemplateRegistry, TemplateSpec, TemplateVersion};
 use firecrab_api_types::PackageOrigin;
@@ -36,6 +36,44 @@ pub fn building_package_path(image_root: &Path, alias: &str) -> PathBuf {
     image_root
         .join(".packages")
         .join(format!("{}.tar.zst.building", alias))
+}
+
+/// Delete a published `{alias}.tar.zst` and its `.origin` sidecar.
+///
+/// Used when pack has already published and a later catalog insert fails.
+pub(crate) fn discard_staged_package(image_root: &Path, alias: &str) {
+    let dest = staged_package_path(image_root, alias);
+    let _ = fs::remove_file(dest);
+    let _ = clear_staged_package_origin(image_root, alias);
+}
+
+/// Discards a published archive unless [`Self::keep`] is called after insert.
+pub(crate) struct StagedPackageGuard {
+    image_root: PathBuf,
+    alias: String,
+    keep: bool,
+}
+
+impl StagedPackageGuard {
+    pub(crate) fn after_publish(image_root: &Path, alias: &str) -> Self {
+        Self {
+            image_root: image_root.to_path_buf(),
+            alias: alias.to_owned(),
+            keep: false,
+        }
+    }
+
+    pub(crate) fn keep(mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for StagedPackageGuard {
+    fn drop(&mut self) {
+        if !self.keep {
+            discard_staged_package(&self.image_root, &self.alias);
+        }
+    }
 }
 
 /// Pack the installed template for `alias` using the register request's version.

--- a/firecrab-api/src/templates.rs
+++ b/firecrab-api/src/templates.rs
@@ -396,6 +396,11 @@ impl TemplateRegistry {
         &self.image_root_path
     }
 
+    /// Pinned image-root directory fd for `openat2` checks.
+    pub(crate) fn image_root(&self) -> &File {
+        self.image_root.as_ref()
+    }
+
     /// Built-in template specs the project knows about (installed or not).
     pub fn known_specs() -> Vec<TemplateSpec> {
         default_specs()
@@ -898,7 +903,7 @@ pub(crate) fn kernel_architecture(header: &[u8]) -> KernelFormat {
 /// Rejects a kernel this host cannot boot. Firecracker's own failure mode
 /// there is a silent hang with no console output, so the cost of letting one
 /// through is an unbootable VM with nothing to diagnose.
-fn verify_kernel_architecture(root: &File, path: &Path) -> Result<(), TemplateError> {
+pub(crate) fn verify_kernel_architecture(root: &File, path: &Path) -> Result<(), TemplateError> {
     let mut file = open_beneath(root, path)?;
     let mut header = Vec::new();
     // A kernel shorter than one header is simply unclassifiable, so read

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -107,6 +107,8 @@ An unknown, uninstalled, or internal alias is `404`.
 A catalog alias or a second register of the same local alias is `409 alias_collision`.
 A running job for that alias is `409 register_in_progress`.
 Local rows carry `{alias}.tar.zst` and its SHA-256 after a successful pack.
+A foreign-architecture or unsupported ELF kernel fails the job: no catalog row and no staged archive.
+An unclassifiable kernel is still accepted.
 
 ## VM states
 

--- a/public-docs/images.md
+++ b/public-docs/images.md
@@ -151,7 +151,7 @@ Restart the API after replacing files outside the API workflow.
 ## Register
 
 A locally installed custom alias can join this host's SQLite catalog via `POST /api/microregistry/register`.
-Success packs `{alias}.tar.zst` (`kernel/…`, `rootfs/…`, optional initrd, `kernel/.firecrab-template.json`).
+Success packs `{alias}.tar.zst` (`kernel/…`, `rootfs/…`, optional initrd, `kernel/.firecrab-template.json`). A foreign or unsupported kernel fails the job with no row or archive; an unclassifiable kernel is still accepted.
 Poll `GET /api/microregistry/register/{alias}`; a success survives restart. A catalog outage still lists local rows (`source` is the attempted URL, or empty if unset); with none, GET stays 503.
 
 ## Add an alias


### PR DESCRIPTION
## Summary

A MicroRegistry register job now runs the existing registration-time kernel architecture check (**#89 / #94**) after the template is resolved and **before** pack or catalog insert. A foreign or unsupported ELF fails the job and leaves nothing behind. An unclassifiable kernel is still accepted.

This is **#108 L5 only**. It does not change the L2 job routes, the L3 table, or the L4 archive shape.

Stacked on #115 (L4). Merge L4 first.

## Motivation

- #89 / #94 already reject a foreign kernel when a template is registered. The same check must apply when publishing into MicroRegistry.
- A failed register must not leave a catalog row or a partial `{alias}.tar.zst`.
- Pre-#89 artifacts cannot be classified (`Unrecognized`). Those stay accepted, same as template registration.

## Position

```text
#108 MicroRegistry register
├─ L1 Dashboard     have  (#109)
├─ L2 API           have  (#113)
├─ L3 Catalog       have  (#114)
├─ L4 Package       #115  (base of this PR)
└─ L5 Verify        this  kernel arch before pack/insert
```

## What landed

- `run_microregistry_register` calls `templates::verify_kernel_architecture` after `resolve_alias` and before `pack_registered_template`.
- Failure uses `finish_err_with` and the `TemplateError` display text. No SQLite row, no staged archive, no `.building` file, no origin sidecar.
- `HOST.other()` and ELF machine `0xf3` are refused. `Unrecognized` (e.g. the test `b"kernel"` placeholder) stays `Succeeded`.
- Visibility of the existing verifier is widened only as needed. No new check, no R2, no frontend.

## Acceptance

- Registering an installed image whose kernel is another architecture fails the job. `GET /api/microregistry` has no new row. `.packages/{alias}.tar.zst` and `.building` do not exist.
- An unsupported ELF machine fails the same way.
- An unclassifiable kernel still registers and packs.
- A successful path is unchanged: pack, then insert the L3 row.

Out of scope:

- L1 dashboard edits
- L2 route / tracker changes
- L3 schema changes
- L4 archive member changes
- Push to `registry.firecrab.dev` / R2

## Testing

- `cargo test -p firecrab-api register_job_refuses` — foreign, unsupported, and unsafe-rootfs cases passed
- `cargo fmt --all -- --check`
- `python3 scripts/check-doc-links.py`

Related to #108.