### PR TITLE
test(e2e): register an installed image from the MicroRegistry panel

### DIFF
--- a/firecrab-e2e/README.md
+++ b/firecrab-e2e/README.md
@@ -1,6 +1,6 @@
-# OCI import browser E2E
+# Browser E2E
 
-Isolated Playwright suite for [issue #90](https://github.com/SteelCrab/firecrab/issues/90).
+Isolated Playwright suite for [issue #90](https://github.com/SteelCrab/firecrab/issues/90) (OCI import) and [issue #108](https://github.com/SteelCrab/firecrab/issues/108) (MicroRegistry register).
 It drives the dashboard against a **local** OCI registry fixture.
 Nothing is pulled from Docker Hub.
 
@@ -44,6 +44,15 @@ Full path (KVM, `firecracker` on `PATH`, and a live net helper):
 ./scripts/dev-net-helper.sh    # other terminal; socket /run/firecrab/net-helper.sock
 npm test --prefix firecrab-e2e
 ```
+
+MicroRegistry register ([#108](https://github.com/SteelCrab/firecrab/issues/108)), skip guest boot:
+
+```sh
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:register --prefix firecrab-e2e
+```
+
+Expect **2 passed, 2 skipped** (import + register/409; failed-job and reinstall/boot are product-gated).
+A leftover `127.0.0.1-15556-firecrab-e2e-ready` catalog row fails `beforeAll` until L3 grows a DELETE.
 
 Playwright starts `firecrab-api` on `:3000` and Vite on `:8080` unless those
 ports already answer.

--- a/firecrab-e2e/package.json
+++ b/firecrab-e2e/package.json
@@ -3,10 +3,11 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Isolated browser E2E for issue #90 (OCI inspect → import → boot). Playwright is test-only.",
+  "description": "Isolated browser E2E for issue #90 (OCI import) and #108 (MicroRegistry register). Playwright is test-only.",
   "scripts": {
     "test": "playwright test",
     "test:import": "FIRECRAB_E2E_SKIP_GUEST_BOOT=1 playwright test",
+    "test:register": "playwright test tests/microregistry-register.spec.ts",
     "test:headed": "playwright test --headed",
     "install-browsers": "playwright install chromium"
   },

--- a/firecrab-e2e/src/api.ts
+++ b/firecrab-e2e/src/api.ts
@@ -17,6 +17,25 @@ interface NetworkRow {
   name: string;
 }
 
+interface CatalogImageRow {
+  alias: string;
+  version: string;
+}
+
+export interface CatalogEntry {
+  alias: string;
+  version: string;
+  downloadable: boolean;
+  installed: boolean;
+  packageStaged: boolean;
+}
+
+export interface RegisterSnapshot {
+  alias: string;
+  status: string;
+  log: string;
+}
+
 export class ApiCleanup {
   constructor(private readonly base = apiUrl()) {}
 
@@ -60,6 +79,89 @@ export class ApiCleanup {
     return json as NetworkRow[];
   }
 
+  async listMicroregistry(): Promise<CatalogImageRow[]> {
+    const { status, json } = await this.request("GET", "/api/microregistry");
+    if (status >= 400 || !json || typeof json !== "object") return [];
+    const images = (json as { images?: unknown }).images;
+    if (!Array.isArray(images)) return [];
+    const rows: CatalogImageRow[] = [];
+    for (const image of images) {
+      if (!image || typeof image !== "object") continue;
+      const row = image as { alias?: unknown; version?: unknown };
+      if (typeof row.alias !== "string" || typeof row.version !== "string") continue;
+      rows.push({ alias: row.alias, version: row.version });
+    }
+    return rows;
+  }
+
+  async catalogEntry(alias: string): Promise<CatalogEntry | null> {
+    const { status, json } = await this.request("GET", "/api/microregistry");
+    if (status >= 400 || !json || typeof json !== "object") return null;
+    const images = (json as { images?: unknown }).images;
+    if (!Array.isArray(images)) return null;
+    for (const image of images) {
+      if (!image || typeof image !== "object") continue;
+      const row = image as {
+        alias?: unknown;
+        version?: unknown;
+        downloadable?: unknown;
+        installed?: unknown;
+        packageStaged?: unknown;
+      };
+      if (row.alias !== alias || typeof row.version !== "string") continue;
+      return {
+        alias,
+        version: row.version,
+        downloadable: row.downloadable === true,
+        installed: row.installed === true,
+        packageStaged: row.packageStaged === true,
+      };
+    }
+    return null;
+  }
+
+  async startRegister(
+    alias: string,
+    version: string,
+  ): Promise<{ status: number; json: unknown }> {
+    return this.request("POST", "/api/microregistry/register", { alias, version });
+  }
+
+  async getRegister(alias: string): Promise<RegisterSnapshot | null> {
+    const { status, json } = await this.request(
+      "GET",
+      `/api/microregistry/register/${encodeURIComponent(alias)}`,
+    );
+    if (status >= 400 || !json || typeof json !== "object") return null;
+    const body = json as { alias?: unknown; status?: unknown; log?: unknown };
+    if (typeof body.alias !== "string" || typeof body.status !== "string") return null;
+    return {
+      alias: body.alias,
+      status: body.status,
+      log: typeof body.log === "string" ? body.log : "",
+    };
+  }
+
+  async deleteStagedPackage(alias: string): Promise<void> {
+    await this.request("DELETE", `/api/images/${encodeURIComponent(alias)}/package`);
+  }
+
+  /**
+   * Best-effort local catalog delete. L3 is insert-only today, so this
+   * 404s until that layer grows a DELETE.
+   */
+  async deleteLocalCatalogRow(alias: string): Promise<boolean> {
+    const encoded = encodeURIComponent(alias);
+    for (const pathname of [
+      `/api/microregistry/${encoded}`,
+      `/api/microregistry/local/${encoded}`,
+    ]) {
+      const { status } = await this.request("DELETE", pathname);
+      if (status === 200 || status === 204) return true;
+    }
+    return false;
+  }
+
   async stopVm(id: string): Promise<void> {
     await this.request("POST", `/api/vms/${id}/stop`);
   }
@@ -90,9 +192,9 @@ export class ApiCleanup {
   }
 
   /** Stop + delete every VM this suite owns (by name or imported template). */
-  async deleteOwnedVms(alias: string): Promise<void> {
+  async deleteOwnedVms(alias: string, vmName = VM_NAME): Promise<void> {
     const vms = await this.listVms();
-    const owned = vms.filter((vm) => vm.name === VM_NAME || vm.template === alias);
+    const owned = vms.filter((vm) => vm.name === vmName || vm.template === alias);
     for (const vm of owned) {
       if (vm.state === "running" || vm.state === "starting" || vm.state === "stopping") {
         await this.stopVm(vm.id);
@@ -109,11 +211,14 @@ export class ApiCleanup {
     await this.deleteImage(alias);
   }
 
-  async deleteOwnedNetwork(createdNetworkId: string | null): Promise<void> {
+  async deleteOwnedNetwork(
+    createdNetworkId: string | null,
+    networkName = NETWORK_NAME,
+  ): Promise<void> {
     if (!createdNetworkId) return;
     const networks = await this.listNetworks();
     const row = networks.find((network) => network.id === createdNetworkId);
-    if (!row || row.name !== NETWORK_NAME) return;
+    if (!row || row.name !== networkName) return;
     await this.deleteNetwork(createdNetworkId);
   }
 }

--- a/firecrab-e2e/src/constants.ts
+++ b/firecrab-e2e/src/constants.ts
@@ -33,6 +33,30 @@ export const NETWORK_NAME = "oci-e2e";
 /** Isolated subnet so this suite does not share a developer's default net. */
 export const NETWORK_CIDR = "172.30.90.0/24";
 
+/** Loopback port for the #108 register spec's OCI fixture. Distinct from {@link REGISTRY_PORT}. */
+export const REGISTER_REGISTRY_PORT = Number.parseInt(
+  process.env.FIRECRAB_OCI_REGISTER_E2E_PORT ?? "15556",
+  10,
+);
+
+/** Deterministic reference when the register fixture binds {@link REGISTER_REGISTRY_PORT}. */
+export const REGISTER_FIXED_REFERENCE = `127.0.0.1:${REGISTER_REGISTRY_PORT}/firecrab/e2e:ready`;
+
+/** Alias `POST /api/oci/import` claims for {@link REGISTER_FIXED_REFERENCE}. */
+export const REGISTER_FIXED_ALIAS = `127.0.0.1-${REGISTER_REGISTRY_PORT}-firecrab-e2e-ready`;
+
+/** Catalog version typed into the MicroRegistry register form. */
+export const REGISTER_VERSION = "1";
+
+/** VM created by the guest-boot half of the register suite. */
+export const REGISTER_VM_NAME = "register-e2e-ready";
+
+/** Dedicated MicroNetwork for the register guest-boot half. */
+export const REGISTER_NETWORK_NAME = "register-e2e";
+
+/** Isolated subnet so the register spec does not share {@link NETWORK_CIDR}. */
+export const REGISTER_NETWORK_CIDR = "172.30.91.0/24";
+
 export const DEFAULT_API_URL = "http://127.0.0.1:3000";
 export const DEFAULT_BASE_URL = "http://localhost:8080";
 

--- a/firecrab-e2e/tests/microregistry-register.spec.ts
+++ b/firecrab-e2e/tests/microregistry-register.spec.ts
@@ -1,0 +1,301 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { ApiCleanup } from "../src/api.js";
+import {
+  NETWORK_READY,
+  REGISTER_FIXED_ALIAS,
+  REGISTER_FIXED_REFERENCE,
+  REGISTER_NETWORK_CIDR,
+  REGISTER_NETWORK_NAME,
+  REGISTER_REGISTRY_PORT,
+  REGISTER_VM_NAME,
+  REGISTER_VERSION,
+  SKIP_GUEST_BOOT,
+} from "../src/constants.js";
+import { startLocalOciRegistry, type LocalOciRegistry } from "../src/registry.js";
+
+/**
+ * Issue #108 browser E2E — register an already-installed image.
+ *
+ *   FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:register --prefix firecrab-e2e
+ *   npm run test:register --prefix firecrab-e2e
+ *
+ * The registry fixture is spawned here (python3 scripts/oci-e2e-registry.py,
+ * FIRECRAB_OCI_REGISTER_E2E_PORT=15556). Cleanup always stops it and deletes
+ * any VM, imported template, staged package, or catalog row this file created.
+ *
+ * Product blockers (not faked; neighbouring assertions stay intact):
+ *   - Failed-job / no-catalog-row: no dashboard or HTTP trigger for an L5
+ *     kernel miss. The test exists and is skipped, not asserted as a pass.
+ *   - Delete-template then Download/Install from the local row: consume is
+ *     known_spec-only, so a custom OCI alias cannot be reinstalled. The
+ *     boot test drives that path and fails loudly when the row is not
+ *     downloadable — it does not boot the original import instead.
+ *   - Guest boot from that reinstalled image: gated by
+ *     FIRECRAB_E2E_SKIP_GUEST_BOOT; never weakened to a no-boot pass.
+ *   - L3 has no DELETE for microregistry_local; leftover rows poison a rerun.
+ */
+test.describe.configure({ mode: "serial" });
+
+let registry: LocalOciRegistry;
+let createdNetworkId: string | null = null;
+const api = new ApiCleanup();
+
+function reference(): string {
+  return registry.announcement.reference;
+}
+
+function alias(): string {
+  return registry.announcement.alias;
+}
+
+function sentinel(): string {
+  return registry.announcement.ready;
+}
+
+async function openEnglish(page: Page, hash: string): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem("firecrab.locale", "en");
+  });
+  await page.goto(hash);
+}
+
+function conflictCode(json: unknown): string | undefined {
+  if (!json || typeof json !== "object") return undefined;
+  const error = (json as { error?: { code?: unknown } }).error;
+  return error && typeof error.code === "string" ? error.code : undefined;
+}
+
+async function cleanupOwned(): Promise<void> {
+  const imported = registry?.announcement.alias ?? REGISTER_FIXED_ALIAS;
+  await api.deleteOwnedVms(imported, REGISTER_VM_NAME);
+  await api.deleteStagedPackage(imported);
+  await api.deleteImportedImage(imported);
+  await api.deleteStagedPackage(imported);
+  await api.deleteLocalCatalogRow(imported);
+  await api.deleteOwnedNetwork(createdNetworkId, REGISTER_NETWORK_NAME);
+  createdNetworkId = null;
+}
+
+test.beforeAll(async () => {
+  registry = await startLocalOciRegistry(REGISTER_REGISTRY_PORT);
+  expect(registry.announcement.reference).toBe(REGISTER_FIXED_REFERENCE);
+  expect(registry.announcement.alias).toBe(REGISTER_FIXED_ALIAS);
+  await cleanupOwned();
+  const leftover = (await api.listMicroregistry()).some((row) => row.alias === alias());
+  if (leftover) {
+    throw new Error(
+      `local catalog still has ${alias()} after cleanup. L3 microregistry_local is insert-only; a leftover row poisons the next register. Owning layer: L3.`,
+    );
+  }
+});
+
+test.afterAll(async () => {
+  try {
+    await cleanupOwned();
+  } finally {
+    await registry?.stop();
+  }
+});
+
+test("inspects the local fixture and imports it as an installed image", async ({ page }) => {
+  await openEnglish(page, "/#/images");
+  await expect(page.locator("#oci-reference")).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeDisabled();
+
+  await page.locator("#oci-reference").fill(reference());
+  await page.locator("#oci-inspect").click();
+
+  const oci = page.locator("section.panel", { has: page.getByRole("heading", { name: "OCI" }) });
+  await expect(oci.getByText("Compatible with this host.")).toBeVisible({ timeout: 30_000 });
+  await expect(oci.locator("dd", { hasText: alias() }).first()).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeEnabled();
+
+  await page.locator("#oci-import").click();
+  const status = oci.locator(".state-badge");
+  await expect(status).toHaveText(/Imported|Import failed/, { timeout: 180_000 });
+  if ((await status.textContent())?.includes("failed")) {
+    const log = (await oci.locator(".image-install-log").textContent()) ?? "";
+    throw new Error(`OCI import failed for ${reference()}:\n${log}`);
+  }
+
+  await expect(oci.getByText("Registered image")).toBeVisible();
+  await expect(page.locator("table.image-table")).toContainText(alias());
+});
+
+test("registers the installed image and refuses a second register with 409", async ({ page }) => {
+  await openEnglish(page, "/#/images");
+  const select = page.locator("#microregistry-register-alias");
+  await expect(select).toBeEnabled({ timeout: 15_000 });
+  await expect(page.locator(`#microregistry-register-alias option[value="${alias()}"]`)).toHaveCount(
+    1,
+    { timeout: 15_000 },
+  );
+
+  await select.selectOption(alias());
+  await page.locator("#microregistry-register-version").fill(REGISTER_VERSION);
+  const submit = page.locator("#microregistry-register-submit");
+  await expect(submit).toBeEnabled();
+
+  const posted = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return response.request().method() === "POST" && url.pathname === "/api/microregistry/register";
+  });
+  await submit.click();
+  const accepted = await posted;
+  if (accepted.status() === 409) {
+    throw new Error(
+      `register 409 for ${alias()} on the first submit — leftover local catalog row (L3 has no DELETE)`,
+    );
+  }
+  expect(accepted.status()).toBe(202);
+
+  // L1 still polls GET /api/microregistry/jobs/{jobId}; L2 serves
+  // GET /api/microregistry/register/{alias} and the 202 body has no jobId.
+  // Wait on the L2 snapshot so a broken handoff fails here, not in the badge.
+  await expect
+    .poll(async () => (await api.getRegister(alias()))?.status ?? "", { timeout: 180_000 })
+    .toMatch(/^(succeeded|failed)$/);
+  const finished = await api.getRegister(alias());
+  if (finished?.status === "failed") {
+    throw new Error(`register failed for ${alias()}:\n${finished.log}`);
+  }
+  expect(finished?.status).toBe("succeeded");
+
+  await page.locator("button.microregistry-refresh").click();
+  const table = page.locator("table.microregistry-table");
+  const rows = table.locator("tbody tr", { hasText: alias() });
+  await expect(rows).toHaveCount(1);
+  await expect(rows).toContainText(REGISTER_VERSION);
+
+  const listed = (await api.listMicroregistry()).filter((row) => row.alias === alias());
+  expect(listed).toEqual([{ alias: alias(), version: REGISTER_VERSION }]);
+
+  // Form stays disabled after Register (L1/L2 poll mismatch). The 409 is the
+  // L2/L3 contract, so the second POST goes through the API helper.
+  const second = await api.startRegister(alias(), REGISTER_VERSION);
+  expect(second.status).toBe(409);
+  expect(conflictCode(second.json)).toBe("alias_collision");
+  expect((await api.listMicroregistry()).filter((row) => row.alias === alias())).toHaveLength(1);
+  await page.locator("button.microregistry-refresh").click();
+  await expect(rows).toHaveCount(1);
+});
+
+test("a failed register job leaves no current catalog row", async () => {
+  // Not gated by FIRECRAB_E2E_SKIP_GUEST_BOOT — that flag only skips guest boot.
+  // When L1 exposes a real failure trigger (L5 kernel miss on an installed
+  // image), drive it here, wait for GET /api/microregistry/register/{alias}
+  // to be failed, and assert GET /api/microregistry has no current row for
+  // that alias. Do not mock, overwrite kernel bytes, or use alpine known_spec.
+  test.skip(
+    true,
+    "L5+L1 product blocker: no dashboard or HTTP trigger for a failed register job. POST /api/microregistry/register 404s for an uninstalled alias (no job); this tree's job only inserts a catalog row and has no kernel-miss path. Not mocked.",
+  );
+});
+
+test("deletes the template, reinstalls from the local row, and boots to FIRECRAB_NETWORK_READY", async ({
+  page,
+}) => {
+  test.skip(
+    SKIP_GUEST_BOOT,
+    "FIRECRAB_E2E_SKIP_GUEST_BOOT is set — register, local row, and 409 already ran. Unset the flag (and provide KVM + firecracker + ./scripts/dev-net-helper.sh) for delete → reinstall → guest-boot.",
+  );
+
+  await openEnglish(page, "/#/images");
+  const imageRow = page.locator("table.image-table tbody tr", { hasText: alias() });
+  await expect(imageRow).toBeVisible();
+  await imageRow.locator("button.options-menu-trigger").click();
+  await imageRow.getByRole("button", { name: "Delete" }).click();
+  await expect(imageRow).toHaveCount(0, { timeout: 15_000 });
+  await expect
+    .poll(async () => (await api.listImages()).some((image) => image.alias === alias() && image.installed))
+    .toBe(false);
+
+  await page.locator("button.microregistry-refresh").click();
+  const catalogRow = page.locator("table.microregistry-table tbody tr", { hasText: alias() });
+  await expect(catalogRow).toHaveCount(1);
+  await expect(catalogRow).toContainText(REGISTER_VERSION);
+
+  const entry = await api.catalogEntry(alias());
+  const action = catalogRow.getByRole("button", { name: /^(Download|Install)$/ });
+  await expect(action).toBeVisible();
+  if (!entry?.downloadable || (await action.isDisabled())) {
+    throw new Error(
+      `cannot reinstall ${alias()} from the local catalog row after template delete (downloadable=${String(entry?.downloadable)}, packageStaged=${String(entry?.packageStaged)}). consume is known_spec-only and this tree's register writes an empty package/sha256. Owning layer: consume / L4. Not replaced by booting the original import.`,
+    );
+  }
+
+  await action.click();
+  await expect(catalogRow.locator(".state-badge")).toHaveText(/Installed|Download failed|Unsupported/, {
+    timeout: 180_000,
+  });
+  const badge = (await catalogRow.locator(".state-badge").textContent()) ?? "";
+  if (!/Installed/.test(badge)) {
+    const banner = (await page.locator(".field-error").allTextContents()).join("; ");
+    throw new Error(
+      `reinstall from the local row did not install ${alias()}: status=${badge.trim()} ${banner}`,
+    );
+  }
+  await expect
+    .poll(async () => (await api.listImages()).some((image) => image.alias === alias() && image.installed), {
+      timeout: 30_000,
+    })
+    .toBe(true);
+
+  await openEnglish(page, "/#/networks");
+  const networkPanel = page.locator("section.panel", {
+    has: page.getByRole("heading", { name: "MicroNetwork" }),
+  });
+  const networkRows = networkPanel.locator("table.vm-table tbody tr");
+  if ((await networkRows.count()) === 0) {
+    await page.locator("#mn-name").fill(REGISTER_NETWORK_NAME);
+    await page.locator("#mn-subnet").fill(REGISTER_NETWORK_CIDR);
+    await networkPanel.locator('button[type="submit"]').click();
+    const created = networkRows.filter({ hasText: REGISTER_NETWORK_NAME });
+    const fieldError = networkPanel.locator(".field-error").filter({ hasText: /\S/ });
+    await expect(created.or(fieldError).first()).toBeVisible({ timeout: 30_000 });
+    if ((await created.count()) === 0) {
+      throw new Error(
+        `failed to create MicroNetwork ${REGISTER_NETWORK_NAME}: ${(await fieldError.allTextContents()).join("; ")}`,
+      );
+    }
+    const networks = await api.listNetworks();
+    createdNetworkId = networks.find((network) => network.name === REGISTER_NETWORK_NAME)?.id ?? null;
+  }
+
+  await openEnglish(page, "/#/vms");
+  await expect(page.locator("#vm-image")).toBeEnabled({ timeout: 15_000 });
+  await expect(page.locator(`#vm-image option[value="${alias()}"]`)).toHaveCount(1, {
+    timeout: 15_000,
+  });
+  await page.locator("#vm-name").fill(REGISTER_VM_NAME);
+  await page.locator("#vm-image").selectOption(alias());
+  await expect(page.locator("#vm-micro-network")).not.toHaveValue("");
+  await page.locator("#vm-create-submit").click();
+  await expect(page.getByText(`Created: ${REGISTER_VM_NAME}`)).toBeVisible({ timeout: 30_000 });
+
+  const row = page.locator("table.vm-table tbody tr", { hasText: REGISTER_VM_NAME });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: "start" }).click();
+  await expect(row.locator(".state-badge")).toHaveText(/running|error/, { timeout: 240_000 });
+  if ((await row.locator(".state-badge").textContent()) !== "running") {
+    await row.locator("button.link-button").click();
+    await expect(page.locator(".console-title")).toBeVisible();
+    await expect
+      .poll(async () => (await page.locator("pre.detail-log").textContent())?.trim() ?? "", {
+        timeout: 10_000,
+      })
+      .not.toBe("");
+    const logText = (await page.locator("pre.detail-log").textContent()) ?? "";
+    const banner = (await page.locator(".banner").textContent().catch(() => "")) ?? "";
+    const steps = (await page.locator(".pipeline-step").allTextContents()).join("\n");
+    throw new Error(
+      `VM ${REGISTER_VM_NAME} entered error instead of running.\nbanner: ${banner}\nsteps:\n${steps}\nlog:\n${logText}`,
+    );
+  }
+
+  await row.locator("button.link-button").click();
+  const log = page.locator("pre.detail-log");
+  await expect(log).toContainText(NETWORK_READY, { timeout: 30_000 });
+  await expect(log).toContainText(sentinel(), { timeout: 60_000 });
+});


### PR DESCRIPTION
## Summary

One Playwright spec proves the #108 register layers compose in the browser: import a local OCI fixture, Register it from the MicroRegistry panel, see the local row, and refuse a second register with **409**.

This is **#108 E2E only**. It does not change `firecrab-api`, `firecrab-api-types`, or `firecrab-frontend`. Product gaps are reported as skips or loud failures, not patched around.

## Motivation

L2–L5 can each pass unit tests while the handoff between them is broken. This is the slice that catches that: one unattended round trip against the existing `firecrab-e2e` harness.

## What landed

- `firecrab-e2e/tests/microregistry-register.spec.ts` beside the OCI import spec.
- Distinct constants (`REGISTER_*`, port **15556**, CIDR `172.30.91.0/24`) so it cannot collide with the import suite.
- `ApiCleanup` helpers: list/register/poll catalog, best-effort local-row DELETE (404 until L3 grows one).
- `npm run test:register`. `FIRECRAB_E2E_SKIP_GUEST_BOOT` gates only the guest-boot half; `test:register` does not hardcode the flag.

## Acceptance (this PR)

With `FIRECRAB_E2E_SKIP_GUEST_BOOT=1` and a current API on `:3000`:

- Import `127.0.0.1:15556/firecrab/e2e:ready` from Images.
- Register that alias + version `1` from the MicroRegistry panel → 202, then `GET /api/microregistry/register/{alias}` is `succeeded`.
- The catalog table shows the row. A second POST is **409** `alias_collision`.
- Failed-job / no-catalog-row is **skipped** (no dashboard trigger for an L5 kernel miss).
- Delete → Download/Install → `FIRECRAB_NETWORK_READY` is **skipped** when the flag is set. Unset the flag to run it; it fails loudly if the row is not downloadable (consume is still `known_spec`-only).

## Product blockers (not faked)

- **L1/L2 poll mismatch.** Dashboard polls `GET /api/microregistry/jobs/{jobId}`; API serves `GET /api/microregistry/register/{alias}` and the 202 body has no `jobId`. The spec waits on the L2 snapshot and sends the 409 POST via the API helper because the form stays disabled.
- **L3 insert-only.** No DELETE for `microregistry_local`. `beforeAll` fails if `127.0.0.1-15556-firecrab-e2e-ready` is leftover.
- **Consume.** `POST /api/images/{alias}/package` and `/install` 404 for a custom OCI alias, so delete-then-reinstall cannot succeed yet.
- **Failed job.** No dashboard/HTTP way to induce an L5 kernel miss on an installed image.

## Out of scope

- Fixing L1 poll path, L3 DELETE, consume of custom aliases, or L5 dashboard trigger
- A second Playwright harness or a parallel cleanup module
- Pulling from Docker Hub / `registry.firecrab.dev`

## Testing

- Workflow fixer: `FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:register --prefix firecrab-e2e` → **2 passed, 2 skipped**
- Korean maintainer note: `docs/40-tests/microregistry-register-e2e.md` (gitignored)

Related to #108.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for registering installed OCI images from a local registry.
  * Added validation for registration progress, catalog updates, duplicate-registration errors, and optional guest boot workflows.

* **Documentation**
  * Updated E2E documentation and commands to cover MicroRegistry registration, including known skipped scenarios and cleanup limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->