### PR TITLE
fix(release): stop smoke hanging on firecrab-api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,7 @@ jobs:
             scripts/firecrab-release.sh scripts/package-host-release.sh \
             scripts/bake-install-sh.sh scripts/ci-prepare-install-payload.sh \
             scripts/verify-release-binary.sh \
+            scripts/smoke-release-exec.sh scripts/test-smoke-release-exec.sh \
             scripts/build-m2images.sh scripts/package-m2images.sh \
             scripts/publish-m2images-r2.sh \
             scripts/firecracker-menual/install-alpine-rootfs.sh \
@@ -192,6 +193,7 @@ jobs:
           bash -n scripts/firecrab-doctor.sh
           bash scripts/test-firecrab-release.sh
           bash scripts/test-install-cli.sh
+          bash scripts/test-smoke-release-exec.sh
           ./install.sh --help
           ./install.sh --check
           test ! -e /var/lib/firecrab || { echo "--check created the data directory"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
     name: Smoke x86_64 gnu on ${{ matrix.image }}
     needs: package-host
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     container: ${{ matrix.image }}
     strategy:
       fail-fast: false
@@ -190,17 +191,22 @@ jobs:
           - opensuse/tumbleweed
     steps:
       - name: Unpack tools
+        # git: actions/checkout in the container. timeout(1): smoke-release-exec.sh.
         run: |
           if command -v apt-get >/dev/null; then
-            apt-get update -qq && apt-get install -y -qq tar gzip
+            apt-get update -qq && apt-get install -y -qq tar gzip git ca-certificates coreutils
           elif command -v dnf >/dev/null; then
-            dnf install -y -q tar gzip
+            dnf install -y -q tar gzip git ca-certificates
           elif command -v pacman >/dev/null; then
-            pacman -Sy --noconfirm --needed tar gzip
+            pacman -Sy --noconfirm --needed tar gzip git ca-certificates
           elif command -v zypper >/dev/null; then
-            zypper --non-interactive install --no-recommends tar gzip
+            zypper --non-interactive install --no-recommends tar gzip git ca-certificates
           fi
         shell: sh -e {0}
+
+      - uses: actions/checkout@v7
+        with:
+          path: src
 
       - uses: actions/download-artifact@v8
         with:
@@ -208,25 +214,27 @@ jobs:
           path: bundle
 
       - name: glibc binary execs
+        # Do not wait for firecrab-api to exit — it is a server. The v0.1.0
+        # retag sat here for 6h on fedora/arch/tumbleweed and never published.
         run: |
-          tar -xzf bundle/firecrab-host-x86_64-gnu.tar.gz
-          set +e
-          ./firecrab-api
-          rc=$?
-          set -e
-          printf 'firecrab-api rc=%s\n' "$rc"
-          test "$rc" -ne 126
-          test "$rc" -ne 127
+          mkdir -p unpacked
+          tar -xzf bundle/firecrab-host-x86_64-gnu.tar.gz -C unpacked
+          src/scripts/smoke-release-exec.sh -- unpacked/firecrab-api
 
   smoke-host-aarch64:
     name: Smoke aarch64 ${{ matrix.libc }}
     needs: package-host
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
         libc: [gnu, musl]
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src
+
       - uses: actions/download-artifact@v8
         with:
           name: firecrab-host-aarch64-${{ matrix.libc }}
@@ -234,20 +242,20 @@ jobs:
 
       - name: Binary execs
         run: |
-          tar -xzf bundle/firecrab-host-aarch64-${{ matrix.libc }}.tar.gz
-          set +e
-          ./firecrab-api
-          rc=$?
-          set -e
-          printf 'firecrab-api rc=%s\n' "$rc"
-          test "$rc" -ne 126
-          test "$rc" -ne 127
+          mkdir -p unpacked
+          tar -xzf bundle/firecrab-host-aarch64-${{ matrix.libc }}.tar.gz -C unpacked
+          src/scripts/smoke-release-exec.sh -- unpacked/firecrab-api
 
   smoke-host-alpine:
     name: Smoke x86_64 musl on alpine
     needs: package-host
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
+      - uses: actions/checkout@v7
+        with:
+          path: src
+
       - uses: actions/download-artifact@v8
         with:
           name: firecrab-host-x86_64-musl
@@ -255,14 +263,10 @@ jobs:
 
       - name: musl binary execs inside Alpine
         run: |
-          tar -xzf bundle/firecrab-host-x86_64-musl.tar.gz
-          set +e
-          docker run --rm -v "$PWD:/b:ro" alpine:3.21 /b/firecrab-api
-          rc=$?
-          set -e
-          printf 'firecrab-api rc=%s\n' "$rc"
-          test "$rc" -ne 126
-          test "$rc" -ne 127
+          mkdir -p unpacked
+          tar -xzf bundle/firecrab-host-x86_64-musl.tar.gz -C unpacked
+          src/scripts/smoke-release-exec.sh -- \
+            docker run --rm -v "$PWD/unpacked:/b:ro" alpine:3.21 /b/firecrab-api
 
   create-release:
     name: Publish GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ network helper.
 - NAT uplink fallback in the dashboard is parenthesized so Vite accepts it.
 - Image catalog architecture must be stated explicitly, including on
   arm64 installer doctor paths.
+- Release smoke no longer waits for `firecrab-api` to exit, so a binary
+  that actually starts cannot stall Publish GitHub Release for six hours.
 
 ### Improved
 

--- a/scripts/smoke-release-exec.sh
+++ b/scripts/smoke-release-exec.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Prove a release binary can exec without waiting for it to exit.
+#
+# firecrab-api is a long-lived HTTP server. The v0.1.0 tag run hung for the
+# 6h job limit on every distro where the ELF actually started. 126/127 mean
+# the loader could not run it; any other status (including timeout) means it
+# exec'd.
+set -u
+
+usage() {
+    printf 'Usage: %s [--seconds N] -- <command> [args...]\n' "${0##*/}" >&2
+    exit 2
+}
+
+seconds=8
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --seconds)
+            [ $# -ge 2 ] || usage
+            seconds=$2
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+[ $# -ge 1 ] || usage
+
+case "$seconds" in
+    ''|*[!0-9]*|0) printf 'seconds must be a positive integer\n' >&2; exit 2 ;;
+esac
+
+if ! command -v timeout >/dev/null 2>&1; then
+    printf 'timeout(1) is required\n' >&2
+    exit 1
+fi
+
+set +e
+# -k: SIGKILL if the server ignores TERM, so this cannot sit out a 6h job.
+timeout -k 2 "$seconds" "$@"
+rc=$?
+set -e
+
+printf 'smoke-release-exec rc=%s\n' "$rc"
+
+# 125: timeout(1) itself failed to start the command.
+# 126: found but not executable. 127: not found / bad interpreter.
+if [ "$rc" -eq 125 ] || [ "$rc" -eq 126 ] || [ "$rc" -eq 127 ]; then
+    printf 'command is not executable (rc=%s)\n' "$rc" >&2
+    exit 1
+fi
+exit 0

--- a/scripts/test-smoke-release-exec.sh
+++ b/scripts/test-smoke-release-exec.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Unit tests for scripts/smoke-release-exec.sh.
+# firecrab-api is a long-lived server: a process that is still running when
+# the budget expires must pass. 126/127 (cannot exec) must fail.
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT=$ROOT/scripts/smoke-release-exec.sh
+
+failed=0
+pass() { printf 'ok  %s\n' "$*"; }
+fail() { printf 'not ok  %s\n' "$*" >&2; failed=1; }
+
+expect_ok() {
+    local label=$1
+    shift
+    if "$@" >/dev/null 2>&1; then
+        pass "$label"
+    else
+        fail "$label (expected success)"
+    fi
+}
+
+expect_fail() {
+    local label=$1
+    shift
+    if "$@" >/dev/null 2>&1; then
+        fail "$label (expected failure)"
+    else
+        pass "$label"
+    fi
+}
+
+[ -x "$SCRIPT" ] || {
+    printf 'not ok  smoke-release-exec.sh missing or not executable\n' >&2
+    exit 1
+}
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+printf '#!/bin/sh\nexit 1\n' >"$scratch/exits-one"
+chmod +x "$scratch/exits-one"
+printf '#!/bin/sh\nsleep 30\n' >"$scratch/hangs"
+chmod +x "$scratch/hangs"
+printf 'not a program\n' >"$scratch/not-exec"
+
+# The hang that stalled v0.1.0: a server that never exits must not block
+# the caller past --seconds, and must be treated as an executable success.
+start=$(date +%s)
+expect_ok "still-running process is success" \
+    "$SCRIPT" --seconds 1 -- "$scratch/hangs"
+elapsed=$(( $(date +%s) - start ))
+if [ "$elapsed" -lt 8 ]; then
+    pass "hang returns before 8s (took ${elapsed}s)"
+else
+    fail "hang took ${elapsed}s; timeout did not fire"
+fi
+
+expect_ok "immediate non-zero exit is success (binary ran)" \
+    "$SCRIPT" --seconds 2 -- "$scratch/exits-one"
+
+expect_fail "missing command is failure" \
+    "$SCRIPT" --seconds 2 -- "$scratch/does-not-exist"
+
+expect_fail "non-executable file is failure" \
+    "$SCRIPT" --seconds 2 -- "$scratch/not-exec"
+
+expect_fail "no command is usage error" \
+    "$SCRIPT" --seconds 1
+
+if [ "$failed" -ne 0 ]; then
+    exit 1
+fi
+printf 'all smoke-release-exec tests passed\n'


### PR DESCRIPTION
## Summary

The `v0.1.0` retag ([run 31933643139](https://github.com/SteelCrab/firecrab/actions/runs/31933643139)) built every host bundle, then sat in smoke for the 6h job limit. `create-release` never ran, so the GitHub Release is missing.

Smoke ran `./firecrab-api` and waited for it to exit. That binary is a server. On fedora/arch/tumbleweed/alpine it printed `listening on http://127.0.0.1:3000` and never returned.

`scripts/smoke-release-exec.sh` now caps the process with `timeout -k 2` and treats a still-running process as success (same as a quick non-126/127 exit). Jobs also have `timeout-minutes: 10`.

## Test plan

- [x] `bash scripts/test-smoke-release-exec.sh`
- [x] `bash scripts/test-firecrab-release.sh`
- [x] `shellcheck scripts/smoke-release-exec.sh scripts/test-smoke-release-exec.sh`
- [x] `python3 scripts/check-changelog.py`
- [ ] PR **Release Build** smoke jobs finish in minutes, not hours
- [ ] After merge, retag `v0.1.0` so Publish GitHub Release runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release smoke tests that verify packaged commands can start successfully without waiting for long-running processes to exit.
  - Added validation for executable, missing, non-executable, and failing commands.

- **Bug Fixes**
  - Prevented startup-capable binaries from blocking release publication.

- **Tests**
  - Added automated coverage for timeout handling, argument validation, and execution failures.
  - Improved CI checks for release smoke-test scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->