### PR TITLE
chore: bump the pinned Rust toolchain to 1.96.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
             cargo-${{ runner.os }}-
 
       - name: Install pinned toolchain
-        # rust-toolchain.toml pins channel 1.94.1 + clippy/rustfmt/llvm-tools
+        # rust-toolchain.toml pins channel 1.96.0 + clippy/rustfmt/llvm-tools
         run: rustup show
 
       - name: Install dnsmasq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Keep host privileges small: the API stays unprivileged; only `firecrab-net-helpe
 ## Prerequisites
 
 - **Linux** with `/dev/kvm` (needed to boot guests; unit tests mostly do not need it)
-- **Rust** matching [`rust-toolchain.toml`](rust-toolchain.toml) (currently 1.94.1 with `clippy`, `rustfmt`, `llvm-tools`)
+- **Rust** matching [`rust-toolchain.toml`](rust-toolchain.toml) (currently 1.96.0 with `clippy`, `rustfmt`, `llvm-tools`)
 - **Node.js 22+** and npm (dashboard)
 - Common host tools for full local runs: `ip`, `nft`, `dnsmasq`, `mkfs.ext4`, Firecracker (or use `./install.sh`)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94.1"
+rust-version = "1.96.0"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust&logoColor=white"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.96%2B-orange?logo=rust&logoColor=white"></a>
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust&logoColor=white"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.96%2B-orange?logo=rust&logoColor=white"></a>
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust&logoColor=white"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.96%2B-orange?logo=rust&logoColor=white"></a>
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.94%2B-orange?logo=rust&logoColor=white"></a>
+  <a href="https://www.rust-lang.org"><img alt="Rust" src="https://img.shields.io/badge/rust-1.96%2B-orange?logo=rust&logoColor=white"></a>
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.96.0"
 profile = "minimal"
 components = ["clippy", "rustfmt", "llvm-tools"]
 


### PR DESCRIPTION
## Summary

Pin the workspace to Rust **1.96.0** (was 1.94.1). rust-toolchain.toml, `package.rust-version`, CI comment, CONTRIBUTING, and README badges stay in lockstep.

## Testing

- `rustc 1.96.0 (ac68faa20 2026-05-25)`
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets` — passed (existing warnings only; CI does not deny them)
- `cargo test --workspace --offline --locked` — 621 passed, 1 flaky timeout on `starting_a_vm_templated_as_microboot_skips_the_network_ready_wait` under full parallel load; isolated rerun passed

A follow-up to **1.97.1** is filed as a good first issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Rust toolchain to version 1.96.0.
  * Updated continuous integration settings to use Rust 1.96.0.

* **Documentation**
  * Updated contributor guidance and multilingual README badges to reflect the Rust 1.96+ requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->