### PR TITLE
docs: add the 0.1.0 changelog and release notes check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,13 @@ jobs:
         # pipeline notices when a file moves out from under them.
         run: python3 scripts/check-doc-links.py
 
+      - name: Changelog
+        # First public release notes and the section contract used by
+        # release.yml when a v* tag publishes GitHub Release notes.
+        run: |
+          python3 -m unittest scripts/test_check_changelog.py
+          python3 scripts/check-changelog.py
+
       - name: Cache cargo
         uses: actions/cache@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,13 +89,19 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v7
+
       - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
           path: artifacts
 
+      - name: Release notes from CHANGELOG
+        run: python3 scripts/check-changelog.py --extract "${GITHUB_REF_NAME}" > release-notes.md
+
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
           files: artifacts/**/*.tar.gz
-          generate_release_notes: true
+          body_path: release-notes.md
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,72 @@
+# Changelog
+
+All notable changes to firecrab are documented in this file.
+
+The format uses the sections **Added**, **Changed**, **Deprecated**, **Fixed**,
+and **Improved**. Version headings match the Cargo workspace version.
+
+## [0.1.0] - 2026-08-16
+
+First public release of firecrab: a single-host Firecracker microVM manager
+with an unprivileged API, a browser dashboard, and a capability-bounded
+network helper.
+
+### Added
+
+- REST API and systemd-installable `firecrab-api` for creating, inspecting,
+  editing stopped guests, starting, stopping, and deleting MicroVMs.
+- Browser dashboard (English and Korean) with VM list, create flow, detail
+  editing, serial console, logs, and host status.
+- Browser serial console, including CJK IME composition.
+- `firecrab-net-helper` over a versioned Unix-socket protocol so only the
+  helper holds host network capabilities.
+- Explicit MicroNetworks: isolated bridges, persistent IPv4, MAC, and
+  hostname per VM, internet or isolated egress, and optional NAT uplink.
+- MicroStorage pools plus the default host disk layout for VM artifacts.
+- M2Image catalog install for Alpine, Ubuntu, and Rocky templates, each
+  with that distro's own official kernel.
+- OCI inspect and import: pull a registry image, merge layers, and register
+  a bootable ext4 rootfs.
+- MicroRegistry register of an already-installed local image into the
+  in-memory catalog.
+- Runtime environment variables on stopped VMs, written into the guest
+  service wrapper on the next start.
+- Host and guest port forwards on the API and dashboard.
+- `install.sh` host installer and `firecrab-doctor` health checks.
+- Release-profile and cross-target GitHub Actions builds for
+  `x86_64`/`aarch64` GNU and musl.
+
+### Changed
+
+- Workspace version is `0.1.0` across the Rust crates.
+- Dashboard package version is `0.1.0`.
+- The pinned Rust toolchain is 1.96.0 (`rust-toolchain.toml`, workspace
+  `rust-version`, and CI).
+- Test assertions use stable `assert_matches!` so failures print `Debug`.
+
+### Deprecated
+
+- None.
+
+### Fixed
+
+- DHCP and DNS are allowed on each MicroNetwork bridge and through the
+  common guest firewall profiles so guests can obtain a lease.
+- Saving a running VM applies port-forward edits instead of dropping them.
+- NAT uplink fallback in the dashboard is parenthesized so Vite accepts it.
+- Image catalog architecture must be stated explicitly, including on
+  arm64 installer doctor paths.
+
+### Improved
+
+- README architecture diagrams cover the host, MicroNetwork, OCI import,
+  and MicroVM boot path, including how to inspect guest PID 1.
+- Public English docs under `public-docs/` describe install, networking,
+  storage, images, OCI import, the API, and operations.
+- CI runs fmt, clippy, workspace tests with Codecov, rustdoc, installer
+  smoke (including Debian/Fedora/Arch/openSUSE deps), and the frontend
+  lint/build on every pull request.
+- Changelog validation is part of the documentation CI job so a release
+  cannot drop a required section.
+
+[0.1.0]: https://github.com/SteelCrab/firecrab/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,10 +125,13 @@ The guest-boot half needs KVM, Firecracker, and `./scripts/dev-net-helper.sh`; s
 
 ```sh
 python3 scripts/check-doc-links.py
+python3 scripts/check-changelog.py
 shellcheck install.sh scripts/firecrab-doctor.sh
 ```
 
 `check-doc-links.py` enforces published docs rules: English only, max **170 lines** per `public-docs/**/*.md` file except `api.md`, valid relative links, and no stale `docs/` paths in tracked sources.
+
+`check-changelog.py` requires root [`CHANGELOG.md`](CHANGELOG.md) to document the workspace version with **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**. A `v*` tag uses that section as the GitHub Release body.
 
 ## Issues
 
@@ -173,7 +176,7 @@ One logical change per commit is nice; a tidy PR history is more important than 
 | Job | On every PR | Notes |
 | --- | --- | --- |
 | Rust fmt, clippy, test + coverage | yes | Workspace-wide |
-| rustdoc + `check-doc-links.py` | yes | Doc links and public-docs shape |
+| rustdoc + `check-doc-links.py` + `check-changelog.py` | yes | Doc links, public-docs shape, and changelog sections |
 | Installer shellcheck + install/uninstall smoke | yes | Guest boot skipped (`--no-images`) |
 | Frontend lint + build | yes | Node 22 |
 | Multi-distro installer deps | yes | Debian, Fedora, Arch, openSUSE containers |

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,6 +3,7 @@
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
+  <a href="./CHANGELOG.md"><img alt="Changelog" src="https://img.shields.io/badge/changelog-0.1.0-informational"></a>
 </p>
 
 ```text

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,6 +3,7 @@
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
+  <a href="./CHANGELOG.md"><img alt="Changelog" src="https://img.shields.io/badge/changelog-0.1.0-informational"></a>
 </p>
 
 ```text

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
+  <a href="./CHANGELOG.md"><img alt="Changelog" src="https://img.shields.io/badge/changelog-0.1.0-informational"></a>
 </p>
 
 ```text

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,6 +3,7 @@
   <a href="https://codecov.io/gh/SteelCrab/firecrab"><img alt="Codecov" src="https://codecov.io/gh/SteelCrab/firecrab/branch/main/graph/badge.svg"></a>
   <a href="https://www.linux.org"><img alt="Linux" src="https://img.shields.io/badge/platform-linux-blue?logo=linux&logoColor=white"></a>
   <a href="./LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue"></a>
+  <a href="./CHANGELOG.md"><img alt="Changelog" src="https://img.shields.io/badge/changelog-0.1.0-informational"></a>
 </p>
 
 ```text

--- a/firecrab-frontend/package-lock.json
+++ b/firecrab-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firecrab-frontend",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firecrab-frontend",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",

--- a/firecrab-frontend/package.json
+++ b/firecrab-frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firecrab-frontend",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/check-changelog.py
+++ b/scripts/check-changelog.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Validate CHANGELOG.md and extract a tagged release's notes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CHANGELOG = REPO / "CHANGELOG.md"
+CARGO_TOML = REPO / "Cargo.toml"
+
+REQUIRED_SECTIONS = ("Added", "Changed", "Deprecated", "Fixed", "Improved")
+HEADING_RE = re.compile(r"^## \[(\d+\.\d+\.\d+)\] - (\d{4}-\d{2}-\d{2})\s*$")
+WORKSPACE_VERSION_RE = re.compile(
+    r"^\[workspace\.package\]\s*$|^version\s*=\s*\"(\d+\.\d+\.\d+)\"\s*$",
+    re.MULTILINE,
+)
+VERSION_LINE_RE = re.compile(r"^version\s*=\s*\"(\d+\.\d+\.\d+)\"\s*$")
+
+
+class ChangelogError(Exception):
+    """The changelog cannot satisfy the requested operation."""
+
+
+def workspace_version(cargo_toml: Path) -> str:
+    text = cargo_toml.read_text(encoding="utf-8")
+    in_workspace_package = False
+    for line in text.splitlines():
+        if line.strip() == "[workspace.package]":
+            in_workspace_package = True
+            continue
+        if in_workspace_package:
+            if line.startswith("["):
+                break
+            match = VERSION_LINE_RE.match(line)
+            if match:
+                return match.group(1)
+    raise ChangelogError(f"{cargo_toml}: no [workspace.package] version")
+
+
+def _split_releases(text: str) -> list[tuple[str, str, str]]:
+    """Return (version, date, full_block) for each ## [x.y.z] heading."""
+    lines = text.splitlines()
+    starts: list[tuple[int, str, str]] = []
+    for index, line in enumerate(lines):
+        match = HEADING_RE.match(line)
+        if match:
+            starts.append((index, match.group(1), match.group(2)))
+
+    releases: list[tuple[str, str, str]] = []
+    for offset, (index, version, date) in enumerate(starts):
+        end = starts[offset + 1][0] if offset + 1 < len(starts) else len(lines)
+        block = "\n".join(lines[index:end]).rstrip() + "\n"
+        releases.append((version, date, block))
+    return releases
+
+
+def validate_text(text: str, expected_version: str) -> list[str]:
+    problems: list[str] = []
+    if not text.lstrip().startswith("# Changelog"):
+        problems.append("CHANGELOG.md must start with '# Changelog'")
+
+    releases = _split_releases(text)
+    if not releases:
+        problems.append(
+            "CHANGELOG.md needs a version heading like '## [0.1.0] - YYYY-MM-DD'"
+        )
+        return problems
+
+    latest_version, _date, block = releases[0]
+    if latest_version != expected_version:
+        problems.append(
+            f"latest heading is [{latest_version}], expected workspace {expected_version}"
+        )
+
+    headings = [
+        line[4:]
+        for line in block.splitlines()
+        if line.startswith("### ")
+    ]
+    if tuple(headings) != REQUIRED_SECTIONS:
+        problems.append(
+            "release "
+            f"{latest_version} must have sections in order: "
+            + ", ".join(REQUIRED_SECTIONS)
+            + f" (found {', '.join(headings) or 'none'})"
+        )
+
+    for section in REQUIRED_SECTIONS:
+        marker = f"### {section}"
+        if marker not in block:
+            problems.append(f"missing ### {section}")
+            continue
+        after = block.split(marker, 1)[1]
+        next_heading = after.find("\n### ")
+        body = after if next_heading < 0 else after[:next_heading]
+        if not re.search(r"(?m)^\s*[-*]\s+\S", body):
+            problems.append(f"### {section} needs at least one list item")
+
+    return problems
+
+
+def validate_path(path: Path, expected_version: str) -> list[str]:
+    if not path.is_file():
+        return [f"{path}: missing CHANGELOG.md"]
+    return validate_text(path.read_text(encoding="utf-8"), expected_version)
+
+
+def extract_notes(text: str, tag: str) -> str:
+    version = tag[1:] if tag.startswith("v") else tag
+    for found, _date, block in _split_releases(text):
+        if found == version:
+            return block
+    raise ChangelogError(f"CHANGELOG.md has no heading for {version}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--extract",
+        metavar="TAG",
+        help="print the CHANGELOG section for a git tag (e.g. v0.1.0)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = workspace_version(CARGO_TOML)
+    except ChangelogError as error:
+        print(error)
+        return 1
+
+    if args.extract:
+        if not CHANGELOG.is_file():
+            print(f"{CHANGELOG}: missing CHANGELOG.md")
+            return 1
+        try:
+            sys.stdout.write(extract_notes(CHANGELOG.read_text(encoding="utf-8"), args.extract))
+        except ChangelogError as error:
+            print(error)
+            return 1
+        return 0
+
+    problems = validate_path(CHANGELOG, version)
+    if problems:
+        print(f"Changelog check failed with {len(problems)} problem(s).")
+        for problem in problems:
+            print(f"  {problem}")
+        return 1
+
+    print(
+        f"CHANGELOG.md has [{version}] with "
+        + ", ".join(REQUIRED_SECTIONS)
+        + "."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_check_changelog.py
+++ b/scripts/test_check_changelog.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_changelog.py (stdlib unittest)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+import importlib.util
+from pathlib import Path
+from textwrap import dedent
+
+
+def _load_checker():
+    path = Path(__file__).with_name("check-changelog.py")
+    spec = importlib.util.spec_from_file_location("check_changelog", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check_changelog = _load_checker()
+
+VALID = dedent(
+    """\
+    # Changelog
+
+    ## [0.1.0] - 2026-08-16
+
+    ### Added
+
+    - First public release.
+
+    ### Changed
+
+    - None.
+
+    ### Deprecated
+
+    - None.
+
+    ### Fixed
+
+    - None.
+
+    ### Improved
+
+    - None.
+    """
+)
+
+
+class ValidateChangelogTests(unittest.TestCase):
+    def test_valid_document_has_no_problems(self) -> None:
+        self.assertEqual(check_changelog.validate_text(VALID, "0.1.0"), [])
+
+    def test_missing_required_section_is_reported(self) -> None:
+        text = VALID.replace("### Improved\n\n- None.\n", "")
+        problems = check_changelog.validate_text(text, "0.1.0")
+        self.assertTrue(any("Improved" in problem for problem in problems), problems)
+
+    def test_version_heading_must_match_workspace(self) -> None:
+        problems = check_changelog.validate_text(VALID, "0.2.0")
+        self.assertTrue(any("0.2.0" in problem for problem in problems), problems)
+
+    def test_extract_returns_the_named_release_body(self) -> None:
+        body = check_changelog.extract_notes(VALID, "v0.1.0")
+        self.assertIn("### Added", body)
+        self.assertIn("First public release.", body)
+        self.assertTrue(body.startswith("## [0.1.0] - 2026-08-16"))
+
+    def test_extract_unknown_tag_raises(self) -> None:
+        with self.assertRaises(check_changelog.ChangelogError):
+            check_changelog.extract_notes(VALID, "v9.9.9")
+
+    def test_repo_changelog_matches_workspace_version(self) -> None:
+        repo = Path(__file__).resolve().parent.parent
+        version = check_changelog.workspace_version(repo / "Cargo.toml")
+        problems = check_changelog.validate_path(repo / "CHANGELOG.md", version)
+        self.assertEqual(problems, [], problems)
+
+
+class FileHelperTests(unittest.TestCase):
+    def test_validate_path_missing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "CHANGELOG.md"
+            problems = check_changelog.validate_path(path, "0.1.0")
+        self.assertTrue(any("missing" in problem.lower() for problem in problems), problems)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Prepare the first public **0.1.0** release notes and wire them into CI and GitHub Releases.

- Add root [`CHANGELOG.md`](CHANGELOG.md) with **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**.
- CI docs job runs `scripts/check-changelog.py` so the latest heading matches the Cargo workspace version and those five sections stay present.
- `v*` tags publish that section as the GitHub Release body (instead of only auto-generated notes).
- Align `firecrab-frontend` to `0.1.0`. Cargo workspace was already `0.1.0`.

After this merges, tag `v0.1.0` on `main` to run Release Build and publish the four Linux tarballs.

## Testing

- `python3 -m unittest scripts/test_check_changelog.py` — 7 passed
- `python3 scripts/check-changelog.py` — `[0.1.0]` with the five required sections
- `python3 scripts/check-changelog.py --extract v0.1.0` — prints the 0.1.0 block
- `python3 scripts/check-doc-links.py` — passed
- YAML parse of `ci.yml` and `release.yml` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a structured changelog for the 0.1.0 release.
  * Release notes are now generated from version-specific changelog entries.

* **Documentation**
  * Added changelog badges to all README languages.
  * Documented changelog requirements and validation steps.

* **Quality Improvements**
  * Added automated changelog validation and tests to the release and CI processes.
  * Updated the frontend version to 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->