### PR TITLE
feat(install): gnu and musl host bundles for x86_64 and aarch64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Host bundles that install.sh downloads are static musl so one binary
+# per architecture runs on Debian, Fedora, Arch, openSUSE, and Alpine.
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         # release.yml when a v* tag publishes GitHub Release notes.
         run: |
           python3 -m unittest scripts/test_check_changelog.py
+          python3 -m unittest scripts/test_write_release_notes.py
           python3 scripts/check-changelog.py
 
       - name: Cache cargo
@@ -165,6 +166,9 @@ jobs:
       - name: shellcheck
         run: |
           shellcheck install.sh scripts/firecrab-doctor.sh \
+            scripts/firecrab-release.sh scripts/package-host-release.sh \
+            scripts/bake-install-sh.sh scripts/ci-prepare-install-payload.sh \
+            scripts/verify-release-binary.sh \
             scripts/build-m2images.sh scripts/package-m2images.sh \
             scripts/publish-m2images-r2.sh \
             scripts/firecracker-menual/install-alpine-rootfs.sh \
@@ -186,6 +190,8 @@ jobs:
         run: |
           bash -n install.sh
           bash -n scripts/firecrab-doctor.sh
+          bash scripts/test-firecrab-release.sh
+          bash scripts/test-install-cli.sh
           ./install.sh --help
           ./install.sh --check
           test ! -e /var/lib/firecrab || { echo "--check created the data directory"; exit 1; }
@@ -202,14 +208,23 @@ jobs:
           AFTER=$(ls -la /var/lib/firecrab 2>&1 || true)
           test "$BEFORE" = "$AFTER" || { echo "--doctor mutated host state"; exit 1; }
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: firecrab-frontend/package-lock.json
+
+      - name: Build install payload
+        # CI installs from local binaries, not GitHub Releases (PRs have none).
+        run: ./scripts/ci-prepare-install-payload.sh
+
       - name: Install
         # --no-images: building a guest rootfs needs sudo/chroot and ~10 minutes.
         # Everything else — deps, account, directories, units, dashboard — is real.
-        #
-        # PATH is carried into sudo on purpose: rustup lives in the runner
-        # user's home, and without it the installer would decide cargo is
-        # missing and fetch a second toolchain for root, ignoring the cache.
-        run: sudo -E env "PATH=$PATH" ./install.sh --no-images
+        run: |
+          sudo -E env "PATH=$PATH" ./install.sh --no-images \
+            --bin-dir target/release \
+            --dashboard-dir firecrab-frontend/dist
 
       - name: Both daemons are up
         run: |
@@ -303,7 +318,9 @@ jobs:
 
       - name: Re-running is safe
         run: |
-          sudo -E env "PATH=$PATH" ./install.sh --no-images
+          sudo -E env "PATH=$PATH" ./install.sh --no-images \
+            --bin-dir target/release \
+            --dashboard-dir firecrab-frontend/dist
           systemctl is-active --quiet firecrab-api
           # The MicroNetwork created above has to survive a re-install.
           curl -fsS http://127.0.0.1:3000/api/micro-networks | grep -q '"ci"'
@@ -330,8 +347,8 @@ jobs:
     name: Installer deps (${{ matrix.image }})
     # GitHub only hosts Ubuntu for Linux, so other distributions are covered in
     # containers. No systemd there, hence --deps-only: what actually differs per
-    # distribution is package naming and the toolchain, and that is what this
-    # exercises. Full install with units stays on the runner VM above.
+    # distribution is package naming, and that is what this exercises.
+    # Full install with units stays on the runner VM above.
     runs-on: ubuntu-latest
     container: ${{ matrix.image }}
     strategy:
@@ -384,17 +401,15 @@ jobs:
         run: ./install.sh --check
 
       - name: --deps-only installs them for real
-        # Containers run as root, so no sudo. A distro whose node packaging we
-        # cannot name drops the dashboard with a warning instead of failing —
-        # that path is exercised here too (Fedora ships only versioned streams).
+        # Containers run as root, so no sudo. The installer no longer pulls
+        # rustc or Node — those belong to --bin-dir / the release bundle.
         run: ./install.sh --deps-only
 
       - name: Everything the daemons need is present
         run: |
-          for command in ip nft dnsmasq mkfs.ext4 firecracker cc; do
+          for command in ip nft dnsmasq mkfs.ext4 firecracker sha256sum; do
             command -v "$command" >/dev/null || { echo "missing: $command"; exit 1; }
           done
-          "$HOME/.cargo/bin/cargo" --version || cargo --version
 
   # M2 guest boot matrix: every supported guest template × every GitHub-hosted
   # Linux runner that exposes nested KVM (Ubuntu LTS family). Other host distros
@@ -441,11 +456,22 @@ jobs:
           ls -l /dev/kvm
           uname -a
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: firecrab-frontend/package-lock.json
+
+      - name: Build install payload
+        run: ./scripts/ci-prepare-install-payload.sh
+
       - name: Install firecrab with guest image(s)
         # Alpine is the default image build; Ubuntu and Rocky 9.8 are opt-in.
         run: |
           set -euo pipefail
-          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh)
+          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh
+            --bin-dir target/release
+            --dashboard-dir firecrab-frontend/dist)
           case "${{ matrix.template }}" in
             ubuntu-*) INSTALL+=(--with-ubuntu-image) ;;
             rocky-*) INSTALL+=(--with-rocky-image) ;;
@@ -533,10 +559,24 @@ jobs:
           test -e /dev/kvm || { echo "no /dev/kvm on self-hosted ${{ matrix.host }}"; exit 1; }
           sudo chmod 666 /dev/kvm 2>/dev/null || chmod 666 /dev/kvm 2>/dev/null || true
 
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: firecrab-frontend/package-lock.json
+
+      - name: Build install payload
+        run: ./scripts/ci-prepare-install-payload.sh
+
       - name: Install firecrab with guest image(s)
         run: |
           set -euo pipefail
-          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh)
+          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh
+            --bin-dir target/release
+            --dashboard-dir firecrab-frontend/dist)
           case "${{ matrix.template }}" in
             ubuntu-*) INSTALL+=(--with-ubuntu-image) ;;
             rocky-*) INSTALL+=(--with-rocky-image) ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,36 +38,57 @@ jobs:
   build-release:
     name: Build (${{ matrix.target }})
     needs: release-test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
-        target:
-          # Firecracker itself only ships for x86_64 and aarch64 (see
-          # https://github.com/firecracker-microvm/firecracker/releases) —
-          # firecrab-api/firecrab-net-helper have no reason to target
-          # architectures Firecracker can't run on, so the matrix is
-          # intentionally narrower than a generic Rust release template.
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
+        # Native runner per architecture so we do not need `cross`.
+        # musl + crt-static (.cargo/config.toml) is what install.sh
+        # downloads: one binary per arch, every supported distro.
+        include:
+          - target: x86_64-unknown-linux-musl
+            arch: x86_64
+            runner: ubuntu-24.04
+            musl: true
+          - target: x86_64-unknown-linux-gnu
+            arch: x86_64
+            runner: ubuntu-24.04
+            musl: false
+          - target: aarch64-unknown-linux-musl
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+            musl: true
+          - target: aarch64-unknown-linux-gnu
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+            musl: false
       fail-fast: false
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install pinned toolchain
+        run: rustup show
 
-      - name: Install cross
-        run: cargo install cross --locked
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
 
-      - name: Build firecrab-api and firecrab-net-helper
+      - name: Install musl linker
+        if: matrix.musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: cargo build --release
         run: |
-          cross build --release --target ${{ matrix.target }} \
+          cargo build --release --locked --target ${{ matrix.target }} \
             -p firecrab-api -p firecrab-net-helper
+
+      - name: Verify release binaries
+        run: |
+          libc=gnu
+          if [ "${{ matrix.musl }}" = true ]; then libc=musl; fi
+          ./scripts/verify-release-binary.sh \
+            "target/${{ matrix.target }}/release/firecrab-api" "${{ matrix.arch }}" "$libc"
+          ./scripts/verify-release-binary.sh \
+            "target/${{ matrix.target }}/release/firecrab-net-helper" "${{ matrix.arch }}" "$libc"
 
       - name: Package binaries
         run: |
@@ -81,9 +102,176 @@ jobs:
           name: firecrab-${{ matrix.target }}
           path: firecrab-${{ matrix.target }}.tar.gz
 
+  build-dashboard:
+    name: Build dashboard
+    needs: release-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: firecrab-frontend/package-lock.json
+
+      - name: npm ci && npm run build
+        run: |
+          npm ci
+          npm run build
+        working-directory: firecrab-frontend
+
+      - name: Upload dashboard
+        uses: actions/upload-artifact@v7
+        with:
+          name: firecrab-dashboard
+          path: firecrab-frontend/dist
+
+  package-host:
+    name: Host bundle (${{ matrix.arch }} ${{ matrix.libc }})
+    needs: [build-release, build-dashboard]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - arch: x86_64
+            libc: musl
+            target: x86_64-unknown-linux-musl
+          - arch: x86_64
+            libc: gnu
+            target: x86_64-unknown-linux-gnu
+          - arch: aarch64
+            libc: musl
+            target: aarch64-unknown-linux-musl
+          - arch: aarch64
+            libc: gnu
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: firecrab-${{ matrix.target }}
+          path: bins-tar
+
+      - name: Download dashboard
+        uses: actions/download-artifact@v8
+        with:
+          name: firecrab-dashboard
+          path: dashboard
+
+      - name: Pack firecrab-host-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz
+        run: |
+          mkdir -p bins
+          tar -xzf bins-tar/firecrab-${{ matrix.target }}.tar.gz -C bins
+          ./scripts/package-host-release.sh \
+            "${{ matrix.arch }}" bins dashboard \
+            "firecrab-host-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz"
+
+      - name: Upload host bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: firecrab-host-${{ matrix.arch }}-${{ matrix.libc }}
+          path: firecrab-host-${{ matrix.arch }}-${{ matrix.libc }}.tar.gz
+
+  smoke-host-x86_64-gnu:
+    name: Smoke x86_64 gnu on ${{ matrix.image }}
+    needs: package-host
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:12
+          - fedora:latest
+          - archlinux:latest
+          - opensuse/tumbleweed
+    steps:
+      - name: Unpack tools
+        run: |
+          if command -v apt-get >/dev/null; then
+            apt-get update -qq && apt-get install -y -qq tar gzip
+          elif command -v dnf >/dev/null; then
+            dnf install -y -q tar gzip
+          elif command -v pacman >/dev/null; then
+            pacman -Sy --noconfirm --needed tar gzip
+          elif command -v zypper >/dev/null; then
+            zypper --non-interactive install --no-recommends tar gzip
+          fi
+        shell: sh -e {0}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: firecrab-host-x86_64-gnu
+          path: bundle
+
+      - name: glibc binary execs
+        run: |
+          tar -xzf bundle/firecrab-host-x86_64-gnu.tar.gz
+          set +e
+          ./firecrab-api
+          rc=$?
+          set -e
+          printf 'firecrab-api rc=%s\n' "$rc"
+          test "$rc" -ne 126
+          test "$rc" -ne 127
+
+  smoke-host-aarch64:
+    name: Smoke aarch64 ${{ matrix.libc }}
+    needs: package-host
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        libc: [gnu, musl]
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: firecrab-host-aarch64-${{ matrix.libc }}
+          path: bundle
+
+      - name: Binary execs
+        run: |
+          tar -xzf bundle/firecrab-host-aarch64-${{ matrix.libc }}.tar.gz
+          set +e
+          ./firecrab-api
+          rc=$?
+          set -e
+          printf 'firecrab-api rc=%s\n' "$rc"
+          test "$rc" -ne 126
+          test "$rc" -ne 127
+
+  smoke-host-alpine:
+    name: Smoke x86_64 musl on alpine
+    needs: package-host
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: firecrab-host-x86_64-musl
+          path: bundle
+
+      - name: musl binary execs inside Alpine
+        run: |
+          tar -xzf bundle/firecrab-host-x86_64-musl.tar.gz
+          set +e
+          docker run --rm -v "$PWD:/b:ro" alpine:3.21 /b/firecrab-api
+          rc=$?
+          set -e
+          printf 'firecrab-api rc=%s\n' "$rc"
+          test "$rc" -ne 126
+          test "$rc" -ne 127
+
   create-release:
     name: Publish GitHub Release
-    needs: build-release
+    needs:
+      - build-release
+      - package-host
+      - smoke-host-x86_64-gnu
+      - smoke-host-aarch64
+      - smoke-host-alpine
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
@@ -96,12 +284,34 @@ jobs:
         with:
           path: artifacts
 
-      - name: Release notes from CHANGELOG
-        run: python3 scripts/check-changelog.py --extract "${GITHUB_REF_NAME}" > release-notes.md
+      - name: Stage release files
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          find artifacts -type f \( -name '*.tar.gz' -o -name 'index.html' \) -print
+          find artifacts -type f -name '*.tar.gz' -exec cp -t dist {} +
+          ./scripts/bake-install-sh.sh "${GITHUB_REF_NAME}" dist/install.sh
+          (cd dist && sha256sum ./* > SHA256SUMS)
+          ls -l dist
+          cat dist/SHA256SUMS
+
+      - name: Release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${{ github.repository }}/contributors" --paginate \
+            --jq '.[].login' > /tmp/contributors.txt
+          python3 scripts/write-release-notes.py \
+            --tag "${GITHUB_REF_NAME}" \
+            --repo "${{ github.repository }}" \
+            --contributors-file /tmp/contributors.txt \
+            --out release-notes.md
+          cat release-notes.md
 
       - name: Create release
         uses: softprops/action-gh-release@v3
         with:
-          files: artifacts/**/*.tar.gz
+          files: dist/*
           body_path: release-notes.md
           generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,20 @@ network helper.
   service wrapper on the next start.
 - Host and guest port forwards on the API and dashboard.
 - `install.sh` host installer and `firecrab-doctor` health checks.
+- Host install from a GitHub Release:
+  `curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash`
+- Host bundles for Linux `x86_64` and `aarch64` in both `gnu` (glibc) and
+  `musl`: `firecrab-host-<arch>-<gnu|musl>.tar.gz`. `install.sh` detects
+  the host libc (`--libc gnu|musl` to override).
+- `install.sh --bin-dir` replaces installed binaries from a local directory
+  without compiling on the host.
 - Release-profile and cross-target GitHub Actions builds for
-  `x86_64`/`aarch64` GNU and musl.
+  `x86_64`/`aarch64` GNU and musl, plus `firecrab-host-*.tar.gz` bundles.
 
 ### Changed
 
+- `install.sh` downloads musl release binaries instead of building with
+  rustup and npm on the host.
 - Workspace version is `0.1.0` across the Rust crates.
 - Dashboard package version is `0.1.0`.
 - The pinned Rust toolchain is 1.96.0 (`rust-toolchain.toml`, workspace

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,12 +126,14 @@ The guest-boot half needs KVM, Firecracker, and `./scripts/dev-net-helper.sh`; s
 ```sh
 python3 scripts/check-doc-links.py
 python3 scripts/check-changelog.py
-shellcheck install.sh scripts/firecrab-doctor.sh
+shellcheck install.sh scripts/firecrab-doctor.sh scripts/firecrab-release.sh
+bash scripts/test-firecrab-release.sh
+bash scripts/test-install-cli.sh
 ```
 
 `check-doc-links.py` enforces published docs rules: English only, max **170 lines** per `public-docs/**/*.md` file except `api.md`, valid relative links, and no stale `docs/` paths in tracked sources.
 
-`check-changelog.py` requires root [`CHANGELOG.md`](CHANGELOG.md) to document the workspace version with **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**. A `v*` tag uses that section as the GitHub Release body.
+`check-changelog.py` requires root [`CHANGELOG.md`](CHANGELOG.md) to document the workspace version with **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**. A `v*` tag builds the GitHub Release body with `scripts/write-release-notes.py` (install URL, every host binary, contributors, then that changelog section).
 
 ## Issues
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -89,13 +89,11 @@ API はテンプレートアーティファクトを検証してから使用し�
 
 `/dev/kvm`、ネットワーク接続、`sudo` を実行できる一般ユーザーがいる Linux ホストが必要です。
 インストーラはその一般ユーザーとして実行し、スクリプトの前に **`sudo` を付けないで**ください。
-ソースビルドとユーザー向けツールは起動ユーザーの所有のままにし、パッケージ、systemd、ホスト設定
-など権限が必要な個別操作だけで内部的に `sudo` を使います。
+リリースのバイナリを取得し、パッケージ、systemd、ホスト設定など権限が必要な個別操作だけで
+内部的に `sudo` を使います。
 
 ```sh
-git clone https://github.com/SteelCrab/firecrab.git
-cd firecrab
-./install.sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
 ```
 
 よく使うインストーラのオプション:
@@ -103,14 +101,15 @@ cd firecrab
 ```sh
 ./install.sh --check                 # 前提条件と予定変更を確認
 ./install.sh --doctor                # KVM、ファイアウォール、socket、ホスト設定を診断
+./install.sh --bin-dir target/release
 ./install.sh --with-ubuntu-image
 ./install.sh --with-rocky-image      # Rocky Linux 9.8 をビルド
 ./install.sh --uninstall         # デフォルトではデータを保持
 ./install.sh --uninstall --purge # /var/lib/firecrab も削除
 ```
 
-標準のインストールはダッシュボードと Alpine ゲストイメージをビルドします。スクリプトは KVM を
-有効化できません。`/dev/kvm` がない場合は、先にハードウェア仮想化（またはネステッド仮想化）を
+標準のインストールは musl ホストバンドルを取得し、Alpine ゲストイメージを作ります。スクリプトは
+KVM を有効化できません。`/dev/kvm` がない場合は、先にハードウェア仮想化（またはネステッド仮想化）を
 有効にしてください。すべてのオプション、配置先、アップグレード、トラブルシューティングは
 [インストールガイド](public-docs/installation.md)にあります。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -184,13 +184,11 @@ flowchart TB
 ## Linux 호스트에 설치
 
 `/dev/kvm`, 네트워크, `sudo` 권한이 있는 일반 사용자 계정이 필요합니다. 설치기는 **`sudo`를
-앞에 붙이지 않고** 일반 사용자로 실행하세요. 소스 빌드와 사용자 도구는 호출한 사용자의 소유로
-유지하고, 패키지·systemd·호스트 설정처럼 필요한 개별 단계에서만 내부적으로 `sudo`를 사용합니다.
+앞에 붙이지 않고** 일반 사용자로 실행하세요. 릴리스 바이너리를 받고, 패키지·systemd·호스트
+설정처럼 필요한 개별 단계에서만 내부적으로 `sudo`를 사용합니다.
 
 ```sh
-git clone https://github.com/SteelCrab/firecrab.git
-cd firecrab
-./install.sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
 ```
 
 자주 쓰는 설치기 옵션:
@@ -198,15 +196,16 @@ cd firecrab
 ```sh
 ./install.sh --check                 # 필요 조건과 예정 변경 사항 확인
 ./install.sh --doctor                # KVM, 방화벽, 소켓, 호스트 설정 진단
+./install.sh --bin-dir target/release
 ./install.sh --with-ubuntu-image
 ./install.sh --with-rocky-image      # Rocky Linux 9.8 고정 버전 빌드
 ./install.sh --uninstall         # 기본적으로 데이터 유지
 ./install.sh --uninstall --purge # /var/lib/firecrab도 제거
 ```
 
-기본 설치는 대시보드와 Alpine 게스트 이미지를 빌드합니다. `/dev/kvm`이 없다면 스크립트가
-대신 활성화할 수 없으므로 하드웨어 가상화(또는 중첩 가상화)를 먼저 켜야 합니다. 모든 옵션,
-설치 경로, 업그레이드, 문제 해결은 [설치 가이드](public-docs/installation.md)에 있습니다.
+기본 설치는 musl 호스트 묶음을 받고 Alpine 게스트 이미지를 만듭니다. `/dev/kvm`이 없다면
+스크립트가 대신 활성화할 수 없으므로 하드웨어 가상화(또는 중첩 가상화)를 먼저 켜야 합니다.
+모든 옵션, 설치 경로, 업그레이드, 문제 해결은 [설치 가이드](public-docs/installation.md)에 있습니다.
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -187,14 +187,11 @@ See the detailed [architecture](public-docs/architecture.md).
 
 Requirements are a Linux host with `/dev/kvm`, network access, and a user allowed to
 run `sudo`. Run the installer as that regular user — do **not** prefix the script with
-`sudo`. It keeps source builds and user-level tools owned by the invoking user, and
-uses `sudo` only for the individual package, systemd, and host-setup operations that
-need it.
+`sudo`. It downloads release binaries and uses `sudo` only for the individual package,
+systemd, and host-setup operations that need it.
 
 ```sh
-git clone https://github.com/SteelCrab/firecrab.git
-cd firecrab
-./install.sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
 ```
 
 Useful installer modes:
@@ -202,16 +199,19 @@ Useful installer modes:
 ```sh
 ./install.sh --check                 # report prerequisites and planned changes
 ./install.sh --doctor                # diagnose KVM, firewall, socket, and host setup
+./install.sh --bin-dir target/release
 ./install.sh --with-ubuntu-image
 ./install.sh --with-rocky-image      # build pinned Rocky Linux 9.8
 ./install.sh --uninstall         # retain data by default
 ./install.sh --uninstall --purge # also remove /var/lib/firecrab
 ```
 
-The default install builds the dashboard and an Alpine guest image. KVM cannot be
-enabled by the script: if `/dev/kvm` is absent, enable hardware virtualization (or
-nested virtualization) first. For every option, install path, upgrade detail, and
-troubleshooting step, read the [installation guide](public-docs/installation.md).
+The default install downloads the host bundle for this architecture and libc
+(`gnu` / glibc, or `musl`) and builds an Alpine guest image.
+Pass `--libc gnu` or `--libc musl` to pick one.
+KVM cannot be enabled by the script: if `/dev/kvm` is absent, enable hardware
+virtualization (or nested virtualization) first. For every option, install path,
+upgrade detail, and troubleshooting step, read the [installation guide](public-docs/installation.md).
 
 ## Quick start
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -83,13 +83,11 @@ API 会在使用前验证模板工件；已安装的部署中，API 也会直接
 ## 在 Linux 主机上安装
 
 需要一台具有 `/dev/kvm`、网络访问和可使用 `sudo` 的普通用户的 Linux 主机。请以该普通用户
-运行安装程序，**不要**在脚本前加 `sudo`。它会让源码构建和用户工具归调用用户所有，只对软件包、
-systemd 与主机设置等需要权限的单独操作在内部使用 `sudo`。
+运行安装程序，**不要**在脚本前加 `sudo`。它会下载发行版二进制文件，只对软件包、systemd
+与主机设置等需要权限的单独操作在内部使用 `sudo`。
 
 ```sh
-git clone https://github.com/SteelCrab/firecrab.git
-cd firecrab
-./install.sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
 ```
 
 常用安装选项：
@@ -97,14 +95,15 @@ cd firecrab
 ```sh
 ./install.sh --check                 # 报告前置条件和计划变更
 ./install.sh --doctor                # 诊断 KVM、防火墙、socket 和主机设置
+./install.sh --bin-dir target/release
 ./install.sh --with-ubuntu-image
 ./install.sh --with-rocky-image      # 构建固定版本 Rocky Linux 9.8
 ./install.sh --uninstall         # 默认保留数据
 ./install.sh --uninstall --purge # 同时删除 /var/lib/firecrab
 ```
 
-默认安装会构建仪表盘和 Alpine 客户机镜像。脚本不能启用 KVM：若没有 `/dev/kvm`，请先启用硬件
-虚拟化（或嵌套虚拟化）。所有选项、安装路径、升级和排错请参阅[安装指南](public-docs/installation.md)。
+默认安装会下载 musl 主机包并构建 Alpine 客户机镜像。脚本不能启用 KVM：若没有 `/dev/kvm`，请先
+启用硬件虚拟化（或嵌套虚拟化）。所有选项、安装路径、升级和排错请参阅[安装指南](public-docs/installation.md)。
 
 ## 快速开始
 

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
 # firecrab host installer (public-docs/installation.md).
 #
-# One command on a machine that only has network access: works out what is
-# missing, installs it, builds firecrab, and leaves two systemd daemons
-# running with the dashboard served on http://127.0.0.1:3000/.
+# Downloads a host bundle from a GitHub Release (or installs local binaries
+# via --bin-dir), then lays out systemd units so the dashboard is served on
+# http://127.0.0.1:3000/.
+#
+# Bundles are Linux x86_64/aarch64 × gnu (glibc) / musl. glibc hosts get the
+# gnu bundle; musl hosts (Alpine) get musl. Override with --libc.
 #
 # Every step checks before it changes anything, so re-running is safe and
 # doubles as a repair for a half-broken install.
@@ -21,6 +24,10 @@ UNITDIR=${UNITDIR:-/etc/systemd/system}
 REPO_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 UNITS=(firecrab-net-helper.service firecrab-api.service)
 
+# Placeholder @FIRECRAB_RELEASE_TAG@ is replaced by the tag on a published
+# install.sh (v0.1.0). The repo copy keeps the placeholder and means "latest".
+FIRECRAB_RELEASE_TAG="@FIRECRAB_RELEASE_TAG@"
+
 MODE=install
 INSTALL_DEPS=1
 WITH_IMAGES=1
@@ -28,6 +35,29 @@ WITH_UBUNTU_IMAGE=0
 WITH_ROCKY_IMAGE=0
 WITH_FRONTEND=1
 PURGE=0
+BIN_DIR=
+DASHBOARD_DIR=
+RELEASE_VERSION=
+LIBC=
+PAYLOAD_TMP=
+PAYLOAD_ROOT=
+PAYLOAD_BIN=
+PAYLOAD_UNITS=
+PAYLOAD_EXTRACT=
+PAYLOAD_DOCTOR=
+PAYLOAD_DASHBOARD=
+
+# BEGIN RELEASE_HELPERS
+if [ -f "$REPO_ROOT/scripts/firecrab-release.sh" ]; then
+    # Optional checkout helper; the published installer inlines this block.
+    # shellcheck disable=SC1091
+    . "$REPO_ROOT/scripts/firecrab-release.sh"
+fi
+if ! type firecrab_host_arch >/dev/null 2>&1; then
+    printf 'xx  release helpers missing — run from a firecrab checkout or use the install.sh from a GitHub Release\n' >&2
+    exit 1
+fi
+# END RELEASE_HELPERS
 
 PKG=''          # detected package manager
 PKG_UPDATED=0   # index refreshed at most once
@@ -37,20 +67,35 @@ usage() {
     cat <<'USAGE'
 Usage: ./install.sh [OPTIONS]
 
-  (no options)        install everything that is missing, then start firecrab
+  (no options)        download the latest release binaries and start firecrab
   --check             report what is missing and what would be installed
   --doctor            run host diagnostics (UFW, socket, KVM, nft, …); no root required
   --deps-only         install the dependencies, then stop (no host changes)
-  --no-deps           never install packages/toolchains, only report gaps
+  --no-deps           never install packages, only report gaps
   --no-images         do not build a guest image
   --with-ubuntu-image also build the Ubuntu image (large, needs root chroot)
   --with-rocky-image  also build Rocky Linux 9.8 (large, needs root chroot)
-  --no-frontend       do not build/install the dashboard
+  --no-frontend       do not install the dashboard
+  --version VER       GitHub Release tag (default: latest, or the baked-in tag)
+  --libc gnu|musl     host libc (default: detect; gnu = glibc)
+  --bin-dir DIR       install these local binaries instead of the release
+  --dashboard-dir DIR install this built dashboard (with --bin-dir)
+  --print-install-url print the curl install command and exit
+  --print-release-url print the host-bundle URL and exit
   --uninstall         stop and remove units, binaries and dashboard
   --purge             with --uninstall, also delete /var/lib/firecrab (VM data!)
   -h, --help          this text
 
+  curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
+
+  Host bundles (install.sh picks arch + libc):
+    firecrab-host-x86_64-gnu.tar.gz    Linux x86_64, glibc
+    firecrab-host-x86_64-musl.tar.gz   Linux x86_64, musl (static)
+    firecrab-host-aarch64-gnu.tar.gz   Linux aarch64, glibc
+    firecrab-host-aarch64-musl.tar.gz  Linux aarch64, musl (static)
+
 Environment: FIRECRAB_USER, FIRECRAB_GROUP, PREFIX, DATADIR, CONFDIR, UNITDIR
+             FIRECRAB_RELEASE_REPO, FIRECRAB_DEFAULT_VERSION
 USAGE
 }
 
@@ -90,6 +135,31 @@ while [ $# -gt 0 ]; do
         --with-ubuntu-image) WITH_UBUNTU_IMAGE=1 ;;
         --with-rocky-image) WITH_ROCKY_IMAGE=1 ;;
         --no-frontend) WITH_FRONTEND=0 ;;
+        --version)
+            [ $# -ge 2 ] || die "--version needs a tag (for example v0.1.0)"
+            RELEASE_VERSION=$2
+            shift
+            ;;
+        --libc)
+            [ $# -ge 2 ] || die "--libc needs gnu or musl"
+            LIBC=$2
+            firecrab_normalize_libc "$LIBC" >/dev/null \
+                || die "--libc must be gnu, glibc, or musl"
+            LIBC=$(firecrab_normalize_libc "$LIBC")
+            shift
+            ;;
+        --bin-dir)
+            [ $# -ge 2 ] || die "--bin-dir needs a directory"
+            BIN_DIR=$2
+            shift
+            ;;
+        --dashboard-dir)
+            [ $# -ge 2 ] || die "--dashboard-dir needs a directory"
+            DASHBOARD_DIR=$2
+            shift
+            ;;
+        --print-install-url) MODE=print-install-url ;;
+        --print-release-url) MODE=print-release-url ;;
         --uninstall) MODE=uninstall ;;
         --purge) PURGE=1 ;;
         -h|--help) usage; exit 0 ;;
@@ -97,6 +167,33 @@ while [ $# -gt 0 ]; do
     esac
     shift
 done
+
+if [ -z "$RELEASE_VERSION" ]; then
+    RELEASE_VERSION=${FIRECRAB_DEFAULT_VERSION:-}
+fi
+# A published installer substitutes the placeholder with the tag. The repo
+# copy keeps @FIRECRAB_RELEASE_TAG@, which means "latest".
+case "$FIRECRAB_RELEASE_TAG" in
+    ""|@*) ;;
+    *)
+        if [ -z "$RELEASE_VERSION" ]; then
+            RELEASE_VERSION=$FIRECRAB_RELEASE_TAG
+        fi
+        ;;
+esac
+
+if [ -z "$LIBC" ]; then
+    LIBC=$(firecrab_host_libc)
+else
+    LIBC=$(firecrab_normalize_libc "$LIBC") || die "--libc must be gnu, glibc, or musl"
+fi
+
+cleanup_payload() {
+    if [ -n "${PAYLOAD_TMP:-}" ] && [ -d "$PAYLOAD_TMP" ]; then
+        rm -rf "$PAYLOAD_TMP"
+    fi
+}
+trap cleanup_payload EXIT
 
 # --- package manager -------------------------------------------------------
 
@@ -134,17 +231,6 @@ pkg_name() {
         *:xz)         echo "xz" ;;
         # Dashboard M2Image install decompresses `{alias}.tar.zst` packages.
         *:zstd)       echo "zstd" ;;
-        # cargo needs a linker; rustup only warns that one is missing and the
-        # build then fails at link time with a much less obvious error.
-        apt-get:cc)   echo "build-essential" ;;
-        apk:cc)       echo "build-base" ;;
-        *:cc)         echo "gcc" ;;
-        # Node is the one dependency nobody names the same way. openSUSE has
-        # meta packages; Fedora ships only versioned streams (nodejs22-npm-bin
-        # and friends), so the unversioned guess below simply fails there and
-        # `ensure_build_tools` carries on without the dashboard.
-        zypper:node)  echo "nodejs-default npm-default" ;;
-        *:node)       echo "nodejs npm" ;;
         *) echo "$generic" ;;
     esac
 }
@@ -249,6 +335,7 @@ ensure_runtime_deps() {
     ensure find findutils || failed=1
     ensure tar tar       || failed=1
     ensure zstd zstd     || failed=1
+    ensure sha256sum coreutils || failed=1
     return $failed
 }
 
@@ -267,60 +354,95 @@ ensure_firecracker() {
     have firecracker
 }
 
-# cargo, plus npm when the dashboard is being built.
-ensure_build_tools() {
-    local failed=0
-
-    if have cargo; then
-        log "cargo present"
-    elif [ "$MODE" = check ]; then
-        warn "missing: cargo (would install via rustup)"
-        failed=1
-    elif [ "$INSTALL_DEPS" -eq 1 ]; then
-        step "installing the Rust toolchain (rustup)"
-        # Downloaded whole, then run - piping curl into sh executes whatever
-        # arrived if the transfer is cut off partway.
-        local installer
-        installer=$(mktemp)
-        # shellcheck disable=SC2064 # expand the path now, not at trap time
-        trap "rm -f '$installer'" RETURN
-        if curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "$installer"; then
-            sh "$installer" -y --no-modify-path || { warn "rustup install failed"; failed=1; }
-        else
-            warn "could not download the rustup installer"
-            failed=1
-        fi
-        # rustup lands in $HOME/.cargo for whoever runs this (root under sudo).
-        export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
-        have cargo || { warn "cargo still not on PATH"; failed=1; }
-    else
-        warn "missing: cargo (--no-deps; install rustup yourself)"
-        failed=1
-    fi
-
-    ensure cc cc || failed=1
-
-    if [ "$WITH_FRONTEND" -eq 1 ] && ! ensure npm node; then
-        # Degraded, not fatal: the API and MicroNetworks work without the
-        # dashboard, and node package names vary too much between distributions
-        # to fail an install over. Build it later and re-run.
-        warn "no npm — installing without the dashboard (re-run after installing Node)"
-        WITH_FRONTEND=0
-    fi
-    return $failed
+# Whether this script is running from a firecrab git checkout.
+is_checkout() {
+    [ -f "$REPO_ROOT/Cargo.toml" ] && [ -f "$REPO_ROOT/packaging/systemd/firecrab-api.service" ]
 }
 
-# --- build -----------------------------------------------------------------
-
-# Release binaries, and the dashboard bundle unless it was skipped.
-build_all() {
-    step "building the workspace (release)"
-    ( cd "$REPO_ROOT" && cargo build --release --workspace )
-
-    if [ "$WITH_FRONTEND" -eq 1 ]; then
-        step "building the dashboard"
-        ( cd "$REPO_ROOT/firecrab-frontend" && npm ci && npm run build )
+# Downloads the host bundle for this arch + libc.
+download_host_bundle() {
+    local arch tarball url sums_url
+    arch=$(firecrab_host_arch) || die "unsupported architecture: $(uname -m) (need x86_64 or aarch64)"
+    tarball=$(firecrab_host_tarball "$arch" "$LIBC")
+    PAYLOAD_TMP=$(mktemp -d)
+    url=$(firecrab_release_asset_url "$RELEASE_VERSION" "$tarball")
+    sums_url=$(firecrab_release_asset_url "$RELEASE_VERSION" SHA256SUMS)
+    step "downloading $tarball"
+    if ! curl --proto '=https' --tlsv1.2 -fsSL "$url" -o "$PAYLOAD_TMP/$tarball"; then
+        die "failed to download $url
+Tag a GitHub Release, or install local binaries:
+  cargo build --release -p firecrab-api -p firecrab-net-helper
+  ./install.sh --bin-dir target/release --dashboard-dir firecrab-frontend/dist"
     fi
+    if ! curl --proto '=https' --tlsv1.2 -fsSL "$sums_url" -o "$PAYLOAD_TMP/SHA256SUMS"; then
+        die "failed to download $sums_url"
+    fi
+    firecrab_verify_sha256 "$PAYLOAD_TMP/SHA256SUMS" "$PAYLOAD_TMP/$tarball" \
+        || die "checksum mismatch for $tarball"
+    mkdir -p "$PAYLOAD_TMP/root"
+    tar -xzf "$PAYLOAD_TMP/$tarball" -C "$PAYLOAD_TMP/root"
+    PAYLOAD_ROOT=$PAYLOAD_TMP/root
+    local name
+    for name in firecrab-api firecrab-net-helper; do
+        [ -x "$PAYLOAD_ROOT/$name" ] || die "release bundle is missing $name"
+        firecrab_assert_binary_arch "$PAYLOAD_ROOT/$name" "$arch" \
+            || die "$tarball: $name is not a $arch binary"
+    done
+    log "host bundle $arch/$LIBC"
+}
+
+# Sets PAYLOAD_* to either --bin-dir + this checkout, or a downloaded release.
+resolve_payload() {
+    if [ "$(firecrab_payload_mode "$BIN_DIR")" = dir ]; then
+        [ -d "$BIN_DIR" ] || die "--bin-dir is not a directory: $BIN_DIR"
+        is_checkout || die "--bin-dir needs a firecrab checkout for units and helper scripts"
+        PAYLOAD_BIN=$BIN_DIR
+        PAYLOAD_UNITS=$REPO_ROOT/packaging/systemd
+        PAYLOAD_EXTRACT=$REPO_ROOT/scripts/firecracker-menual
+        PAYLOAD_DOCTOR=$REPO_ROOT/scripts/firecrab-doctor.sh
+        if [ -n "$DASHBOARD_DIR" ]; then
+            PAYLOAD_DASHBOARD=$DASHBOARD_DIR
+        elif [ -f "$REPO_ROOT/firecrab-frontend/dist/index.html" ]; then
+            PAYLOAD_DASHBOARD=$REPO_ROOT/firecrab-frontend/dist
+        else
+            PAYLOAD_DASHBOARD=
+        fi
+        return 0
+    fi
+
+    download_host_bundle
+    PAYLOAD_BIN=$PAYLOAD_ROOT
+    PAYLOAD_UNITS=$PAYLOAD_ROOT/systemd
+    PAYLOAD_EXTRACT=$PAYLOAD_ROOT
+    PAYLOAD_DOCTOR=$PAYLOAD_ROOT/firecrab-doctor.sh
+    PAYLOAD_DASHBOARD=$PAYLOAD_ROOT/dashboard
+}
+
+report_payload() {
+    local tarball
+    if [ "$(firecrab_payload_mode "$BIN_DIR")" = dir ]; then
+        log "binaries: would install from $BIN_DIR"
+        if [ ! -d "$BIN_DIR" ]; then
+            warn "not a directory: $BIN_DIR"
+            return 1
+        fi
+        local name gaps=0
+        for name in firecrab-api firecrab-net-helper; do
+            if [ -x "$BIN_DIR/$name" ]; then
+                log "  $name"
+            else
+                warn "  missing $name (ok if already installed under $LIBDIR)"
+                gaps=1
+            fi
+        done
+        return 0
+    fi
+    if ! tarball=$(firecrab_host_tarball "" "$LIBC"); then
+        warn "unsupported architecture: $(uname -m) (need x86_64 or aarch64)"
+        return 1
+    fi
+    log "binaries: would download $(firecrab_release_asset_url "$RELEASE_VERSION" "$tarball") ($LIBC)"
+    return 0
 }
 
 # --- host layout -----------------------------------------------------------
@@ -378,12 +500,17 @@ ensure_directories() {
     log "directories ready under $DATADIR, $CONFDIR"
 }
 
-# Puts the built binaries, and the dashboard, where the units expect them.
+# Puts the payload binaries, and the dashboard, where the units expect them.
 install_binaries() {
-    local target="$REPO_ROOT/target/release"
-    for binary in firecrab-api firecrab-net-helper; do
-        [ -x "$target/$binary" ] || die "$target/$binary not found — the build did not produce it"
-        $SUDO install -o root -g root -m 0755 "$target/$binary" "$LIBDIR/$binary"
+    local name src
+    for name in firecrab-api firecrab-net-helper; do
+        src=$(firecrab_resolve_binary "$name" "$PAYLOAD_BIN" "$LIBDIR") \
+            || die "no $name in ${PAYLOAD_BIN:-<release>} or $LIBDIR — pass it via --bin-dir or install a release"
+        if [ "$src" -ef "$LIBDIR/$name" ]; then
+            log "keeping existing $LIBDIR/$name"
+        else
+            $SUDO install -o root -g root -m 0755 "$src" "$LIBDIR/$name"
+        fi
     done
     # extract-vmlinux and extract-arm64-image are shell scripts used at
     # runtime by the API to turn a distro vmlinuz into the kernel format
@@ -391,23 +518,28 @@ install_binaries() {
     # binary lets the API find them without needing access to the repo
     # checkout (which may be in a user home the service account cannot reach).
     for helper in extract-vmlinux extract-arm64-image; do
+        [ -f "$PAYLOAD_EXTRACT/$helper" ] || die "missing $PAYLOAD_EXTRACT/$helper"
         $SUDO install -o root -g root -m 0755 \
-            "$REPO_ROOT/scripts/firecracker-menual/$helper" "$LIBDIR/$helper"
+            "$PAYLOAD_EXTRACT/$helper" "$LIBDIR/$helper"
     done
-    # Host doctor is a shell script — no build step. On PATH as firecrab-doctor.
+    [ -f "$PAYLOAD_DOCTOR" ] || die "missing $PAYLOAD_DOCTOR"
     $SUDO install -d -o root -g root -m 0755 "$PREFIX/bin"
-    $SUDO install -o root -g root -m 0755 "$REPO_ROOT/scripts/firecrab-doctor.sh" \
+    $SUDO install -o root -g root -m 0755 "$PAYLOAD_DOCTOR" \
         "$PREFIX/bin/firecrab-doctor"
     log "binaries installed to $LIBDIR (doctor → $PREFIX/bin/firecrab-doctor)"
 
     [ "$WITH_FRONTEND" -eq 1 ] || return 0
-    local dist="$REPO_ROOT/firecrab-frontend/dist"
-    [ -f "$dist/index.html" ] || die "$dist/index.html not found — the dashboard build did not produce it"
-    $SUDO rm -rf "$SHAREDIR/dashboard"
-    $SUDO install -d -o root -g root -m 0755 "$SHAREDIR/dashboard"
-    $SUDO cp -r "$dist/." "$SHAREDIR/dashboard/"
-    $SUDO chown -R root:root "$SHAREDIR/dashboard"
-    log "dashboard installed to $SHAREDIR/dashboard"
+    if [ -n "$PAYLOAD_DASHBOARD" ] && [ -f "$PAYLOAD_DASHBOARD/index.html" ]; then
+        $SUDO rm -rf "$SHAREDIR/dashboard"
+        $SUDO install -d -o root -g root -m 0755 "$SHAREDIR/dashboard"
+        $SUDO cp -r "$PAYLOAD_DASHBOARD/." "$SHAREDIR/dashboard/"
+        $SUDO chown -R root:root "$SHAREDIR/dashboard"
+        log "dashboard installed to $SHAREDIR/dashboard"
+    elif [ -f "$SHAREDIR/dashboard/index.html" ]; then
+        log "keeping existing $SHAREDIR/dashboard"
+    else
+        die "dashboard not found — pass --dashboard-dir, or omit --no-frontend only when using a release bundle"
+    fi
 }
 
 # Seeds api.env once so an operator's edits survive a re-run.
@@ -450,7 +582,7 @@ install_units() {
             -e "s|@FIRECRAB_USER@|$FIRECRAB_USER|g" \
             -e "s|@FIRECRAB_GROUP@|$FIRECRAB_GROUP|g" \
             -e "s|@FIRECRAB_UID@|$uid|g" \
-            "$REPO_ROOT/packaging/systemd/$unit" | $SUDO tee "$UNITDIR/$unit" > /dev/null
+            "$PAYLOAD_UNITS/$unit" | $SUDO tee "$UNITDIR/$unit" > /dev/null
         $SUDO chmod 0644 "$UNITDIR/$unit"
     done
     $SUDO systemctl daemon-reload
@@ -619,7 +751,7 @@ do_check() {
     fi
     ensure_runtime_deps || gaps=1
     ensure_firecracker || gaps=1
-    ensure_build_tools || gaps=1
+    report_payload || gaps=1
     check_kvm || gaps=1
     check_systemd || gaps=1
     report_images || gaps=1
@@ -636,8 +768,14 @@ do_check() {
 
 # Runtime host diagnostics — delegates to scripts/firecrab-doctor.sh (no root).
 do_doctor() {
-    local doctor="$REPO_ROOT/scripts/firecrab-doctor.sh"
-    [ -x "$doctor" ] || die "missing $doctor"
+    local doctor
+    if [ -x "$REPO_ROOT/scripts/firecrab-doctor.sh" ]; then
+        doctor=$REPO_ROOT/scripts/firecrab-doctor.sh
+    elif have firecrab-doctor; then
+        doctor=$(command -v firecrab-doctor)
+    else
+        die "missing firecrab-doctor (run from a checkout, or install first)"
+    fi
     # Pass DATADIR through so the doctor matches this install layout.
     DATADIR="$DATADIR" FIRECRAB_API_USER="$FIRECRAB_USER" \
         exec "$doctor" "${DOCTOR_ARGS[@]}"
@@ -654,13 +792,22 @@ do_deps() {
         ensure_image_build_deps || die "missing image build dependencies (see above)"
     fi
     ensure_firecracker  || die "firecracker is required"
-    ensure_build_tools  || die "build tools are required"
     check_kvm || warn "no KVM here; that only matters where VMs actually run"
     report_ufw
     log "dependencies ready — run without --deps-only to install firecrab"
 }
 
-# The default path: fill the gaps, build, lay out, start.
+do_print_install_url() {
+    firecrab_install_curl_url "${RELEASE_VERSION:-latest}"
+}
+
+do_print_release_url() {
+    local tarball
+    tarball=$(firecrab_host_tarball "" "$LIBC") || die "unsupported architecture: $(uname -m) (need x86_64 or aarch64)"
+    firecrab_release_asset_url "$RELEASE_VERSION" "$tarball"
+}
+
+# The default path: fill the gaps, fetch binaries, lay out, start.
 do_install() {
     # Checked before anything is installed: refusing after pulling in five
     # packages would be a waste of the operator's time.
@@ -669,10 +816,9 @@ do_install() {
 
     ensure_runtime_deps || die "missing runtime dependencies (see above)"
     ensure_firecracker  || die "firecracker is required"
-    ensure_build_tools  || die "build tools are required"
     check_kvm || warn "continuing, but VMs will not start until KVM is available"
 
-    build_all
+    resolve_payload
     ensure_account
     ensure_directories
     install_binaries
@@ -721,6 +867,8 @@ case "$MODE" in
     check) do_check ;;
     doctor) do_doctor ;;
     deps) do_deps ;;
+    print-install-url) do_print_install_url ;;
+    print-release-url) do_print_release_url ;;
     install) do_install ;;
     uninstall) do_uninstall ;;
 esac

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -1,7 +1,10 @@
 # Installation
 
 `install.sh` installs firecrab on one Linux host.
-It builds the services and dashboard and installs systemd units.
+It downloads the host bundle for this architecture (`x86_64` or `aarch64`) and libc (`gnu` / glibc, or `musl`).
+glibc hosts (Debian, Fedora, Arch, openSUSE, Ubuntu) get the gnu bundle.
+musl hosts (Alpine) get the musl bundle.
+Pass `--libc gnu` or `--libc musl` to override.
 
 ## Requirements
 
@@ -27,9 +30,18 @@ It checks tools, KVM, systemd, images, and firewall state.
 ## Install
 
 ```sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash
+```
+
+Pin a version by replacing `latest` with the tag, for example `v0.1.0`.
+
+To patch an installed host with binaries you built yourself:
+
+```sh
 git clone https://github.com/SteelCrab/firecrab.git
 cd firecrab
-./install.sh
+cargo build --release -p firecrab-api -p firecrab-net-helper
+./install.sh --bin-dir target/release --dashboard-dir firecrab-frontend/dist
 ```
 
 Open the dashboard after the services start.
@@ -51,6 +63,10 @@ The default install builds the Alpine image.
 | `--with-ubuntu-image` | Also build Ubuntu 26.04 |
 | `--with-rocky-image` | Also build Rocky Linux 9.8 without Docker |
 | `--no-frontend` | Skip the dashboard |
+| `--version VER` | Use that GitHub Release tag |
+| `--libc gnu` or `--libc musl` | Force glibc or musl instead of auto-detect |
+| `--bin-dir DIR` | Install local binaries instead of the release |
+| `--dashboard-dir DIR` | Install this built dashboard |
 | `--uninstall` | Remove services but keep data |
 | `--uninstall --purge` | Also delete VM data |
 
@@ -87,7 +103,8 @@ Create one before creating a VM.
 
 ## Upgrade
 
-Pull new source and run `./install.sh` again.
+Run the installer again.
+It replaces binaries from the latest release, or from `--bin-dir` when you pass one.
 The installer keeps the database, VM disks, and `api.env`.
 
 ## Related

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -74,7 +74,8 @@ The image directory contains source templates.
 
 ## Upgrade
 
-Pull the new source and run `./install.sh` again.
+Run `install.sh` again to replace binaries from the latest GitHub Release.
+Use `--bin-dir` to drop in locally built binaries instead.
 The installer preserves VM data and `api.env`.
 
 Check both services and run the doctor after an upgrade.

--- a/scripts/bake-install-sh.sh
+++ b/scripts/bake-install-sh.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Produce a standalone install.sh for a GitHub Release: inline helpers + bake tag.
+set -euo pipefail
+
+[ $# -eq 2 ] || { printf 'Usage: %s <tag> <output>\n' "$0" >&2; exit 2; }
+tag=$1
+output=$2
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+
+python3 - "$root" "$tag" "$output" <<'PY'
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+tag = sys.argv[2]
+out = Path(sys.argv[3])
+
+install = (root / "install.sh").read_text(encoding="utf-8")
+helpers = (root / "scripts/firecrab-release.sh").read_text(encoding="utf-8")
+body = "\n".join(
+    line for line in helpers.splitlines() if not line.startswith("#!")
+).rstrip() + "\n"
+
+start = install.index("# BEGIN RELEASE_HELPERS")
+end = install.index("# END RELEASE_HELPERS") + len("# END RELEASE_HELPERS")
+baked = (
+    install[:start]
+    + "# BEGIN RELEASE_HELPERS\n"
+    + body
+    + "# END RELEASE_HELPERS"
+    + install[end:]
+)
+baked = baked.replace("@FIRECRAB_RELEASE_TAG@", tag)
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(baked, encoding="utf-8")
+out.chmod(0o755)
+print(out)
+PY

--- a/scripts/ci-prepare-install-payload.sh
+++ b/scripts/ci-prepare-install-payload.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Build the --bin-dir / --dashboard-dir payload used by CI installer jobs.
+set -euo pipefail
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$root"
+
+cargo build --release --locked -p firecrab-api -p firecrab-net-helper
+npm ci --prefix firecrab-frontend
+npm run build --prefix firecrab-frontend

--- a/scripts/firecrab-release.sh
+++ b/scripts/firecrab-release.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Release URL and payload helpers for install.sh.
+# Safe to source: no work at load time.
+#
+# FIRECRAB_RELEASE_REPO   GitHub owner/name (default SteelCrab/firecrab)
+# FIRECRAB_RELEASE_BASE   override the GitHub releases root (tests)
+
+firecrab_release_repo() {
+    printf '%s\n' "${FIRECRAB_RELEASE_REPO:-SteelCrab/firecrab}"
+}
+
+firecrab_release_base() {
+    if [ -n "${FIRECRAB_RELEASE_BASE:-}" ]; then
+        printf '%s\n' "$FIRECRAB_RELEASE_BASE"
+        return 0
+    fi
+    printf 'https://github.com/%s/releases\n' "$(firecrab_release_repo)"
+}
+
+firecrab_normalize_tag() {
+    local version=${1:-}
+    if [ -z "$version" ] || [ "$version" = latest ]; then
+        printf 'latest\n'
+        return 0
+    fi
+    case "$version" in
+        v*) printf '%s\n' "$version" ;;
+        *) printf 'v%s\n' "$version" ;;
+    esac
+}
+
+firecrab_host_arch() {
+    local machine=${1:-}
+    if [ -z "$machine" ]; then
+        machine=$(uname -m 2>/dev/null || printf 'unknown')
+    fi
+    case "$machine" in
+        x86_64|amd64) printf 'x86_64\n' ;;
+        aarch64|arm64) printf 'aarch64\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+firecrab_normalize_libc() {
+    local libc=${1:-}
+    case "$libc" in
+        gnu|glibc) printf 'gnu\n' ;;
+        musl) printf 'musl\n' ;;
+        "") return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+# musl hosts (Alpine) get the musl bundle; everyone else gets glibc/gnu.
+# FIRECRAB_LIBC or an explicit argument wins.
+firecrab_host_libc() {
+    local libc=${1:-${FIRECRAB_LIBC:-}}
+    if [ -n "$libc" ]; then
+        firecrab_normalize_libc "$libc"
+        return
+    fi
+    if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+        printf 'musl\n'
+        return 0
+    fi
+    if command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; then
+        printf 'musl\n'
+        return 0
+    fi
+    printf 'gnu\n'
+}
+
+firecrab_host_tarball() {
+    local arch libc
+    arch=$(firecrab_host_arch "${1:-}") || return 1
+    libc=$(firecrab_host_libc "${2:-}") || return 1
+    printf 'firecrab-host-%s-%s.tar.gz\n' "$arch" "$libc"
+}
+
+# Architectures and libcs the release host bundle is built for.
+# install.sh picks one of the four: {x86_64,aarch64} × {gnu,musl}.
+firecrab_supported_arches() {
+    printf '%s\n' x86_64 aarch64
+}
+
+firecrab_supported_libcs() {
+    printf '%s\n' gnu musl
+}
+
+firecrab_supported_host_tarballs() {
+    local arch libc
+    for arch in $(firecrab_supported_arches); do
+        for libc in $(firecrab_supported_libcs); do
+            printf 'firecrab-host-%s-%s.tar.gz\n' "$arch" "$libc"
+        done
+    done
+}
+
+# Read ELF e_machine (little-endian 64-bit) and map to a host arch name.
+firecrab_elf_arch() {
+    local path=$1
+    local class data machine
+    [ -f "$path" ] || return 1
+    class=$(od -An -t u1 -j 4 -N 1 -- "$path" | tr -d ' ')
+    data=$(od -An -t u1 -j 5 -N 1 -- "$path" | tr -d ' ')
+    [ "$class" = 2 ] && [ "$data" = 1 ] || return 1
+    machine=$(od -An -t u2 -j 18 -N 2 -- "$path" | tr -d ' ')
+    case "$machine" in
+        62) printf 'x86_64\n' ;;
+        183) printf 'aarch64\n' ;;
+        *) return 1 ;;
+    esac
+}
+
+firecrab_assert_binary_arch() {
+    local path=$1 want=$2
+    local got
+    got=$(firecrab_elf_arch "$path") || return 1
+    [ "$got" = "$want" ]
+}
+
+firecrab_release_asset_url() {
+    local version=$1 asset=$2
+    local tag base
+    tag=$(firecrab_normalize_tag "$version")
+    base=$(firecrab_release_base)
+    if [ "$tag" = latest ]; then
+        printf '%s/latest/download/%s\n' "$base" "$asset"
+    else
+        printf '%s/download/%s/%s\n' "$base" "$tag" "$asset"
+    fi
+}
+
+firecrab_install_curl_url() {
+    local version=${1:-latest}
+    printf 'curl -fsSL %s | bash\n' "$(firecrab_release_asset_url "$version" install.sh)"
+}
+
+firecrab_payload_mode() {
+    if [ -n "${1:-}" ]; then
+        printf 'dir\n'
+    else
+        printf 'release\n'
+    fi
+}
+
+# Print the path to use for `name`: --bin-dir wins when the file is there,
+# otherwise the already-installed copy. Missing on both sides is an error.
+firecrab_resolve_binary() {
+    local name=$1 src_dir=$2 dest_dir=$3
+    if [ -n "$src_dir" ] && [ -x "$src_dir/$name" ]; then
+        printf '%s\n' "$src_dir/$name"
+        return 0
+    fi
+    if [ -x "$dest_dir/$name" ]; then
+        printf '%s\n' "$dest_dir/$name"
+        return 0
+    fi
+    return 1
+}
+
+firecrab_verify_sha256() {
+    local sums=$1 file=$2
+    local name want got
+    name=$(basename -- "$file")
+    want=$(awk -v n="$name" '
+        $2 == n || $2 == "*" n || $2 ~ "/" n "$" { print $1; exit }
+    ' "$sums")
+    [ -n "$want" ] || return 1
+    got=$(sha256sum -- "$file" | awk '{ print $1 }')
+    [ "$want" = "$got" ]
+}

--- a/scripts/package-host-release.sh
+++ b/scripts/package-host-release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Assemble firecrab-host-$arch.tar.gz from musl binaries + dashboard + host files.
+set -euo pipefail
+
+usage() {
+    printf 'Usage: %s <arch> <bin-dir> <dashboard-dir> <output.tar.gz>\n' "$0" >&2
+    exit 2
+}
+
+[ $# -eq 4 ] || usage
+arch=$1
+bin_dir=$2
+dashboard_dir=$3
+output=$4
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck disable=SC1091
+. "$root/scripts/firecrab-release.sh"
+
+case "$arch" in
+    x86_64|aarch64) ;;
+    *) printf 'unsupported arch: %s\n' "$arch" >&2; exit 1 ;;
+esac
+
+[ -x "$bin_dir/firecrab-api" ] || { printf 'missing %s\n' "$bin_dir/firecrab-api" >&2; exit 1; }
+[ -x "$bin_dir/firecrab-net-helper" ] || { printf 'missing %s\n' "$bin_dir/firecrab-net-helper" >&2; exit 1; }
+if ! firecrab_assert_binary_arch "$bin_dir/firecrab-api" "$arch"; then
+    printf '%s is not a %s ELF (wrong architecture)\n' "$bin_dir/firecrab-api" "$arch" >&2
+    exit 1
+fi
+if ! firecrab_assert_binary_arch "$bin_dir/firecrab-net-helper" "$arch"; then
+    printf '%s is not a %s ELF (wrong architecture)\n' "$bin_dir/firecrab-net-helper" "$arch" >&2
+    exit 1
+fi
+[ -f "$dashboard_dir/index.html" ] || { printf 'missing %s/index.html\n' "$dashboard_dir" >&2; exit 1; }
+
+stage=$(mktemp -d)
+trap 'rm -rf "$stage"' EXIT
+mkdir -p "$stage/systemd" "$stage/dashboard"
+
+install -m 0755 "$bin_dir/firecrab-api" "$stage/firecrab-api"
+install -m 0755 "$bin_dir/firecrab-net-helper" "$stage/firecrab-net-helper"
+install -m 0755 "$root/scripts/firecracker-menual/extract-vmlinux" "$stage/extract-vmlinux"
+install -m 0755 "$root/scripts/firecracker-menual/extract-arm64-image" "$stage/extract-arm64-image"
+install -m 0755 "$root/scripts/firecrab-doctor.sh" "$stage/firecrab-doctor.sh"
+cp "$root/packaging/systemd/"*.service "$stage/systemd/"
+cp -a "$dashboard_dir/." "$stage/dashboard/"
+
+mkdir -p "$(dirname -- "$output")"
+tar -C "$stage" -czf "$output" \
+    firecrab-api firecrab-net-helper extract-vmlinux extract-arm64-image \
+    firecrab-doctor.sh systemd dashboard
+printf '%s\n' "$output"

--- a/scripts/test-firecrab-release.sh
+++ b/scripts/test-firecrab-release.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/firecrab-release.sh (URL, arch, binary pick).
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck source=firecrab-release.sh
+. "$ROOT/scripts/firecrab-release.sh"
+
+failed=0
+pass() { printf 'ok  %s\n' "$*"; }
+fail() { printf 'not ok  %s\n' "$*" >&2; failed=1; }
+
+expect_eq() {
+    local got=$1 want=$2 label=$3
+    if [ "$got" = "$want" ]; then
+        pass "$label"
+    else
+        fail "$label (got '$got', want '$want')"
+    fi
+}
+
+expect_fail() {
+    local label=$1
+    shift
+    if "$@" >/dev/null 2>&1; then
+        fail "$label (expected failure)"
+    else
+        pass "$label"
+    fi
+}
+
+# --- arch -------------------------------------------------------------------
+
+expect_eq "$(firecrab_host_arch x86_64)" x86_64 "arch x86_64"
+expect_eq "$(firecrab_host_arch amd64)" x86_64 "arch amd64"
+expect_eq "$(firecrab_host_arch aarch64)" aarch64 "arch aarch64"
+expect_eq "$(firecrab_host_arch arm64)" aarch64 "arch arm64"
+expect_fail "arch ppc64le rejected" firecrab_host_arch ppc64le
+
+expect_eq "$(firecrab_host_tarball x86_64 musl)" firecrab-host-x86_64-musl.tar.gz "tarball x86_64 musl"
+expect_eq "$(firecrab_host_tarball x86_64 gnu)" firecrab-host-x86_64-gnu.tar.gz "tarball x86_64 gnu"
+expect_eq "$(firecrab_host_tarball aarch64 musl)" firecrab-host-aarch64-musl.tar.gz "tarball aarch64 musl"
+expect_eq "$(firecrab_host_tarball aarch64 gnu)" firecrab-host-aarch64-gnu.tar.gz "tarball aarch64 gnu"
+expect_eq "$(firecrab_host_tarball x86_64 glibc)" firecrab-host-x86_64-gnu.tar.gz "glibc alias is gnu"
+expect_fail "unknown libc rejected" firecrab_host_tarball x86_64 dietlibc
+
+got=$(firecrab_supported_arches | tr '\n' ' ')
+expect_eq "${got% }" "x86_64 aarch64" "supported arches are x86_64 and aarch64"
+got=$(firecrab_supported_libcs | tr '\n' ' ')
+expect_eq "${got% }" "gnu musl" "supported libcs are gnu and musl"
+got=$(firecrab_supported_host_tarballs | tr '\n' ' ')
+expect_eq "${got% }" "firecrab-host-x86_64-gnu.tar.gz firecrab-host-x86_64-musl.tar.gz firecrab-host-aarch64-gnu.tar.gz firecrab-host-aarch64-musl.tar.gz" "four host bundles"
+
+expect_eq "$(firecrab_normalize_libc gnu)" gnu "normalize gnu"
+expect_eq "$(firecrab_normalize_libc glibc)" gnu "normalize glibc"
+expect_eq "$(firecrab_normalize_libc musl)" musl "normalize musl"
+expect_eq "$(firecrab_host_libc gnu)" gnu "explicit gnu"
+expect_eq "$(FIRECRAB_LIBC=musl firecrab_host_libc)" musl "FIRECRAB_LIBC override"
+expect_eq "$(FIRECRAB_LIBC=musl firecrab_host_tarball x86_64)" firecrab-host-x86_64-musl.tar.gz "env libc in tarball name"
+expect_fail "bad libc rejected" firecrab_host_libc dietlibc
+
+# --- URLs -------------------------------------------------------------------
+
+expect_eq \
+    "$(firecrab_release_asset_url latest install.sh)" \
+    "https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh" \
+    "latest install.sh URL"
+
+expect_eq \
+    "$(firecrab_release_asset_url v0.1.0 firecrab-host-x86_64.tar.gz)" \
+    "https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/firecrab-host-x86_64.tar.gz" \
+    "pinned host tarball URL"
+
+expect_eq \
+    "$(firecrab_release_asset_url 0.1.0 SHA256SUMS)" \
+    "https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/SHA256SUMS" \
+    "bare version gets v prefix"
+
+expect_eq \
+    "$(firecrab_release_asset_url "" firecrab-host-x86_64.tar.gz)" \
+    "https://github.com/SteelCrab/firecrab/releases/latest/download/firecrab-host-x86_64.tar.gz" \
+    "empty version is latest"
+
+expect_eq \
+    "$(FIRECRAB_RELEASE_REPO=example/fork firecrab_release_asset_url v0.1.0 install.sh)" \
+    "https://github.com/example/fork/releases/download/v0.1.0/install.sh" \
+    "FIRECRAB_RELEASE_REPO override"
+
+expect_eq \
+    "$(firecrab_install_curl_url latest)" \
+    "curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash" \
+    "latest curl install line"
+
+expect_eq \
+    "$(firecrab_install_curl_url v0.1.0)" \
+    "curl -fsSL https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/install.sh | bash" \
+    "pinned curl install line"
+
+# --- payload mode -----------------------------------------------------------
+
+expect_eq "$(firecrab_payload_mode "")" release "empty bin-dir is release"
+expect_eq "$(firecrab_payload_mode /tmp/bins)" dir "/tmp/bins is dir"
+
+# --- pick a binary from --bin-dir or keep the installed one ----------------
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/src" "$scratch/dst"
+printf 'src\n' >"$scratch/src/firecrab-api"
+printf 'old\n' >"$scratch/dst/firecrab-net-helper"
+chmod +x "$scratch/src/firecrab-api" "$scratch/dst/firecrab-net-helper"
+
+expect_eq \
+    "$(firecrab_resolve_binary firecrab-api "$scratch/src" "$scratch/dst")" \
+    "$scratch/src/firecrab-api" \
+    "prefer --bin-dir when the file exists"
+
+expect_eq \
+    "$(firecrab_resolve_binary firecrab-net-helper "$scratch/src" "$scratch/dst")" \
+    "$scratch/dst/firecrab-net-helper" \
+    "keep installed binary when --bin-dir omits it"
+
+expect_fail "missing both sides is an error" \
+    firecrab_resolve_binary firecrab-missing "$scratch/src" "$scratch/dst"
+
+# --- ELF arch of a release binary ------------------------------------------
+
+write_elf64() {
+    local dest=$1 machine=$2
+    python3 - "$dest" "$machine" <<'PY'
+import sys
+path, machine = sys.argv[1], int(sys.argv[2])
+header = bytearray(64)
+header[0:4] = b"\x7fELF"
+header[4] = 2  # ELFCLASS64
+header[5] = 1  # ELFDATA2LSB
+header[6] = 1
+header[18:20] = machine.to_bytes(2, "little")
+open(path, "wb").write(header)
+PY
+}
+
+scratch_elf=$(mktemp -d)
+write_elf64 "$scratch_elf/x86" 62
+write_elf64 "$scratch_elf/arm" 183
+printf 'not-elf\n' >"$scratch_elf/junk"
+
+expect_eq "$(firecrab_elf_arch "$scratch_elf/x86")" x86_64 "ELF e_machine 62 is x86_64"
+expect_eq "$(firecrab_elf_arch "$scratch_elf/arm")" aarch64 "ELF e_machine 183 is aarch64"
+expect_fail "non-ELF rejected" firecrab_elf_arch "$scratch_elf/junk"
+
+if firecrab_assert_binary_arch "$scratch_elf/x86" x86_64; then
+    pass "x86_64 binary accepted on x86_64"
+else
+    fail "x86_64 binary accepted on x86_64"
+fi
+expect_fail "x86_64 binary rejected on aarch64" \
+    firecrab_assert_binary_arch "$scratch_elf/x86" aarch64
+expect_fail "aarch64 binary rejected on x86_64" \
+    firecrab_assert_binary_arch "$scratch_elf/arm" x86_64
+rm -rf "$scratch_elf"
+
+# --- sha256 -----------------------------------------------------------------
+
+printf 'hello\n' >"$scratch/hello.txt"
+sum=$(sha256sum "$scratch/hello.txt")
+printf '%s\n' "$sum" >"$scratch/SHA256SUMS"
+if firecrab_verify_sha256 "$scratch/SHA256SUMS" "$scratch/hello.txt"; then
+    pass "sha256 of a matching file"
+else
+    fail "sha256 of a matching file"
+fi
+printf 'nope\n' >"$scratch/hello.txt"
+if firecrab_verify_sha256 "$scratch/SHA256SUMS" "$scratch/hello.txt" 2>/dev/null; then
+    fail "sha256 of a tampered file"
+else
+    pass "sha256 of a tampered file"
+fi
+
+if [ "$failed" -ne 0 ]; then
+    printf 'FAILED\n' >&2
+    exit 1
+fi
+printf 'all tests passed\n'
+exit 0

--- a/scripts/test-install-cli.sh
+++ b/scripts/test-install-cli.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# CLI contract for the binary installer. No root, no host changes.
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+failed=0
+pass() { printf 'ok  %s\n' "$*"; }
+fail() { printf 'not ok  %s\n' "$*" >&2; failed=1; }
+
+help=$("./install.sh" --help)
+
+if printf '%s\n' "$help" | grep -q -- '--bin-dir'; then
+    pass "--help mentions --bin-dir"
+else
+    fail "--help mentions --bin-dir"
+fi
+
+if printf '%s\n' "$help" | grep -q -- '--libc'; then
+    pass "--help mentions --libc"
+else
+    fail "--help mentions --libc"
+fi
+
+if printf '%s\n' "$help" | grep -q 'firecrab-host-x86_64-gnu.tar.gz' \
+    && printf '%s\n' "$help" | grep -q 'firecrab-host-aarch64-musl.tar.gz'; then
+    pass "--help lists gnu and musl host bundles"
+else
+    fail "--help lists gnu and musl host bundles"
+fi
+
+if printf '%s\n' "$help" | grep -q -- '--version'; then
+    pass "--help mentions --version"
+else
+    fail "--help mentions --version"
+fi
+
+if printf '%s\n' "$help" | grep -q 'releases/latest/download/install.sh'; then
+    pass "--help shows the release install URL"
+else
+    fail "--help shows the release install URL"
+fi
+
+if printf '%s\n' "$help" | grep -qi 'cargo build'; then
+    fail "--help must not tell operators to cargo build as the default"
+else
+    pass "--help does not default to cargo build"
+fi
+
+got=$("./install.sh" --print-install-url)
+want='curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash'
+if [ "$got" = "$want" ]; then
+    pass "--print-install-url (latest)"
+else
+    fail "--print-install-url (got '$got')"
+fi
+
+got=$("./install.sh" --version v0.1.0 --print-install-url)
+want='curl -fsSL https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/install.sh | bash'
+if [ "$got" = "$want" ]; then
+    pass "--print-install-url (v0.1.0)"
+else
+    fail "--print-install-url v0.1.0 (got '$got')"
+fi
+
+got=$("./install.sh" --version v0.1.0 --libc gnu --print-release-url)
+# shellcheck source=firecrab-release.sh
+. "$ROOT/scripts/firecrab-release.sh"
+want=$(firecrab_release_asset_url v0.1.0 "$(firecrab_host_tarball "" gnu)")
+if [ "$got" = "$want" ]; then
+    pass "--print-release-url matches helper"
+else
+    fail "--print-release-url (got '$got', want '$want')"
+fi
+
+check=$("./install.sh" --check 2>&1 || true)
+if printf '%s\n' "$check" | grep -q 'would download'; then
+    pass "--check talks about downloading a release"
+else
+    fail "--check talks about downloading a release"
+fi
+if printf '%s\n' "$check" | grep -q 'would install via rustup'; then
+    fail "--check must not offer rustup"
+else
+    pass "--check does not offer rustup"
+fi
+
+bindir=$(mktemp -d)
+check_dir=$("./install.sh" --bin-dir "$bindir" --check 2>&1 || true)
+rmdir "$bindir"
+if printf '%s\n' "$check_dir" | grep -q -- "$bindir"; then
+    pass "--check --bin-dir mentions the directory"
+else
+    fail "--check --bin-dir mentions the directory"
+fi
+
+# --- published install.sh (helpers inlined, tag baked) ----------------------
+
+pub=$(mktemp -d)
+"$ROOT/scripts/bake-install-sh.sh" v0.1.0 "$pub/install.sh"
+got=$("$pub/install.sh" --print-install-url)
+want='curl -fsSL https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/install.sh | bash'
+if [ "$got" = "$want" ]; then
+    pass "baked install.sh pins the tag in the curl URL"
+else
+    fail "baked install.sh pins the tag (got '$got')"
+fi
+
+# --- host tarball layout ----------------------------------------------------
+
+write_elf64() {
+    local dest=$1 machine=$2
+    python3 - "$dest" "$machine" <<'PY'
+import sys
+path, machine = sys.argv[1], int(sys.argv[2])
+header = bytearray(64)
+header[0:4] = b"\x7fELF"
+header[4] = 2
+header[5] = 1
+header[6] = 1
+header[18:20] = machine.to_bytes(2, "little")
+open(path, "wb").write(header)
+PY
+    chmod +x "$dest"
+}
+
+fake=$(mktemp -d)
+write_elf64 "$fake/firecrab-api" 62
+write_elf64 "$fake/firecrab-net-helper" 62
+mkdir -p "$fake/dist"
+printf '<html></html>\n' >"$fake/dist/index.html"
+"$ROOT/scripts/package-host-release.sh" x86_64 "$fake" "$fake/dist" "$fake/firecrab-host-x86_64.tar.gz" >/dev/null
+members=$(tar -tzf "$fake/firecrab-host-x86_64.tar.gz")
+for need in firecrab-api firecrab-net-helper extract-vmlinux extract-arm64-image \
+            firecrab-doctor.sh dashboard/index.html systemd/firecrab-api.service \
+            systemd/firecrab-net-helper.service; do
+    if printf '%s\n' "$members" | grep -qx -- "$need"; then
+        pass "host tarball contains $need"
+    else
+        fail "host tarball contains $need"
+    fi
+done
+wrong=$(mktemp -d)
+write_elf64 "$wrong/firecrab-api" 183
+write_elf64 "$wrong/firecrab-net-helper" 183
+mkdir -p "$wrong/dist"
+printf '<html></html>\n' >"$wrong/dist/index.html"
+if "$ROOT/scripts/package-host-release.sh" x86_64 "$wrong" "$wrong/dist" "$wrong/out.tar.gz" >/dev/null 2>&1; then
+    fail "host tarball rejects aarch64 bins packed as x86_64"
+else
+    pass "host tarball rejects aarch64 bins packed as x86_64"
+fi
+rm -rf "$pub" "$fake" "$wrong"
+
+if [ "$failed" -ne 0 ]; then
+    printf 'FAILED\n' >&2
+    exit 1
+fi
+printf 'all tests passed\n'

--- a/scripts/test_write_release_notes.py
+++ b/scripts/test_write_release_notes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/write-release-notes.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from textwrap import dedent
+
+
+def _load():
+    path = Path(__file__).with_name("write-release-notes.py")
+    spec = importlib.util.spec_from_file_location("write_release_notes", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+notes = _load()
+
+
+CHANGELOG = dedent(
+    """\
+    # Changelog
+
+    ## [0.1.0] - 2026-08-16
+
+    First public release.
+
+    ### Added
+
+    - Host install from a GitHub Release.
+
+    ### Changed
+
+    - None.
+
+    ### Deprecated
+
+    - None.
+
+    ### Fixed
+
+    - None.
+
+    ### Improved
+
+    - None.
+    """
+)
+
+
+class WriteReleaseNotesTests(unittest.TestCase):
+    def test_body_has_install_url_all_binaries_contributors_and_changelog(self) -> None:
+        body = notes.build_notes(
+            tag="v0.1.0",
+            changelog_text=CHANGELOG,
+            contributors=["SteelCrab", "kudala-bharani"],
+            repo="SteelCrab/firecrab",
+        )
+        self.assertIn(
+            "curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh | bash",
+            body,
+        )
+        self.assertIn(
+            "https://github.com/SteelCrab/firecrab/releases/download/v0.1.0/install.sh",
+            body,
+        )
+        for asset in (
+            "firecrab-host-x86_64-gnu.tar.gz",
+            "firecrab-host-x86_64-musl.tar.gz",
+            "firecrab-host-aarch64-gnu.tar.gz",
+            "firecrab-host-aarch64-musl.tar.gz",
+            "firecrab-x86_64-unknown-linux-gnu.tar.gz",
+            "firecrab-x86_64-unknown-linux-musl.tar.gz",
+            "firecrab-aarch64-unknown-linux-gnu.tar.gz",
+            "firecrab-aarch64-unknown-linux-musl.tar.gz",
+        ):
+            self.assertIn(asset, body)
+        self.assertIn("./install.sh --libc gnu", body)
+        self.assertIn("./install.sh --libc musl", body)
+        self.assertIn("SteelCrab", body)
+        self.assertIn("kudala-bharani", body)
+        self.assertIn("## Changelog", body)
+        self.assertIn("### Added", body)
+        self.assertIn("First public release.", body)
+
+    def test_skips_bot_contributors(self) -> None:
+        names = notes.filter_contributors(["SteelCrab", "dependabot[bot]", "github-actions[bot]"])
+        self.assertEqual(names, ["SteelCrab"])
+
+    def test_writes_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "notes.md"
+            notes.write_notes(
+                tag="v0.1.0",
+                changelog_text=CHANGELOG,
+                contributors=["SteelCrab"],
+                repo="SteelCrab/firecrab",
+                dest=out,
+            )
+            text = out.read_text(encoding="utf-8")
+            self.assertTrue(text.startswith("# firecrab 0.1.0\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify-release-binary.sh
+++ b/scripts/verify-release-binary.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Confirm a release binary matches the requested host arch and libc.
+# musl bundles must be static. gnu/glibc bundles are dynamically linked.
+set -euo pipefail
+
+[ $# -eq 2 ] || [ $# -eq 3 ] || {
+    printf 'Usage: %s <binary> <x86_64|aarch64> [gnu|musl]\n' "$0" >&2
+    exit 2
+}
+path=$1
+arch=$2
+libc=$(printf '%s\n' "${3:-musl}")
+
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+# shellcheck disable=SC1091
+. "$root/scripts/firecrab-release.sh"
+
+libc=$(firecrab_normalize_libc "$libc") \
+    || { printf 'libc must be gnu or musl\n' >&2; exit 1; }
+
+[ -x "$path" ] || { printf 'not executable: %s\n' "$path" >&2; exit 1; }
+firecrab_assert_binary_arch "$path" "$arch" \
+    || { printf '%s is not a %s ELF\n' "$path" "$arch" >&2; exit 1; }
+
+if command -v ldd >/dev/null 2>&1; then
+    linked=$(ldd -- "$path" 2>&1 || true)
+    case "$libc" in
+        musl)
+            if printf '%s\n' "$linked" | grep -q '=>'; then
+                printf '%s is dynamically linked; the musl host bundle must be static\n' "$path" >&2
+                printf '%s\n' "$linked" >&2
+                exit 1
+            fi
+            ;;
+        gnu)
+            if ! printf '%s\n' "$linked" | grep -q 'libc.so.6'; then
+                printf '%s is not a glibc binary (expected libc.so.6)\n' "$path" >&2
+                printf '%s\n' "$linked" >&2
+                exit 1
+            fi
+            ;;
+    esac
+fi
+
+printf '%s: %s %s\n' "$path" "$arch" "$libc"

--- a/scripts/write-release-notes.py
+++ b/scripts/write-release-notes.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Build GitHub Release notes: install URL, every binary, contributors, changelog."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+HOST_BUNDLES = (
+    ("firecrab-host-x86_64-gnu.tar.gz", "Linux x86_64, glibc (Debian, Fedora, Arch, openSUSE, Ubuntu)"),
+    ("firecrab-host-x86_64-musl.tar.gz", "Linux x86_64, musl (Alpine; static)"),
+    ("firecrab-host-aarch64-gnu.tar.gz", "Linux aarch64 / arm64, glibc"),
+    ("firecrab-host-aarch64-musl.tar.gz", "Linux aarch64 / arm64, musl (static)"),
+)
+
+RAW_TARBALLS = (
+    ("firecrab-x86_64-unknown-linux-gnu.tar.gz", "x86_64 glibc API + helper only"),
+    ("firecrab-x86_64-unknown-linux-musl.tar.gz", "x86_64 static musl API + helper only"),
+    ("firecrab-aarch64-unknown-linux-gnu.tar.gz", "aarch64 glibc API + helper only"),
+    ("firecrab-aarch64-unknown-linux-musl.tar.gz", "aarch64 static musl API + helper only"),
+)
+
+
+def _load_changelog():
+    path = Path(__file__).with_name("check-changelog.py")
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("check_changelog", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def filter_contributors(names: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for name in names:
+        cleaned = name.strip()
+        if not cleaned:
+            continue
+        lower = cleaned.lower()
+        if "bot" in lower or lower.endswith("[bot]"):
+            continue
+        if cleaned in seen:
+            continue
+        seen.add(cleaned)
+        out.append(cleaned)
+    return out
+
+
+def git_contributors(repo: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), "shortlog", "-sn", "--all"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    names: list[str] = []
+    for line in result.stdout.splitlines():
+        parts = line.strip().split(None, 1)
+        if len(parts) == 2:
+            names.append(parts[1])
+    return filter_contributors(names)
+
+
+def build_notes(
+    *,
+    tag: str,
+    changelog_text: str,
+    contributors: list[str],
+    repo: str,
+) -> str:
+    version = tag[1:] if tag.startswith("v") else tag
+    pinned = tag if tag.startswith("v") else f"v{tag}"
+    latest_install = (
+        f"https://github.com/{repo}/releases/latest/download/install.sh"
+    )
+    pinned_install = (
+        f"https://github.com/{repo}/releases/download/{pinned}/install.sh"
+    )
+    asset = f"https://github.com/{repo}/releases/download/{pinned}"
+
+    changelog = _load_changelog()
+    changelog_block = changelog.extract_notes(changelog_text, pinned)
+
+    lines: list[str] = [
+        f"# firecrab {version}",
+        "",
+        "## Install",
+        "",
+        "One command on a Linux host. The script detects `x86_64` or `aarch64`",
+        "and `gnu` (glibc) or `musl`, then installs that host bundle.",
+        "",
+        "```sh",
+        f"curl -fsSL {latest_install} | bash",
+        "```",
+        "",
+        "Pin this release:",
+        "",
+        "```sh",
+        f"curl -fsSL {pinned_install} | bash",
+        "```",
+        "",
+        "Force a libc when auto-detect is wrong:",
+        "",
+        "```sh",
+        "./install.sh --libc gnu    # glibc (Debian, Fedora, Arch, openSUSE, Ubuntu)",
+        "./install.sh --libc musl   # Alpine / static musl",
+        "```",
+        "",
+        "Local binaries you already built:",
+        "",
+        "```sh",
+        "./install.sh --bin-dir target/release --dashboard-dir firecrab-frontend/dist",
+        "```",
+        "",
+        "## Binaries",
+        "",
+        "Host bundles include `firecrab-api`, `firecrab-net-helper`, the dashboard,",
+        "systemd units, and `firecrab-doctor`. `install.sh` downloads one of these.",
+        "",
+        "| File | Installs on |",
+        "| --- | --- |",
+    ]
+    for name, who in HOST_BUNDLES:
+        lines.append(f"| [`{name}`]({asset}/{name}) | {who} |")
+    lines.extend(
+        [
+            "",
+            "API + helper only (no dashboard or units):",
+            "",
+            "| File | Contents |",
+            "| --- | --- |",
+        ]
+    )
+    for name, who in RAW_TARBALLS:
+        lines.append(f"| [`{name}`]({asset}/{name}) | {who} |")
+    lines.extend(
+        [
+            "",
+            f"Checksums: [`SHA256SUMS`]({asset}/SHA256SUMS).",
+            f"Standalone installer: [`install.sh`]({pinned_install}).",
+            "",
+            "## Contributors",
+            "",
+        ]
+    )
+    people = filter_contributors(contributors)
+    if people:
+        for name in people:
+            lines.append(f"- {name}")
+    else:
+        lines.append("- See the GitHub contributors graph.")
+    lines.extend(["", "## Changelog", "", changelog_block.rstrip(), ""])
+    return "\n".join(lines)
+
+
+def write_notes(
+    *,
+    tag: str,
+    changelog_text: str,
+    contributors: list[str],
+    repo: str,
+    dest: Path,
+) -> None:
+    dest.write_text(
+        build_notes(
+            tag=tag,
+            changelog_text=changelog_text,
+            contributors=contributors,
+            repo=repo,
+        ),
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="git tag, e.g. v0.1.0")
+    parser.add_argument("--out", required=True, type=Path)
+    parser.add_argument("--repo", default="SteelCrab/firecrab")
+    parser.add_argument(
+        "--contributors-file",
+        type=Path,
+        help="one name per line; default is git shortlog",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=REPO / "CHANGELOG.md",
+    )
+    args = parser.parse_args(argv)
+
+    if args.contributors_file:
+        contributors = args.contributors_file.read_text(encoding="utf-8").splitlines()
+    else:
+        contributors = git_contributors(REPO)
+
+    write_notes(
+        tag=args.tag,
+        changelog_text=args.changelog.read_text(encoding="utf-8"),
+        contributors=contributors,
+        repo=args.repo,
+        dest=args.out,
+    )
+    print(args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- `install.sh` downloads `firecrab-host-<arch>-<gnu|musl>.tar.gz` (glibc or musl, x86_64 or aarch64).
- Release artifacts include all four host bundles plus the four raw binary tarballs.
- GitHub Release notes list the install URL, every binary, contributors, and CHANGELOG.

## Test plan
- [x] `bash scripts/test-firecrab-release.sh`
- [x] `bash scripts/test-install-cli.sh`
- [x] `python3 -m unittest scripts/test_write_release_notes.py`
- [x] `python3 scripts/check-changelog.py` and `check-doc-links.py`
- [ ] CI install job (`--bin-dir`)
- [ ] Release workflow builds and smokes gnu + musl on both arches