### PR TITLE
feat(cli): add firecrab doctor as the first PATH command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
       - name: shellcheck
         run: |
           shellcheck install.sh scripts/firecrab-doctor.sh \
-            scripts/firecrab-release.sh scripts/package-host-release.sh \
+            scripts/firecrab.sh scripts/firecrab-release.sh scripts/package-host-release.sh \
             scripts/bake-install-sh.sh scripts/ci-prepare-install-payload.sh \
             scripts/verify-release-binary.sh \
             scripts/build-m2images.sh scripts/package-m2images.sh \
@@ -190,11 +190,13 @@ jobs:
         run: |
           bash -n install.sh
           bash -n scripts/firecrab-doctor.sh
+          bash -n scripts/firecrab.sh
           bash scripts/test-firecrab-release.sh
           bash scripts/test-install-cli.sh
           ./install.sh --help
           ./install.sh --check
           test ! -e /var/lib/firecrab || { echo "--check created the data directory"; exit 1; }
+          ./scripts/firecrab.sh --help
           ./scripts/firecrab-doctor.sh --help
           # Bare runner will typically FAIL helper socket / images; doctor must
           # still exit 0 or 1 (not crash) and leave the host untouched.
@@ -237,6 +239,7 @@ jobs:
           sudo stat -c '%U %G %a' /run/firecrab/net-helper.sock | tee /dev/stderr | grep -qx 'root firecrab 660'
           id -nG firecrab | tr ' ' '\n' | grep -qx kvm
           test -x /usr/local/bin/firecrab-doctor
+          test -x /usr/local/bin/firecrab
 
       - name: Doctor after install
         # Runtime host path must be clean. Run from the unit WorkingDirectory
@@ -331,6 +334,7 @@ jobs:
           ! systemctl is-active --quiet firecrab-api
           test ! -e /etc/systemd/system/firecrab-api.service
           test ! -e /usr/local/bin/firecrab-doctor
+          test ! -e /usr/local/bin/firecrab
           test -d /var/lib/firecrab
           sudo ./install.sh --uninstall --purge
           test ! -e /var/lib/firecrab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The guest-boot half needs KVM, Firecracker, and `./scripts/dev-net-helper.sh`; s
 ```sh
 python3 scripts/check-doc-links.py
 python3 scripts/check-changelog.py
-shellcheck install.sh scripts/firecrab-doctor.sh scripts/firecrab-release.sh
+shellcheck install.sh scripts/firecrab-doctor.sh scripts/firecrab.sh scripts/firecrab-release.sh
 bash scripts/test-firecrab-release.sh
 bash scripts/test-install-cli.sh
 ```

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ PAYLOAD_BIN=
 PAYLOAD_UNITS=
 PAYLOAD_EXTRACT=
 PAYLOAD_DOCTOR=
+PAYLOAD_CLI=
 PAYLOAD_DASHBOARD=
 
 # BEGIN RELEASE_HELPERS
@@ -400,6 +401,7 @@ resolve_payload() {
         PAYLOAD_UNITS=$REPO_ROOT/packaging/systemd
         PAYLOAD_EXTRACT=$REPO_ROOT/scripts/firecracker-menual
         PAYLOAD_DOCTOR=$REPO_ROOT/scripts/firecrab-doctor.sh
+        PAYLOAD_CLI=$REPO_ROOT/scripts/firecrab.sh
         if [ -n "$DASHBOARD_DIR" ]; then
             PAYLOAD_DASHBOARD=$DASHBOARD_DIR
         elif [ -f "$REPO_ROOT/firecrab-frontend/dist/index.html" ]; then
@@ -415,6 +417,7 @@ resolve_payload() {
     PAYLOAD_UNITS=$PAYLOAD_ROOT/systemd
     PAYLOAD_EXTRACT=$PAYLOAD_ROOT
     PAYLOAD_DOCTOR=$PAYLOAD_ROOT/firecrab-doctor.sh
+    PAYLOAD_CLI=$PAYLOAD_ROOT/firecrab.sh
     PAYLOAD_DASHBOARD=$PAYLOAD_ROOT/dashboard
 }
 
@@ -523,10 +526,13 @@ install_binaries() {
             "$PAYLOAD_EXTRACT/$helper" "$LIBDIR/$helper"
     done
     [ -f "$PAYLOAD_DOCTOR" ] || die "missing $PAYLOAD_DOCTOR"
+    [ -f "$PAYLOAD_CLI" ] || die "missing $PAYLOAD_CLI"
     $SUDO install -d -o root -g root -m 0755 "$PREFIX/bin"
     $SUDO install -o root -g root -m 0755 "$PAYLOAD_DOCTOR" \
         "$PREFIX/bin/firecrab-doctor"
-    log "binaries installed to $LIBDIR (doctor → $PREFIX/bin/firecrab-doctor)"
+    $SUDO install -o root -g root -m 0755 "$PAYLOAD_CLI" \
+        "$PREFIX/bin/firecrab"
+    log "binaries installed to $LIBDIR (cli → $PREFIX/bin/firecrab, doctor → $PREFIX/bin/firecrab-doctor)"
 
     [ "$WITH_FRONTEND" -eq 1 ] || return 0
     if [ -n "$PAYLOAD_DASHBOARD" ] && [ -f "$PAYLOAD_DASHBOARD/index.html" ]; then
@@ -847,7 +853,7 @@ do_uninstall() {
     log "units removed"
 
     $SUDO rm -f "$LIBDIR/firecrab-api" "$LIBDIR/firecrab-net-helper"
-    $SUDO rm -f "$PREFIX/bin/firecrab-doctor"
+    $SUDO rm -f "$PREFIX/bin/firecrab-doctor" "$PREFIX/bin/firecrab"
     $SUDO rm -rf "$SHAREDIR/dashboard"
     $SUDO rmdir --ignore-fail-on-non-empty "$LIBDIR" "$SHAREDIR" 2>/dev/null || true
     log "binaries and dashboard removed"

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -93,6 +93,7 @@ DATADIR=/srv/firecrab PREFIX=/opt ./install.sh
 
 ```sh
 systemctl status firecrab-net-helper firecrab-api
+firecrab doctor
 firecrab-doctor
 curl -s http://127.0.0.1:3000/api/vms
 curl -s http://127.0.0.1:3000/api/micro-networks

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -20,10 +20,10 @@ journalctl -u firecrab-api -f
 journalctl -u firecrab-net-helper -f
 ```
 
-Run the host doctor after a failure.
+Run `firecrab doctor` (or `firecrab-doctor`) after a failure.
 
 ```sh
-firecrab-doctor
+firecrab doctor
 ```
 
 ## API configuration

--- a/public-docs/storage.md
+++ b/public-docs/storage.md
@@ -50,7 +50,7 @@ Other installed and runtime files live outside `/var/lib/firecrab`.
 | `/etc/firecrab/api.env` | Operator-owned API configuration |
 | `/etc/systemd/system/firecrab-*.service` | Installed systemd units |
 | `/usr/local/lib/firecrab/` | API, network helper, and `extract-vmlinux` |
-| `/usr/local/bin/firecrab-doctor` | Host diagnostic command |
+| `/usr/local/bin/firecrab`, `firecrab-doctor` | Host diagnostic commands |
 | `/usr/local/share/firecrab/dashboard/` | Installed dashboard assets |
 | `/run/firecrab/` | Ephemeral helper socket, dnsmasq configuration, PID, hosts, and leases |
 | systemd journal and Linux networking state | Service logs, bridges, TAPs, nftables, and live processes |

--- a/public-docs/troubleshooting.md
+++ b/public-docs/troubleshooting.md
@@ -6,7 +6,7 @@ Start with the read-only host doctor.
 ./install.sh --doctor
 ```
 
-Use `firecrab-doctor` on an installed host.
+Use `firecrab doctor` on an installed host.
 
 ## Basic status
 

--- a/scripts/firecrab-doctor.sh
+++ b/scripts/firecrab-doctor.sh
@@ -7,6 +7,7 @@
 #
 # Usage: ./scripts/firecrab-doctor.sh [--digest] [-h|--help]
 #        ./install.sh --doctor
+#        firecrab doctor   (after install)
 #        firecrab-doctor   (after install)
 #
 # See public-docs/troubleshooting.md

--- a/scripts/firecrab.sh
+++ b/scripts/firecrab.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# firecrab PATH command. Only subcommand is doctor — execs firecrab-doctor.
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE'
+Usage: firecrab <command> [args]
+
+  doctor              diagnose host readiness (forwards to firecrab-doctor)
+  -h, --help          this text
+USAGE
+}
+
+die() { printf 'xx  %s\n' "$*" >&2; exit 1; }
+
+# Sibling-first: $PREFIX/bin/firecrab pairs with $PREFIX/bin/firecrab-doctor;
+# checkout and the host tarball ship firecrab.sh next to firecrab-doctor.sh.
+resolve_doctor() {
+    local self
+    self=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+    if [ -x "$self/firecrab-doctor" ]; then
+        printf '%s\n' "$self/firecrab-doctor"
+        return 0
+    fi
+    if [ -x "$self/firecrab-doctor.sh" ]; then
+        printf '%s\n' "$self/firecrab-doctor.sh"
+        return 0
+    fi
+    if command -v firecrab-doctor >/dev/null 2>&1; then
+        command -v firecrab-doctor
+        return 0
+    fi
+    die "missing firecrab-doctor (run from a checkout, or install first)"
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    "")
+        usage >&2
+        exit 2
+        ;;
+    doctor)
+        shift
+        exec "$(resolve_doctor)" "$@"
+        ;;
+    *)
+        usage >&2
+        printf 'unknown command: %s\n' "$1" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/package-host-release.sh
+++ b/scripts/package-host-release.sh
@@ -43,11 +43,12 @@ install -m 0755 "$bin_dir/firecrab-net-helper" "$stage/firecrab-net-helper"
 install -m 0755 "$root/scripts/firecracker-menual/extract-vmlinux" "$stage/extract-vmlinux"
 install -m 0755 "$root/scripts/firecracker-menual/extract-arm64-image" "$stage/extract-arm64-image"
 install -m 0755 "$root/scripts/firecrab-doctor.sh" "$stage/firecrab-doctor.sh"
+install -m 0755 "$root/scripts/firecrab.sh" "$stage/firecrab.sh"
 cp "$root/packaging/systemd/"*.service "$stage/systemd/"
 cp -a "$dashboard_dir/." "$stage/dashboard/"
 
 mkdir -p "$(dirname -- "$output")"
 tar -C "$stage" -czf "$output" \
     firecrab-api firecrab-net-helper extract-vmlinux extract-arm64-image \
-    firecrab-doctor.sh systemd dashboard
+    firecrab-doctor.sh firecrab.sh systemd dashboard
 printf '%s\n' "$output"

--- a/scripts/test-install-cli.sh
+++ b/scripts/test-install-cli.sh
@@ -133,7 +133,7 @@ printf '<html></html>\n' >"$fake/dist/index.html"
 "$ROOT/scripts/package-host-release.sh" x86_64 "$fake" "$fake/dist" "$fake/firecrab-host-x86_64.tar.gz" >/dev/null
 members=$(tar -tzf "$fake/firecrab-host-x86_64.tar.gz")
 for need in firecrab-api firecrab-net-helper extract-vmlinux extract-arm64-image \
-            firecrab-doctor.sh dashboard/index.html systemd/firecrab-api.service \
+            firecrab-doctor.sh firecrab.sh dashboard/index.html systemd/firecrab-api.service \
             systemd/firecrab-net-helper.service; do
     if printf '%s\n' "$members" | grep -qx -- "$need"; then
         pass "host tarball contains $need"
@@ -152,6 +152,38 @@ else
     pass "host tarball rejects aarch64 bins packed as x86_64"
 fi
 rm -rf "$pub" "$fake" "$wrong"
+
+# --- firecrab dispatcher (unprivileged) ------------------------------------
+
+cli_help=$("./scripts/firecrab.sh" --help)
+if printf '%s\n' "$cli_help" | grep -q doctor; then
+    pass "firecrab --help mentions doctor"
+else
+    fail "firecrab --help mentions doctor"
+fi
+
+rc=0
+./scripts/firecrab.sh >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "firecrab with no args exits 2"
+else
+    fail "firecrab with no args exits 2 (got $rc)"
+fi
+
+rc=0
+./scripts/firecrab.sh nope >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 2 ]; then
+    pass "firecrab unknown command exits 2"
+else
+    fail "firecrab unknown command exits 2 (got $rc)"
+fi
+
+doctor_help=$("./scripts/firecrab.sh" doctor --help)
+if printf '%s\n' "$doctor_help" | grep -q 'Usage: firecrab-doctor'; then
+    pass "firecrab doctor --help prints Usage: firecrab-doctor"
+else
+    fail "firecrab doctor --help prints Usage: firecrab-doctor"
+fi
 
 if [ "$failed" -ne 0 ]; then
     printf 'FAILED\n' >&2

--- a/scripts/write-release-notes.py
+++ b/scripts/write-release-notes.py
@@ -123,7 +123,7 @@ def build_notes(
         "## Binaries",
         "",
         "Host bundles include `firecrab-api`, `firecrab-net-helper`, the dashboard,",
-        "systemd units, and `firecrab-doctor`. `install.sh` downloads one of these.",
+        "systemd units, `firecrab-doctor`, and `firecrab`. `install.sh` downloads one of these.",
         "",
         "| File | Installs on |",
         "| --- | --- |",


### PR DESCRIPTION
## Summary
- Add `scripts/firecrab.sh` and install it as `$PREFIX/bin/firecrab`.
- The only subcommand is `doctor`; it execs the existing `firecrab-doctor`.
- Keep `firecrab-doctor` as the check engine and the installed alias.
- Ship `firecrab.sh` in the host tarball; `install.sh` uninstalls both binaries.

## Test plan
- [x] `bash scripts/test-install-cli.sh`
- [x] `bash -n scripts/firecrab.sh`
- [x] `python3 scripts/check-doc-links.py`
- [x] `python3 scripts/check-changelog.py`
- [ ] CI install job (`shellcheck`, `--bin-dir` install, `test -x /usr/local/bin/firecrab`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `firecrab` command-line wrapper with support for `firecrab doctor`.
  - Host release packages now include the standalone `firecrab` command.
  - Installation and uninstallation now manage the `firecrab` executable automatically.

- **Documentation**
  - Updated installation, operations, storage, and troubleshooting guidance to use `firecrab doctor`.
  - Documented the command in post-installation verification and usage instructions.

- **Tests**
  - Expanded installer validation for command help, error handling, doctor usage, installation, and removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->