### PR TITLE
feat(oci): fetch a dedicated import kernel from the MicroRegistry

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ bash scripts/test-firecrab-release.sh
 bash scripts/test-install-cli.sh
 ```
 
-`check-doc-links.py` enforces published docs rules: English only, max **170 lines** per `public-docs/**/*.md` file except `api.md`, valid relative links, and no stale `docs/` paths in tracked sources.
+`check-doc-links.py` enforces published docs rules: English only, max **300 lines** per `public-docs/**/*.md` file except `api.md`, valid relative links, and no stale `docs/` paths in tracked sources.
 
 `check-changelog.py` requires root [`CHANGELOG.md`](CHANGELOG.md) to document the workspace version with **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**. A `v*` tag builds the GitHub Release body with `scripts/write-release-notes.py` (install URL, that changelog section, then contributor icons).
 
@@ -190,7 +190,7 @@ If your change affects VM boot, say so in the PR so maintainers can trigger the 
 
 | Kind | Where | Rules |
 | --- | --- | --- |
-| Published operator/developer English docs | `public-docs/` | Short pages, English, ≤170 lines except `api.md`, Related footers; use symlink aliases for alternate names |
+| Published operator/developer English docs | `public-docs/` | Contents table, English, ≤300 lines except `api.md`, Related footers; use symlink aliases for alternate names |
 | READMEs | `README.md`, `README.ko.md`, … | Keep install and develop paths accurate |
 | Private project notes | local `docs/` | **Gitignored** — not for PRs or the remote |
 

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -871,6 +871,30 @@ pub enum ResolveError {
         /// Catalog-relative kernel path that was inspected.
         path: PathBuf,
     },
+    /// No source could supply the kernel an imported tree boots under.
+    #[error("no OCI kernel is available for {architecture}: {reason}")]
+    KernelUnavailable {
+        /// Architecture a later TemplateSpec would have to boot.
+        architecture: Architecture,
+        /// What every configured source had to say.
+        reason: String,
+    },
+    /// The published kernel package could not be downloaded.
+    #[error("OCI kernel download from {url} failed: {message}")]
+    KernelDownloadFailed {
+        /// Object URL that was requested.
+        url: String,
+        /// Transport or filesystem diagnostic.
+        message: String,
+    },
+    /// The verified package does not carry the kernel it is pinned for.
+    #[error("OCI kernel package {package} has no member {member}")]
+    KernelPackageMemberMissing {
+        /// Registry object key of the package.
+        package: String,
+        /// Archive member the pin named.
+        member: String,
+    },
     /// A filesystem operation failed while inspecting the paired kernel.
     #[error("OCI kernel pairing {operation} failed at {path}: {source}")]
     KernelIo {
@@ -2065,6 +2089,11 @@ mod boot;
 #[cfg(test)]
 mod boot_tests;
 
+mod kernel;
+
+#[cfg(test)]
+mod kernel_tests;
+
 mod name;
 
 #[cfg(test)]
@@ -3131,15 +3160,17 @@ pub async fn write_provisioned_ext4(
 /// Pairs a packed ext4 with this host's architecture-matched kernel and
 /// boot args.
 ///
-/// `TemplateSpec` requires both; an OCI image supplies neither. The kernel
-/// is the catalog artifact for this architecture that needs no initrd —
-/// currently Ubuntu — and must already be installed under `image_root`.
-/// The ext4 is left in place. This stage does not register a template.
-pub fn pair_ext4_with_host_kernel(
+/// `TemplateSpec` requires both; an OCI image supplies neither. The kernel is
+/// the digest-pinned artifact Firecrab publishes for this architecture,
+/// fetched once and cached under `image_root`; a host that cannot reach the
+/// registry falls back to an installed catalog kernel. The ext4 is left in
+/// place. This stage does not register a template.
+pub async fn pair_ext4_with_host_kernel(
     image: OciExt4Image,
     image_root: &Path,
 ) -> Result<OciBootableImage, ResolveError> {
-    boot::pair_ext4_with_host_kernel(image, image_root)
+    let pair = boot::host_kernel_pair(image_root).await?;
+    boot::pair_ext4_with_kernel(image, image_root, &pair)
 }
 
 /// Derives a unique alias and version from the reference and attaches them
@@ -3313,7 +3344,7 @@ async fn import_oci_image_in_scratch(
     let ext4 = write_provisioned_ext4(&provisioned, &scratch.join("rootfs.ext4")).await?;
 
     tracker.append_log(alias, "pairing host kernel");
-    let bootable = pair_ext4_with_host_kernel(ext4, image_root)?;
+    let bootable = pair_ext4_with_host_kernel(ext4, image_root).await?;
 
     tracker.append_log(alias, "naming and registering template");
     let named = name_oci_image(bootable, reference, templates)?;

--- a/firecrab-api/src/oci/boot.rs
+++ b/firecrab-api/src/oci/boot.rs
@@ -4,9 +4,14 @@
 //! so the kernel must have the Firecracker boot path built in — `virtio_blk`,
 //! `virtio_net`, `virtio_mmio`, and `ext4`. Distro kernels that keep those as
 //! modules need their matching initrd, and that initrd would take PID 1 away
-//! from the injected guest init. The compiled-in catalog's first host
-//! artifact without an initrd is the Ubuntu kernel; this stage records that
-//! pair and does not register a template.
+//! from the injected guest init.
+//!
+//! Firecrab publishes a kernel that meets exactly those requirements
+//! (`kernel.rs`), so an import no longer has to borrow one from a catalog
+//! image: fetching 14 MB beats installing Ubuntu's 890 MB package to read a
+//! single file out of it. A host that cannot reach the registry still boots
+//! an installed catalog kernel — the first host artifact without an initrd,
+//! which is Ubuntu's. This stage records the pair and registers nothing.
 
 use std::io::Read as _;
 use std::os::unix::fs::OpenOptionsExt as _;
@@ -20,20 +25,79 @@ use crate::templates::{KernelFormat, kernel_architecture};
 /// into a [`crate::templates::TemplateSpec`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct KernelBootPair {
+    /// Architecture the kernel boots, which must be this host's.
     pub architecture: Architecture,
+    /// Registry alias or catalog image the kernel came from, named in errors.
     pub source_alias: String,
+    /// Image-root-relative kernel path.
     pub kernel: PathBuf,
+    /// Image-root-relative initrd path; always `None` for an OCI import.
     pub initrd: Option<PathBuf>,
+    /// Firecracker command line the paired rootfs boots with.
     pub boot_args: String,
 }
 
 /// The architecture-matched pair this host will boot imported images with.
-pub(super) fn host_kernel_pair() -> Result<KernelBootPair, ResolveError> {
-    kernel_pair_for(Architecture::HOST)
+pub(super) async fn host_kernel_pair(image_root: &Path) -> Result<KernelBootPair, ResolveError> {
+    resolve_kernel_pair(
+        image_root,
+        Architecture::HOST,
+        kernel::configured_kernel_override().as_deref(),
+        kernel::configured_base_url().as_deref(),
+    )
+    .await
+}
+
+/// Resolves the pair for `architecture`, preferring the published kernel.
+///
+/// The dedicated kernel is what this stage is for, so it is tried first even
+/// on a host that already has a catalog image installed. An installed catalog
+/// kernel is the fallback rather than the default: it keeps an air-gapped or
+/// registry-outage host importing exactly as it did before, without making
+/// every other host download a distro package for one file.
+pub(super) async fn resolve_kernel_pair(
+    image_root: &Path,
+    architecture: Architecture,
+    override_path: Option<&Path>,
+    base_url: Option<&str>,
+) -> Result<KernelBootPair, ResolveError> {
+    let Some(pinned) = kernel::pinned_kernel(architecture) else {
+        return catalog_kernel_pair(architecture);
+    };
+    let error = match kernel::ensure_pinned_kernel(
+        image_root,
+        architecture,
+        &pinned,
+        override_path,
+        base_url,
+    )
+    .await
+    {
+        Ok(pair) => return Ok(pair),
+        Err(error) => error,
+    };
+    let Some(installed) = installed_catalog_pair(image_root, architecture) else {
+        return Err(error);
+    };
+    tracing::warn!(
+        error = %error,
+        alias = installed.source_alias,
+        kernel = %installed.kernel.display(),
+        "falling back to an installed catalog kernel for this OCI import"
+    );
+    Ok(installed)
+}
+
+/// The catalog pair for `architecture` when its kernel is actually installed.
+fn installed_catalog_pair(image_root: &Path, architecture: Architecture) -> Option<KernelBootPair> {
+    let pair = catalog_kernel_pair(architecture).ok()?;
+    image_root.join(&pair.kernel).is_file().then_some(pair)
 }
 
 /// First catalog artifact for `architecture` that needs no initrd.
-pub(super) fn kernel_pair_for(architecture: Architecture) -> Result<KernelBootPair, ResolveError> {
+pub(super) fn catalog_kernel_pair(
+    architecture: Architecture,
+) -> Result<KernelBootPair, ResolveError> {
     m2image_manifest::load()
         .images
         .into_iter()
@@ -53,37 +117,52 @@ pub(super) fn kernel_pair_for(architecture: Architecture) -> Result<KernelBootPa
         .ok_or(ResolveError::NoHostKernel { architecture })
 }
 
-/// Records the host catalog kernel and its boot args on a packed ext4.
+/// Records a resolved kernel and its boot args on a packed ext4.
 ///
 /// The kernel file must already exist under `image_root`. Its header is
 /// classified with the same rules registration uses. A mismatch is refused
 /// here so a later TemplateSpec is never pointed at a silent-hang kernel.
 /// The ext4 is not moved or deleted, and nothing is registered.
-pub(super) fn pair_ext4_with_host_kernel(
+pub(super) fn pair_ext4_with_kernel(
     image: OciExt4Image,
     image_root: &Path,
+    pair: &KernelBootPair,
 ) -> Result<OciBootableImage, ResolveError> {
-    let pair = host_kernel_pair()?;
     let kernel_path = image_root.join(&pair.kernel);
-    let header = read_kernel_header(&kernel_path, &pair)?;
-    match kernel_architecture(&header) {
-        KernelFormat::Bootable(found) if found == pair.architecture => Ok(OciBootableImage {
-            rootfs: image,
-            kernel: pair.kernel,
-            initrd: pair.initrd,
-            boot_args: pair.boot_args,
-            architecture: found,
-        }),
+    let header = read_kernel_header(&kernel_path, pair)?;
+    verify_kernel_architecture(&pair.kernel, &header, pair.architecture)?;
+    Ok(OciBootableImage {
+        rootfs: image,
+        kernel: pair.kernel.clone(),
+        initrd: pair.initrd.clone(),
+        boot_args: pair.boot_args.clone(),
+        architecture: pair.architecture,
+    })
+}
+
+/// Refuses a kernel header this host cannot boot.
+///
+/// `path` only names the subject in the error, so both the pairing stage and
+/// the kernel cache report the same rejections for the same bytes.
+pub(super) fn verify_kernel_architecture(
+    path: &Path,
+    header: &[u8],
+    architecture: Architecture,
+) -> Result<(), ResolveError> {
+    match kernel_architecture(header) {
+        KernelFormat::Bootable(found) if found == architecture => Ok(()),
         KernelFormat::Bootable(found) => Err(ResolveError::KernelArchitectureMismatch {
-            path: pair.kernel,
+            path: path.to_owned(),
             found,
-            host: pair.architecture,
+            host: architecture,
         }),
         KernelFormat::Foreign { machine } => Err(ResolveError::UnsupportedKernelArchitecture {
-            path: pair.kernel,
+            path: path.to_owned(),
             machine,
         }),
-        KernelFormat::Unrecognized => Err(ResolveError::KernelUnrecognized { path: pair.kernel }),
+        KernelFormat::Unrecognized => Err(ResolveError::KernelUnrecognized {
+            path: path.to_owned(),
+        }),
     }
 }
 

--- a/firecrab-api/src/oci/boot_tests.rs
+++ b/firecrab-api/src/oci/boot_tests.rs
@@ -12,8 +12,8 @@ fn ubuntu_artifact(architecture: Architecture) -> crate::m2image_manifest::Relea
 }
 
 #[test]
-fn kernel_pair_for_x86_64_is_the_ubuntu_vmlinux_without_an_initrd() {
-    let pair = boot::kernel_pair_for(Architecture::X86_64).expect("ubuntu publishes x86_64");
+fn catalog_pair_for_x86_64_is_the_ubuntu_vmlinux_without_an_initrd() {
+    let pair = boot::catalog_kernel_pair(Architecture::X86_64).expect("ubuntu publishes x86_64");
     let ubuntu = ubuntu_artifact(Architecture::X86_64);
 
     assert_eq!(pair.architecture, Architecture::X86_64);
@@ -30,8 +30,8 @@ fn kernel_pair_for_x86_64_is_the_ubuntu_vmlinux_without_an_initrd() {
 }
 
 #[test]
-fn kernel_pair_for_aarch64_is_the_ubuntu_image_without_an_initrd() {
-    let pair = boot::kernel_pair_for(Architecture::Aarch64).expect("ubuntu publishes aarch64");
+fn catalog_pair_for_aarch64_is_the_ubuntu_image_without_an_initrd() {
+    let pair = boot::catalog_kernel_pair(Architecture::Aarch64).expect("ubuntu publishes aarch64");
     let ubuntu = ubuntu_artifact(Architecture::Aarch64);
 
     assert_eq!(pair.architecture, Architecture::Aarch64);
@@ -42,13 +42,6 @@ fn kernel_pair_for_aarch64_is_the_ubuntu_image_without_an_initrd() {
     assert!(pair.boot_args.contains("keep_bootcon"));
     assert!(pair.boot_args.contains("console=ttyS0"));
     assert!(pair.boot_args.contains("root=/dev/vda"));
-}
-
-#[test]
-fn host_kernel_pair_is_the_pair_for_this_build() {
-    let host = boot::host_kernel_pair().expect("a no-initrd host kernel exists");
-    let expected = boot::kernel_pair_for(Architecture::HOST).expect("host pair exists");
-    assert_eq!(host, expected);
 }
 
 fn elf_kernel(machine: u16) -> Vec<u8> {
@@ -94,23 +87,34 @@ fn packed_ext4(path: std::path::PathBuf) -> OciExt4Image {
     }
 }
 
+fn host_catalog_pair() -> boot::KernelBootPair {
+    boot::catalog_kernel_pair(Architecture::HOST).expect("host catalog pair")
+}
+
 fn install_kernel(image_root: &std::path::Path, bytes: &[u8]) -> std::path::PathBuf {
-    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let pair = host_catalog_pair();
     let path = image_root.join(&pair.kernel);
     write_file(&path, bytes);
     pair.kernel
 }
 
+fn pair_with_catalog_kernel(
+    image: OciExt4Image,
+    image_root: &std::path::Path,
+) -> Result<OciBootableImage, ResolveError> {
+    boot::pair_ext4_with_kernel(image, image_root, &host_catalog_pair())
+}
+
 #[test]
-fn pairing_records_the_host_kernel_and_its_boot_args() {
+fn pairing_records_the_resolved_kernel_and_its_boot_args() {
     let directory = tempfile::tempdir().expect("create fixture directory");
     let image_root = directory.path();
     let expected_kernel = install_kernel(image_root, &kernel_bytes_for(Architecture::HOST));
     let ext4_path = image_root.join("rootfs/oci.ext4");
     let image = packed_ext4(ext4_path.clone());
-    let expected = boot::host_kernel_pair().expect("host kernel pair");
+    let expected = host_catalog_pair();
 
-    let paired = pair_ext4_with_host_kernel(image, image_root).expect("pair kernel");
+    let paired = pair_with_catalog_kernel(image, image_root).expect("pair kernel");
 
     assert_eq!(paired.architecture(), Architecture::HOST);
     assert_eq!(paired.kernel(), expected_kernel.as_path());
@@ -130,9 +134,9 @@ fn pairing_rejects_a_missing_host_kernel() {
     let image_root = directory.path();
     let ext4_path = image_root.join("rootfs/oci.ext4");
     let image = packed_ext4(ext4_path.clone());
-    let expected = boot::host_kernel_pair().expect("host kernel pair");
+    let expected = host_catalog_pair();
 
-    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("missing kernel");
+    let error = pair_with_catalog_kernel(image, image_root).expect_err("missing kernel");
 
     match error {
         ResolveError::KernelMissing {
@@ -160,7 +164,7 @@ fn pairing_rejects_a_kernel_built_for_another_architecture() {
     let ext4_path = image_root.join("rootfs/oci.ext4");
     let image = packed_ext4(ext4_path);
 
-    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("foreign arch");
+    let error = pair_with_catalog_kernel(image, image_root).expect_err("foreign arch");
 
     match error {
         ResolveError::KernelArchitectureMismatch { found, host, .. } => {
@@ -178,7 +182,7 @@ fn pairing_rejects_an_elf_firecracker_cannot_boot() {
     install_kernel(image_root, &elf_kernel(0xf3));
     let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
 
-    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("riscv");
+    let error = pair_with_catalog_kernel(image, image_root).expect_err("riscv");
 
     match error {
         ResolveError::UnsupportedKernelArchitecture { machine, .. } => {
@@ -192,7 +196,7 @@ fn pairing_rejects_an_elf_firecracker_cannot_boot() {
 fn pairing_does_not_follow_a_kernel_symlink() {
     let directory = tempfile::tempdir().expect("create fixture directory");
     let image_root = directory.path();
-    let pair = boot::host_kernel_pair().expect("host kernel pair");
+    let pair = host_catalog_pair();
     let target = directory.path().join("elsewhere");
     write_file(&target, &kernel_bytes_for(Architecture::HOST));
     let kernel_path = image_root.join(&pair.kernel);
@@ -200,7 +204,7 @@ fn pairing_does_not_follow_a_kernel_symlink() {
     std::os::unix::fs::symlink(&target, &kernel_path).expect("symlink kernel");
     let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
 
-    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("symlink");
+    let error = pair_with_catalog_kernel(image, image_root).expect_err("symlink");
 
     assert_matches!(
         error,
@@ -216,20 +220,20 @@ fn pairing_rejects_an_unclassifiable_kernel() {
     install_kernel(image_root, b"not-a-kernel");
     let image = packed_ext4(image_root.join("rootfs/oci.ext4"));
 
-    let error = pair_ext4_with_host_kernel(image, image_root).expect_err("garbage");
+    let error = pair_with_catalog_kernel(image, image_root).expect_err("garbage");
 
     match error {
         ResolveError::KernelUnrecognized { path } => {
-            assert_eq!(path, boot::host_kernel_pair().expect("host pair").kernel);
+            assert_eq!(path, host_catalog_pair().kernel);
         }
         other => panic!("expected KernelUnrecognized, got {other}"),
     }
 }
 
 #[test]
-fn kernel_pair_skips_kernels_that_need_an_initrd() {
+fn catalog_pair_skips_kernels_that_need_an_initrd() {
     for architecture in [Architecture::X86_64, Architecture::Aarch64] {
-        let pair = boot::kernel_pair_for(architecture).expect("a no-initrd kernel exists");
+        let pair = boot::catalog_kernel_pair(architecture).expect("a no-initrd kernel exists");
         for alias in ["alpine-3.24.1", "rocky-9.8"] {
             let artifact = m2image_manifest::image(alias)
                 .expect("release image")
@@ -244,4 +248,52 @@ fn kernel_pair_skips_kernels_that_need_an_initrd() {
             assert_ne!(pair.source_alias, alias);
         }
     }
+}
+
+/// A base URL nothing listens on, so the fetch fails without a fixture server.
+const UNREACHABLE_BASE_URL: &str = "http://127.0.0.1:1";
+/// The architecture this build pins a kernel for, on either host.
+const PINNED_ARCHITECTURE: Architecture = Architecture::X86_64;
+
+#[tokio::test]
+async fn resolution_falls_back_to_an_installed_catalog_kernel_when_the_registry_is_unreachable() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let catalog = boot::catalog_kernel_pair(PINNED_ARCHITECTURE).expect("catalog pair");
+    write_file(
+        &image_root.join(&catalog.kernel),
+        &kernel_bytes_for(PINNED_ARCHITECTURE),
+    );
+
+    let pair = boot::resolve_kernel_pair(
+        image_root,
+        PINNED_ARCHITECTURE,
+        None,
+        Some(UNREACHABLE_BASE_URL),
+    )
+    .await
+    .expect("an installed catalog kernel keeps this host importing");
+
+    assert_eq!(pair, catalog);
+}
+
+#[tokio::test]
+async fn resolution_reports_the_registry_failure_when_no_catalog_kernel_is_installed() {
+    let directory = tempfile::tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+
+    let error = boot::resolve_kernel_pair(
+        image_root,
+        PINNED_ARCHITECTURE,
+        None,
+        Some(UNREACHABLE_BASE_URL),
+    )
+    .await
+    .expect_err("nothing can supply a kernel");
+
+    assert_matches!(
+        error,
+        ResolveError::KernelDownloadFailed { .. },
+        "the registry failure is more actionable than a missing catalog kernel, got {error}"
+    );
 }

--- a/firecrab-api/src/oci/kernel.rs
+++ b/firecrab-api/src/oci/kernel.rs
@@ -29,6 +29,10 @@ const PACKAGE_MAX_BYTES: u64 = 512 * 1024 * 1024;
 const KERNEL_MAX_BYTES: u64 = 256 * 1024 * 1024;
 /// Archive directory the packaged kernel lives in.
 const PACKAGE_KERNEL_DIRECTORY: &str = "kernel";
+/// Ceiling on reaching the registry, matching the OCI registry session.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+/// Ceiling on the gap between two body chunks, not on the whole download.
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Firecracker command line an imported rootfs boots with on x86_64.
 const X86_64_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw";
@@ -254,6 +258,11 @@ async fn download_package(
     }
     let client = reqwest::Client::builder()
         .user_agent(concat!("firecrab-api/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(CONNECT_TIMEOUT)
+        // Unlike a total request timeout, this resets whenever another chunk
+        // arrives, so a slow link may take as long as the package needs while
+        // a registry that stops answering still fails an import predictably.
+        .read_timeout(READ_TIMEOUT)
         .build()
         .map_err(|error| download_failed(url, error.to_string()))?;
     let response = client

--- a/firecrab-api/src/oci/kernel.rs
+++ b/firecrab-api/src/oci/kernel.rs
@@ -1,0 +1,471 @@
+//! Supplies the kernel an imported container tree boots under.
+//!
+//! A container image carries no kernel, and a container tree has no
+//! `/lib/modules`, so the kernel must have `virtio_blk`, `virtio_net`,
+//! `virtio_mmio`, and `ext4` built in and must need no initrd — an initrd
+//! would take PID 1 away from the injected guest init. Firecrab publishes one
+//! such kernel per architecture on the MicroRegistry, so importing a 50 MB
+//! container no longer means installing a full distro image first.
+//!
+//! The guest toolbox (`busybox.rs`) already establishes the shape: a
+//! digest-pinned artifact, downloaded once, re-verified on every reuse, cached
+//! under the image root, with an operator override for mirrors and air-gapped
+//! hosts. The pin names digests rather than a version tag, so a repointed
+//! object cannot change what a host boots.
+
+use super::*;
+
+use std::fs::OpenOptions;
+use std::os::unix::fs::OpenOptionsExt as _;
+
+use super::boot::{KernelBootPair, verify_kernel_architecture};
+
+/// Operator override naming a kernel image already on this host.
+const KERNEL_PATH_ENV: &str = "FIRECRAB_OCI_KERNEL_PATH";
+/// Ceiling on the published package, so a mirrored base URL cannot stream an
+/// unbounded body onto the image volume before any digest is checked.
+const PACKAGE_MAX_BYTES: u64 = 512 * 1024 * 1024;
+/// Ceiling on the kernel lifted out of that package.
+const KERNEL_MAX_BYTES: u64 = 256 * 1024 * 1024;
+/// Archive directory the packaged kernel lives in.
+const PACKAGE_KERNEL_DIRECTORY: &str = "kernel";
+
+/// Firecracker command line an imported rootfs boots with on x86_64.
+const X86_64_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw";
+
+/// One published kernel artifact this build trusts.
+///
+/// Borrowed rather than owned so the compiled pins are `'static` constants
+/// while tests can pin a fixture built at runtime.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PinnedKernel<'a> {
+    /// Registry alias, which is also the package filename stem.
+    pub alias: &'a str,
+    /// Upstream kernel version, which is a registry path segment.
+    pub version: &'a str,
+    /// Kernel filename inside the package and under the cache.
+    pub image: &'a str,
+    /// `sha256:…` of the published `.tar.zst`.
+    pub package_digest: &'a str,
+    /// `sha256:…` of the kernel file inside that package.
+    pub image_digest: &'a str,
+    /// Firecracker command line this kernel boots an OCI rootfs with.
+    pub boot_args: &'a str,
+}
+
+/// The kernel this build pins for `architecture`.
+///
+/// `None` means no dedicated kernel is published for that architecture yet and
+/// the caller must fall back to an installed catalog kernel. aarch64 is `None`
+/// until the arm64 build is published: the artifact is built on a native host,
+/// and a pin without a digest would be a tag by another name.
+pub(super) fn pinned_kernel(architecture: Architecture) -> Option<PinnedKernel<'static>> {
+    match architecture {
+        Architecture::X86_64 => Some(PinnedKernel {
+            alias: "vmlinux-7.1.8",
+            version: "7.1.8",
+            image: "vmlinux-7.1.8-x86_64",
+            package_digest: "sha256:eb2efc87a8b64b9bcf5c4b7365193c578e6cf203c4773060ec157d6f34c11f53",
+            image_digest: "sha256:1d693ebb340ee418127aacf679080671679e455302a8f89ff8d4a45b6d293cdb",
+            boot_args: X86_64_BOOT_ARGS,
+        }),
+        Architecture::Aarch64 => None,
+    }
+}
+
+/// Reads the operator's kernel override, if one is set.
+pub(super) fn configured_kernel_override() -> Option<PathBuf> {
+    let value = std::env::var(KERNEL_PATH_ENV).ok()?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| PathBuf::from(value))
+}
+
+/// The MicroRegistry base the kernel is fetched from.
+///
+/// This is the same `FIRECRAB_IMAGE_BASE_URL` that serves catalog images, so a
+/// private mirror or an air-gapped `none` already covers the kernel too.
+pub(super) fn configured_base_url() -> Option<String> {
+    ImageInstallTracker::from_env()
+        .base_url()
+        .map(str::to_owned)
+}
+
+/// Registry object key of a pinned package.
+pub(super) fn package_key(architecture: Architecture, pinned: &PinnedKernel<'_>) -> String {
+    format!(
+        "{PACKAGE_KERNEL_DIRECTORY}/{}/{}/{}.tar.zst",
+        pinned.version,
+        architecture.as_str(),
+        pinned.alias
+    )
+}
+
+/// Image-root-relative cache path a registered `TemplateSpec` records.
+pub(super) fn cache_relative(architecture: Architecture, pinned: &PinnedKernel<'_>) -> PathBuf {
+    Path::new(".oci/kernel")
+        .join(architecture.as_str())
+        .join(pinned.image)
+}
+
+/// Archive member the kernel is lifted from.
+fn package_member(pinned: &PinnedKernel<'_>) -> String {
+    format!("{PACKAGE_KERNEL_DIRECTORY}/{}", pinned.image)
+}
+
+/// Acquires the pinned kernel, reaching the registry only when the cache
+/// cannot serve it.
+///
+/// The cached file is re-verified against the pinned digest and the ELF or
+/// arm64 header on every call, so a truncated or repointed cache entry is
+/// refetched instead of booted.
+pub(super) async fn ensure_pinned_kernel(
+    image_root: &Path,
+    architecture: Architecture,
+    pinned: &PinnedKernel<'_>,
+    override_path: Option<&Path>,
+    base_url: Option<&str>,
+) -> Result<KernelBootPair, ResolveError> {
+    let relative = cache_relative(architecture, pinned);
+    let cached = image_root.join(&relative);
+    let directory = cached
+        .parent()
+        .expect("kernel cache paths are built with a parent");
+    tokio::fs::create_dir_all(directory)
+        .await
+        .map_err(|source| cache_io("create kernel cache", directory.to_owned(), source))?;
+    let lock = cache_path_lock(directory, Path::new(pinned.image)).await?;
+    let _guard = lock.lock().await;
+
+    let pair = KernelBootPair {
+        architecture,
+        source_alias: pinned.alias.to_owned(),
+        kernel: relative,
+        initrd: None,
+        boot_args: pinned.boot_args.to_owned(),
+    };
+    if verify_kernel(&cached, &pair, pinned).await.is_ok() {
+        return Ok(pair);
+    }
+    // A cache entry that fails verification is stale or corrupt, never trusted.
+    let _ = tokio::fs::remove_file(&cached).await;
+
+    let staged = directory.join(format!(".{}-{}.partial", pinned.image, Uuid::new_v4()));
+    let result = stage_kernel(
+        image_root,
+        architecture,
+        pinned,
+        override_path,
+        base_url,
+        &staged,
+    )
+    .await;
+    if let Err(error) = result {
+        let _ = tokio::fs::remove_file(&staged).await;
+        return Err(error);
+    }
+    if let Err(error) = verify_kernel(&staged, &pair, pinned).await {
+        let _ = tokio::fs::remove_file(&staged).await;
+        return Err(error);
+    }
+    tokio::fs::rename(&staged, &cached)
+        .await
+        .map_err(|source| cache_io("publish OCI kernel", cached.clone(), source))?;
+    Ok(pair)
+}
+
+/// Writes the kernel to `staged` from whichever source is configured.
+async fn stage_kernel(
+    image_root: &Path,
+    architecture: Architecture,
+    pinned: &PinnedKernel<'_>,
+    override_path: Option<&Path>,
+    base_url: Option<&str>,
+    staged: &Path,
+) -> Result<(), ResolveError> {
+    if let Some(supplied) = override_path {
+        return copy_operator_kernel(supplied, staged).await;
+    }
+    let Some(base_url) = base_url else {
+        return Err(ResolveError::KernelUnavailable {
+            architecture,
+            reason: format!("no {KERNEL_PATH_ENV} override and remote image install is disabled"),
+        });
+    };
+    let key = package_key(architecture, pinned);
+    let url = format!("{}/{key}", base_url.trim_end_matches('/'));
+    let package = image_root.join(".oci/kernel").join(format!(
+        ".{}-{}.tar.zst",
+        pinned.alias,
+        Uuid::new_v4()
+    ));
+    let result = match download_package(&url, &package, pinned).await {
+        Ok(()) => lift_kernel(&package, &key, pinned, staged).await,
+        Err(error) => Err(error),
+    };
+    let _ = tokio::fs::remove_file(&package).await;
+    result
+}
+
+/// Copies an operator-supplied kernel into the cache staging path.
+///
+/// The bytes still have to match the pinned digest, so an override is a
+/// mirror of the published artifact rather than a way around it.
+async fn copy_operator_kernel(supplied: &Path, staged: &Path) -> Result<(), ResolveError> {
+    let metadata = tokio::fs::symlink_metadata(supplied)
+        .await
+        .map_err(|source| kernel_io("inspect operator kernel", supplied.to_owned(), source))?;
+    if !metadata.file_type().is_file() {
+        return Err(kernel_io(
+            "inspect operator kernel",
+            supplied.to_owned(),
+            io::Error::new(io::ErrorKind::InvalidInput, "not a regular file"),
+        ));
+    }
+    if metadata.len() > KERNEL_MAX_BYTES {
+        return Err(kernel_io(
+            "inspect operator kernel",
+            supplied.to_owned(),
+            io::Error::other(format!(
+                "{} bytes exceeds the {KERNEL_MAX_BYTES}-byte limit",
+                metadata.len()
+            )),
+        ));
+    }
+    tokio::fs::copy(supplied, staged)
+        .await
+        .map_err(|source| kernel_io("copy operator kernel", supplied.to_owned(), source))?;
+    Ok(())
+}
+
+/// Streams the published package to disk, hashing it as it lands.
+///
+/// The digest is calculated from the bytes actually written, and the body is
+/// cut off at [`PACKAGE_MAX_BYTES`], so neither a repointed object nor an
+/// endless response can be unpacked.
+async fn download_package(
+    url: &str,
+    destination: &Path,
+    pinned: &PinnedKernel<'_>,
+) -> Result<(), ResolveError> {
+    if let Some(parent) = destination.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|source| cache_io("create kernel cache", parent.to_owned(), source))?;
+    }
+    let client = reqwest::Client::builder()
+        .user_agent(concat!("firecrab-api/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .map_err(|error| download_failed(url, error.to_string()))?;
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|error| download_failed(url, error.to_string()))?;
+    if !response.status().is_success() {
+        return Err(download_failed(
+            url,
+            format!("HTTP {}", response.status().as_u16()),
+        ));
+    }
+
+    let mut file = tokio::fs::File::create(destination)
+        .await
+        .map_err(|source| cache_io("stage kernel package", destination.to_owned(), source))?;
+    let mut hasher = Sha256::new();
+    let mut written = 0_u64;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| download_failed(url, error.to_string()))?;
+        written = written.saturating_add(chunk.len() as u64);
+        if written > PACKAGE_MAX_BYTES {
+            return Err(download_failed(
+                url,
+                format!("body exceeds the {PACKAGE_MAX_BYTES}-byte limit"),
+            ));
+        }
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|source| cache_io("write kernel package", destination.to_owned(), source))?;
+    }
+    file.flush()
+        .await
+        .map_err(|source| cache_io("flush kernel package", destination.to_owned(), source))?;
+
+    let actual = digest_from(hasher);
+    let expected = parse_pin(pinned.package_digest)?;
+    if actual != expected {
+        return Err(ResolveError::DigestMismatch {
+            subject: url.to_owned(),
+            expected,
+            actual,
+        });
+    }
+    Ok(())
+}
+
+/// Lifts the pinned kernel out of a verified package.
+async fn lift_kernel(
+    package: &Path,
+    key: &str,
+    pinned: &PinnedKernel<'_>,
+    staged: &Path,
+) -> Result<(), ResolveError> {
+    let reported = package.to_owned();
+    let package = package.to_owned();
+    let key = key.to_owned();
+    let member = package_member(pinned);
+    let staged = staged.to_owned();
+    tokio::task::spawn_blocking(move || lift_kernel_blocking(&package, &key, &member, &staged))
+        .await
+        .map_err(|error| {
+            cache_io(
+                "join kernel unpack worker",
+                reported,
+                io::Error::other(error),
+            )
+        })?
+}
+
+/// Blocking half of [`lift_kernel`].
+fn lift_kernel_blocking(
+    package: &Path,
+    key: &str,
+    member: &str,
+    staged: &Path,
+) -> Result<(), ResolveError> {
+    let file = std::fs::File::open(package)
+        .map_err(|source| cache_io("open kernel package", package.to_owned(), source))?;
+    let decoder = zstd::stream::read::Decoder::new(file)
+        .map_err(|source| cache_io("decompress kernel package", package.to_owned(), source))?;
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|source| cache_io("read kernel package", package.to_owned(), source))?;
+    for entry in entries {
+        let mut entry =
+            entry.map_err(|source| cache_io("read kernel package", package.to_owned(), source))?;
+        let path = entry
+            .path()
+            .map_err(|source| cache_io("read kernel package", package.to_owned(), source))?;
+        if path.to_string_lossy().replace('\\', "/") != member {
+            continue;
+        }
+        let mut target = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o644)
+            .custom_flags(libc::O_CLOEXEC)
+            .open(staged)
+            .map_err(|source| cache_io("stage OCI kernel", staged.to_owned(), source))?;
+        let copied = io::copy(&mut entry.by_ref().take(KERNEL_MAX_BYTES + 1), &mut target)
+            .map_err(|source| cache_io("write OCI kernel", staged.to_owned(), source))?;
+        if copied > KERNEL_MAX_BYTES {
+            return Err(cache_io(
+                "write OCI kernel",
+                staged.to_owned(),
+                io::Error::other(format!(
+                    "member {member} exceeds the {KERNEL_MAX_BYTES}-byte limit"
+                )),
+            ));
+        }
+        target
+            .sync_all()
+            .map_err(|source| cache_io("write OCI kernel", staged.to_owned(), source))?;
+        return Ok(());
+    }
+    Err(ResolveError::KernelPackageMemberMissing {
+        package: key.to_owned(),
+        member: member.to_owned(),
+    })
+}
+
+/// Proves a file is the pinned kernel and one this host can boot.
+async fn verify_kernel(
+    path: &Path,
+    pair: &KernelBootPair,
+    pinned: &PinnedKernel<'_>,
+) -> Result<(), ResolveError> {
+    let expected = parse_pin(pinned.image_digest)?;
+    let subject = pair.kernel.clone();
+    let architecture = pair.architecture;
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        verify_kernel_blocking(&path, &subject, architecture, expected)
+    })
+    .await
+    .map_err(|error| {
+        cache_io(
+            "join kernel verification worker",
+            pair.kernel.clone(),
+            io::Error::other(error),
+        )
+    })?
+}
+
+/// Blocking half of [`verify_kernel`].
+fn verify_kernel_blocking(
+    path: &Path,
+    subject: &Path,
+    architecture: Architecture,
+    expected: Sha256Digest,
+) -> Result<(), ResolveError> {
+    let mut file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|source| kernel_io("open kernel", subject.to_owned(), source))?;
+    let mut hasher = Sha256::new();
+    let mut header = Vec::new();
+    let mut buffer = vec![0_u8; 128 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|source| kernel_io("read kernel", subject.to_owned(), source))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+        if header.len() < 64 {
+            let wanted = (64 - header.len()).min(read);
+            header.extend_from_slice(&buffer[..wanted]);
+        }
+    }
+    let actual = digest_from(hasher);
+    if actual != expected {
+        return Err(ResolveError::DigestMismatch {
+            subject: subject.display().to_string(),
+            expected,
+            actual,
+        });
+    }
+    verify_kernel_architecture(subject, &header, architecture)
+}
+
+/// Parses a compiled pin, which is a constant and must always be well formed.
+fn parse_pin(value: &str) -> Result<Sha256Digest, ResolveError> {
+    Sha256Digest::parse(value).map_err(|error| {
+        ResolveError::Malformed(format!("pinned OCI kernel digest {value:?}: {error}"))
+    })
+}
+
+/// Wraps a finished hasher as a descriptor digest.
+fn digest_from(hasher: Sha256) -> Sha256Digest {
+    Sha256Digest::parse(&format!("sha256:{:x}", hasher.finalize()))
+        .expect("a hex sha256 digest is a valid descriptor digest")
+}
+
+fn download_failed(url: &str, message: String) -> ResolveError {
+    ResolveError::KernelDownloadFailed {
+        url: url.to_owned(),
+        message,
+    }
+}
+
+fn kernel_io(operation: &'static str, path: PathBuf, source: io::Error) -> ResolveError {
+    ResolveError::KernelIo {
+        operation,
+        path,
+        source,
+    }
+}

--- a/firecrab-api/src/oci/kernel_tests.rs
+++ b/firecrab-api/src/oci/kernel_tests.rs
@@ -426,6 +426,72 @@ async fn an_operator_supplied_kernel_must_still_match_the_pinned_digest() {
     );
 }
 
+/// Accepts a connection and answers nothing, holding it until dropped.
+///
+/// A registry that stops mid-transfer looks exactly like this to the client:
+/// the socket stays open and no byte ever arrives.
+struct StalledRegistry {
+    base_url: String,
+    task: JoinHandle<()>,
+}
+
+impl Drop for StalledRegistry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl StalledRegistry {
+    async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stalled registry");
+        let base_url = format!(
+            "http://{}",
+            listener.local_addr().expect("stalled registry address")
+        );
+        let task = tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((stream, _)) = listener.accept().await {
+                held.push(stream);
+            }
+        });
+        Self { base_url, task }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn a_registry_that_answers_nothing_fails_instead_of_hanging() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+    let stalled = StalledRegistry::start().await;
+
+    let attempt = tokio::time::timeout(
+        std::time::Duration::from_secs(600),
+        kernel::ensure_pinned_kernel(
+            image_root,
+            Architecture::HOST,
+            &published.pinned(),
+            None,
+            Some(&stalled.base_url),
+        ),
+    )
+    .await
+    .expect("an import must not wait on a stalled registry forever");
+
+    assert_matches!(
+        attempt.expect_err("a stalled registry cannot supply a kernel"),
+        ResolveError::KernelDownloadFailed { .. },
+        "expected KernelDownloadFailed once the read timeout elapses"
+    );
+}
+
 #[tokio::test]
 async fn an_operator_path_that_is_not_a_regular_file_is_refused() {
     let directory = tempdir().expect("create fixture directory");

--- a/firecrab-api/src/oci/kernel_tests.rs
+++ b/firecrab-api/src/oci/kernel_tests.rs
@@ -1,0 +1,547 @@
+use super::*;
+use core::assert_matches;
+
+use std::io::Cursor;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use axum::body::Body;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{Response, StatusCode};
+use axum::routing::get;
+use tar::{Builder, EntryType, Header};
+use tempfile::tempdir;
+use tokio::task::JoinHandle;
+
+/// Alias, version, and image name the fixture package is published under.
+const FIXTURE_ALIAS: &str = "vmlinux-9.9.9";
+const FIXTURE_VERSION: &str = "9.9.9";
+
+fn fixture_image_name(architecture: Architecture) -> String {
+    match architecture {
+        Architecture::X86_64 => format!("vmlinux-{FIXTURE_VERSION}-x86_64"),
+        Architecture::Aarch64 => format!("Image-{FIXTURE_VERSION}-aarch64"),
+    }
+}
+
+/// A 64-bit little-endian ELF header Firecracker classifies as `machine`.
+fn elf_kernel(machine: u16) -> Vec<u8> {
+    let mut bytes = vec![0_u8; 4096];
+    bytes[0..4].copy_from_slice(b"\x7fELF");
+    bytes[4] = 2;
+    bytes[5] = 1;
+    bytes[6] = 1;
+    bytes[16..18].copy_from_slice(&2_u16.to_le_bytes());
+    bytes[18..20].copy_from_slice(&machine.to_le_bytes());
+    bytes
+}
+
+/// A bare `Linux/arm64 Image` header.
+fn arm64_image_kernel() -> Vec<u8> {
+    let mut bytes = vec![0_u8; 4096];
+    bytes[0..2].copy_from_slice(b"MZ");
+    bytes[56..60].copy_from_slice(&0x644d_5241_u32.to_le_bytes());
+    bytes
+}
+
+fn kernel_bytes_for(architecture: Architecture) -> Vec<u8> {
+    match architecture {
+        Architecture::Aarch64 => arm64_image_kernel(),
+        Architecture::X86_64 => elf_kernel(0x3e),
+    }
+}
+
+fn tar_entry(builder: &mut Builder<Vec<u8>>, path: &str, data: &[u8]) {
+    let mut header = Header::new_gnu();
+    header.set_entry_type(EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_size(data.len() as u64);
+    builder
+        .append_data(&mut header, path, Cursor::new(data))
+        .expect("append fixture tar entry");
+}
+
+/// Builds the `.tar.zst` the registry publishes: `kernel/<image>` beside the
+/// config it was built from, exactly as `package-vmlinux.sh` writes it.
+fn kernel_package(member: &str, kernel: &[u8]) -> Vec<u8> {
+    let mut builder = Builder::new(Vec::new());
+    tar_entry(&mut builder, member, kernel);
+    tar_entry(
+        &mut builder,
+        "config/fixture.config",
+        b"CONFIG_VIRTIO_BLK=y\n",
+    );
+    let tar = builder.into_inner().expect("finish fixture tar");
+    zstd::stream::encode_all(tar.as_slice(), 0).expect("compress fixture package")
+}
+
+#[derive(Clone)]
+struct PackageState {
+    package: Arc<Vec<u8>>,
+    key: Arc<String>,
+    requests: Arc<AtomicUsize>,
+}
+
+/// Static object host standing in for `registry.firecrab.dev`.
+struct KernelRegistry {
+    base_url: String,
+    state: PackageState,
+    task: JoinHandle<()>,
+}
+
+impl Drop for KernelRegistry {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl KernelRegistry {
+    async fn start(package: Vec<u8>, key: String) -> Self {
+        let state = PackageState {
+            package: Arc::new(package),
+            key: Arc::new(key),
+            requests: Arc::new(AtomicUsize::new(0)),
+        };
+        let app = axum::Router::new()
+            .route("/{*key}", get(serve_package))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind kernel registry");
+        let base_url = format!(
+            "http://{}",
+            listener.local_addr().expect("kernel registry address")
+        );
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve kernel registry");
+        });
+        Self {
+            base_url,
+            state,
+            task,
+        }
+    }
+
+    fn requests(&self) -> usize {
+        self.state.requests.load(Ordering::SeqCst)
+    }
+}
+
+async fn serve_package(
+    State(state): State<PackageState>,
+    AxumPath(key): AxumPath<String>,
+) -> Response<Body> {
+    state.requests.fetch_add(1, Ordering::SeqCst);
+    if key != *state.key {
+        return Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::empty())
+            .expect("build missing package response");
+    }
+    Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(state.package.to_vec()))
+        .expect("build package response")
+}
+
+/// One published kernel plus the pin a build would carry for it.
+struct PublishedKernel {
+    registry: KernelRegistry,
+    kernel: Vec<u8>,
+    package_digest: String,
+    image_digest: String,
+    image: String,
+}
+
+impl PublishedKernel {
+    /// Publishes `kernel` under the layout the real registry serves.
+    async fn publish(architecture: Architecture, kernel: Vec<u8>, member: Option<&str>) -> Self {
+        let image = fixture_image_name(architecture);
+        let member = member.map_or_else(|| format!("kernel/{image}"), str::to_owned);
+        let package = kernel_package(&member, &kernel);
+        let key = format!(
+            "kernel/{FIXTURE_VERSION}/{}/{FIXTURE_ALIAS}.tar.zst",
+            architecture.as_str()
+        );
+        Self {
+            package_digest: Sha256Digest::of_bytes(&package).to_string(),
+            image_digest: Sha256Digest::of_bytes(&kernel).to_string(),
+            registry: KernelRegistry::start(package, key).await,
+            kernel,
+            image,
+        }
+    }
+
+    fn pinned(&self) -> kernel::PinnedKernel<'_> {
+        kernel::PinnedKernel {
+            alias: FIXTURE_ALIAS,
+            version: FIXTURE_VERSION,
+            image: &self.image,
+            package_digest: &self.package_digest,
+            image_digest: &self.image_digest,
+            boot_args: "console=ttyS0 root=/dev/vda rw",
+        }
+    }
+
+    /// Publishes the pinned digest of a kernel the registry does not serve.
+    fn with_foreign_pin(mut self, digest: &str) -> Self {
+        self.package_digest = digest.to_owned();
+        self
+    }
+}
+
+async fn ensure(
+    published: &PublishedKernel,
+    image_root: &std::path::Path,
+) -> Result<boot::KernelBootPair, ResolveError> {
+    kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &published.pinned(),
+        None,
+        Some(&published.registry.base_url),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn a_fetched_kernel_is_cached_under_the_image_root_and_never_downloaded_twice() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+
+    let first = ensure(&published, image_root).await.expect("first fetch");
+    let second = ensure(&published, image_root).await.expect("cached reuse");
+
+    assert_eq!(first, second);
+    assert_eq!(first.architecture, Architecture::HOST);
+    assert_eq!(first.source_alias, FIXTURE_ALIAS);
+    assert_eq!(first.initrd, None);
+    assert_eq!(first.boot_args, "console=ttyS0 root=/dev/vda rw");
+    assert_eq!(
+        first.kernel,
+        std::path::PathBuf::from(format!(
+            ".oci/kernel/{}/{}",
+            Architecture::HOST.as_str(),
+            published.image
+        )),
+        "the pair must name an image-root-relative path a TemplateSpec can record"
+    );
+    assert_eq!(
+        std::fs::read(image_root.join(&first.kernel)).expect("cached kernel"),
+        published.kernel
+    );
+    assert_eq!(
+        published.registry.requests(),
+        1,
+        "a warm host must not contact the registry again"
+    );
+}
+
+#[tokio::test]
+async fn a_corrupt_cached_kernel_is_refetched() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+
+    let first = ensure(&published, image_root).await.expect("first fetch");
+    std::fs::write(image_root.join(&first.kernel), b"truncated").expect("corrupt the cache");
+    let second = ensure(&published, image_root).await.expect("refetch");
+
+    assert_eq!(first, second);
+    assert_eq!(
+        std::fs::read(image_root.join(&second.kernel)).expect("restored kernel"),
+        published.kernel
+    );
+    assert_eq!(published.registry.requests(), 2);
+}
+
+#[tokio::test]
+async fn a_package_that_does_not_match_the_pinned_digest_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await
+    .with_foreign_pin(&Sha256Digest::of_bytes(b"another package").to_string());
+
+    let error = ensure(&published, image_root)
+        .await
+        .expect_err("pinned digest mismatch");
+
+    assert_matches!(
+        error,
+        ResolveError::DigestMismatch { .. },
+        "expected DigestMismatch for a repointed package, got {error}"
+    );
+    assert!(
+        !image_root
+            .join(format!(
+                ".oci/kernel/{}/{}",
+                Architecture::HOST.as_str(),
+                published.image
+            ))
+            .exists(),
+        "a refused package must publish nothing"
+    );
+}
+
+#[tokio::test]
+async fn a_package_without_the_pinned_kernel_member_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        Some("kernel/some-other-build"),
+    )
+    .await;
+
+    let error = ensure(&published, image_root)
+        .await
+        .expect_err("missing member");
+
+    match error {
+        ResolveError::KernelPackageMemberMissing { member, .. } => {
+            assert_eq!(member, format!("kernel/{}", published.image));
+        }
+        other => panic!("expected KernelPackageMemberMissing, got {other}"),
+    }
+}
+
+#[tokio::test]
+async fn a_kernel_built_for_another_architecture_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST.other()),
+        None,
+    )
+    .await;
+
+    let error = ensure(&published, image_root)
+        .await
+        .expect_err("foreign architecture");
+
+    match error {
+        ResolveError::KernelArchitectureMismatch { found, host, .. } => {
+            assert_eq!(found, Architecture::HOST.other());
+            assert_eq!(host, Architecture::HOST);
+        }
+        other => panic!("expected KernelArchitectureMismatch, got {other}"),
+    }
+    assert!(
+        !image_root
+            .join(format!(
+                ".oci/kernel/{}/{}",
+                Architecture::HOST.as_str(),
+                published.image
+            ))
+            .exists(),
+        "a foreign kernel must publish nothing"
+    );
+}
+
+#[tokio::test]
+async fn an_operator_supplied_kernel_is_published_without_contacting_the_registry() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+    let supplied = directory.path().join("operator-vmlinux");
+    std::fs::write(&supplied, &published.kernel).expect("write operator kernel");
+
+    let pair = kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &published.pinned(),
+        Some(&supplied),
+        Some(&published.registry.base_url),
+    )
+    .await
+    .expect("operator override");
+
+    assert_eq!(
+        std::fs::read(image_root.join(&pair.kernel)).expect("published kernel"),
+        published.kernel
+    );
+    assert_eq!(
+        published.registry.requests(),
+        0,
+        "an operator-supplied kernel must not reach the network"
+    );
+}
+
+#[tokio::test]
+async fn an_operator_supplied_kernel_must_still_match_the_pinned_digest() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+    let supplied = directory.path().join("operator-vmlinux");
+    std::fs::write(&supplied, kernel_bytes_for(Architecture::HOST.other()))
+        .expect("write operator kernel");
+
+    let error = kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &published.pinned(),
+        Some(&supplied),
+        None,
+    )
+    .await
+    .expect_err("operator kernel is not the pinned one");
+
+    assert_matches!(
+        error,
+        ResolveError::DigestMismatch { .. },
+        "expected DigestMismatch for an operator file that is not the pin, got {error}"
+    );
+}
+
+#[tokio::test]
+async fn an_operator_path_that_is_not_a_regular_file_is_refused() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+    let supplied = directory.path().join("kernel-directory");
+    std::fs::create_dir(&supplied).expect("create operator directory");
+
+    let error = kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &published.pinned(),
+        Some(&supplied),
+        None,
+    )
+    .await
+    .expect_err("a directory is not a kernel");
+
+    assert_matches!(
+        error,
+        ResolveError::KernelIo { .. },
+        "expected KernelIo for an operator path that is not a file, got {error}"
+    );
+}
+
+#[tokio::test]
+async fn a_registry_that_does_not_publish_the_pinned_version_is_reported() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+    let mut pinned = published.pinned();
+    pinned.version = "0.0.0";
+
+    let error = kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &pinned,
+        None,
+        Some(&published.registry.base_url),
+    )
+    .await
+    .expect_err("the pinned version is not published");
+
+    match error {
+        ResolveError::KernelDownloadFailed { url, message } => {
+            assert!(
+                url.ends_with("kernel/0.0.0/x86_64/vmlinux-9.9.9.tar.zst")
+                    || url.ends_with("kernel/0.0.0/aarch64/vmlinux-9.9.9.tar.zst")
+            );
+            assert_eq!(message, "HTTP 404");
+        }
+        other => panic!("expected KernelDownloadFailed, got {other}"),
+    }
+}
+
+#[test]
+fn the_kernel_source_defaults_to_the_public_registry_and_no_override() {
+    assert_eq!(
+        kernel::configured_base_url().as_deref(),
+        Some(crate::image_install::DEFAULT_IMAGE_BASE_URL),
+        "an unconfigured host fetches the kernel from the public MicroRegistry"
+    );
+    assert!(kernel::configured_kernel_override().is_none());
+}
+
+#[tokio::test]
+async fn a_host_with_no_kernel_source_is_told_so() {
+    let directory = tempdir().expect("create fixture directory");
+    let image_root = directory.path();
+    let published = PublishedKernel::publish(
+        Architecture::HOST,
+        kernel_bytes_for(Architecture::HOST),
+        None,
+    )
+    .await;
+
+    let error = kernel::ensure_pinned_kernel(
+        image_root,
+        Architecture::HOST,
+        &published.pinned(),
+        None,
+        None,
+    )
+    .await
+    .expect_err("no configured source");
+
+    assert_matches!(
+        error,
+        ResolveError::KernelUnavailable { .. },
+        "expected KernelUnavailable when remote install is disabled, got {error}"
+    );
+}
+
+#[test]
+fn the_compiled_pin_names_a_digest_and_the_published_registry_layout() {
+    let pinned = kernel::pinned_kernel(Architecture::X86_64).expect("x86_64 kernel is published");
+
+    assert_eq!(pinned.alias, "vmlinux-7.1.8");
+    assert_eq!(pinned.version, "7.1.8");
+    assert_eq!(pinned.image, "vmlinux-7.1.8-x86_64");
+    assert_eq!(
+        kernel::package_key(Architecture::X86_64, &pinned),
+        "kernel/7.1.8/x86_64/vmlinux-7.1.8.tar.zst"
+    );
+    Sha256Digest::parse(pinned.package_digest).expect("package digest is pinned, not a tag");
+    Sha256Digest::parse(pinned.image_digest).expect("kernel digest is pinned, not a tag");
+    assert!(pinned.boot_args.contains("root=/dev/vda"));
+    assert!(pinned.boot_args.contains("console=ttyS0"));
+}

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -86,15 +86,13 @@ result.
 
 Merging builds a private sibling partial tree and atomically publishes it only
 after every layer succeeds; the destination must not already exist. Failures
-attempt to remove the partial tree and always retain verified blob and
-decompressed-layer cache entries.
+attempt to remove the partial tree and always retain verified blob and decompressed-layer cache entries.
 
 ## Guest toolbox
 
 A container image is an application, not an operating system: it has no PID 1,
 no DHCP client, and nothing that reports readiness. The internal pipeline
-supplies all three from one static program before a merged tree can become a
-bootable image.
+supplies all three from one static program before a merged tree can become a bootable image.
 
 That program is taken from a digest-pinned busybox image, pulled through the
 same verified stages as the image being imported. It must be a 64-bit
@@ -126,10 +124,8 @@ fastfetch (polyfilled, GLIBC_2.17) to `/usr/bin/fastfetch`, cached at
 with `FIRECRAB_OCI_FASTFETCH_PATH`. A missing program is not an import failure.
 `/etc/firecrab/services.d` is created empty for the image's own entrypoint, which a later stage translates into an ordinary service under that init rather than PID 1.
 
-Images that place `/sbin` or `/etc` behind a symbolic link are activated
-through it.
-Resolution is clamped to the tree, and an entry already occupying a guest
-path is replaced without writing through it.
+Images that place `/sbin` or `/etc` behind a symbolic link are activated through it.
+Resolution is clamped to the tree, and an entry already occupying a guest path is replaced without writing through it.
 A failed activation restores every path it touched.
 
 ## Ext4 image
@@ -151,7 +147,10 @@ This stage still pairs no kernel and registers nothing.
 
 ## Kernel, name, register
 
-The packed ext4 is paired with this host's no-initrd catalog kernel — Ubuntu.
+The packed ext4 is paired with the kernel Firecrab publishes for this architecture — `virtio_blk`, `virtio_net`, `virtio_mmio`, and `ext4` built in, no initrd — so no catalog image has to be installed first.
+It is pinned by digest, fetched once from `FIRECRAB_IMAGE_BASE_URL`, cached at `<FIRECRAB_IMAGE_ROOT>/.oci/kernel/<arch>/`, and re-verified on every reuse.
+`FIRECRAB_OCI_KERNEL_PATH` names a host copy, which must match the same digest.
+A host that cannot reach the registry falls back to an installed catalog kernel.
 The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
 A catalog or installed alias is refused; the ext4 is copied to `rootfs/<alias>.ext4`.
 That local template is not a MicroRegistry row; register it as in [Images](images.md) and [API](api.md).

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -1,29 +1,47 @@
 # OCI images
 
 firecrab can inspect a container image and import it as a bootable template.
-The pipeline caches layers, merges them, injects a guest runtime, writes ext4,
-pairs a kernel, and registers an alias.
+The pipeline caches layers, merges them, injects a guest runtime, writes ext4, pairs a kernel, and registers an alias.
+
+## Contents
+
+| Section | Content |
+| --- | --- |
+| [Inspect](#inspect) | Ask whether an image can run here |
+| [Import](#import) | Start and poll the background job |
+| [Blob cache](#blob-cache) | Verified registry bytes on disk |
+| [Layer decompression](#layer-decompression) | Compressed stream to verified tar |
+| [Layer safety preflight](#layer-safety-preflight) | Tar rules checked before extraction |
+| [Layer merge](#layer-merge) | Manifest order, whiteouts, atomic publish |
+| [Guest toolbox](#guest-toolbox) | The static program the guest boots as PID 1 |
+| [Guest activation](#guest-activation) | Init, boot script, console, metrics |
+| [Ext4 image](#ext4-image) | Sizing and publishing the rootfs |
+| [Kernel](#kernel) | The published kernel and its cache |
+| [Name and register](#name-and-register) | Alias rules and the local template |
+| [Service](#service) | The image entrypoint as a service |
+| [Related](#related) | Other documents |
 
 ## Inspect
 
-Ask whether a container image can run on this host without downloading its config or layers.
+- Answers whether an image can run here, without downloading its config or layers.
+- Reference is written as at `docker pull`; a bare name is Docker Hub `library` at `latest`.
+- Answer is the manifest digest this host would pull, plus the alias a later import claims.
+- A missing architecture is rejected (OCI uses Go's names, so x86_64 is `amd64`).
+- HTTPS only, except `localhost` and `127.0.0.1`.
 
 ```sh
 curl -s 'http://127.0.0.1:3000/api/oci/inspect?reference=nginx:1.27'
 ```
 
-The reference is written as at `docker pull`, so a bare name resolves to Docker Hub's `library` namespace at `latest`.
-The answer is the manifest digest this host would pull; a missing architecture is rejected (OCI uses Go's names, so x86_64 is `amd64`).
-Registries are reached over HTTPS, except `localhost` and `127.0.0.1`.
-This endpoint reads metadata only and includes the alias a later import will claim.
-
-Docker Hub's anonymous pull quota is per source address, so a shared egress IP answers `429`.
-Save an account with `PUT /api/microregistry/docker-hub` — see [API](api.md) — and inspect, import, and the toolbox pull all use it.
-A login cannot help when the failure is `Permission denied (os error 13)`: that is this host refusing the socket, covered in [Troubleshooting](troubleshooting.md).
+- Docker Hub's anonymous quota is per source address, so a shared egress IP answers `429`.
+- Save an account with `PUT /api/microregistry/docker-hub` — see [API](api.md) — and inspect, import, and the toolbox pull all use it.
+- `Permission denied (os error 13)` is this host refusing the socket, not a login problem — see [Troubleshooting](troubleshooting.md).
 
 ## Import
 
-Import is a background job because REST requests time out at 10 seconds.
+- Import is a background job, because REST requests time out at 10 seconds.
+- Poll `GET /api/oci/import/{alias}` for the `ImageInstallResponse` package install uses.
+- Success adds the alias to `GET /api/images`.
 
 ```sh
 curl -s -X POST http://127.0.0.1:3000/api/oci/import \
@@ -31,135 +49,116 @@ curl -s -X POST http://127.0.0.1:3000/api/oci/import \
   -d '{"reference":"nginx:1.27"}'
 ```
 
-Poll `GET /api/oci/import/{alias}` for the same `ImageInstallResponse` package install uses.
-A bad reference is `400 validation_failed`; a catalog or installed alias `409 alias_collision`; a running job `409 import_in_progress`.
-Success adds the alias to `GET /api/images`.
+| Failure | Answer |
+| --- | --- |
+| Bad reference | `400 validation_failed` |
+| Catalog or installed alias | `409 alias_collision` |
+| Job already running | `409 import_in_progress` |
 
 ## Blob cache
 
-Internal OCI pulls cache image configs and layers by their SHA-256 digest at `<FIRECRAB_IMAGE_ROOT>/.oci/blobs/sha256/<hex>`.
-Entries contain the raw bytes returned by the registry and are never replaced with decompressed data.
-Every cache lookup verifies size and SHA-256 before reuse; a corrupt entry is discarded and fetched again.
-One config or layer download is limited to 16 GiB by default (`FIRECRAB_OCI_MAX_BLOB_BYTES`).
+- Configs and layers are cached by SHA-256 at `<FIRECRAB_IMAGE_ROOT>/.oci/blobs/sha256/<hex>`.
+- Entries hold the raw registry bytes, never decompressed data.
+- Every lookup verifies size and digest; a corrupt entry is discarded and fetched again.
+- One download is limited to 16 GiB (`FIRECRAB_OCI_MAX_BLOB_BYTES`).
 
 ## Layer decompression
 
-The internal import pipeline decompresses plain, gzip, and zstd layer streams into `.oci/layers/sha256/<diff-id>/<compressed-digest>.<codec>.tar`.
-Each result keeps the manifest descriptor, whose digest covers the registry bytes, separate from the matching config `rootfs.diff_ids` entry, whose digest covers the uncompressed tar stream.
-
-The decoder publishes a tar only after the diff ID matches.
-Cache hits are rehashed and corrupt entries are rebuilt from the verified blob.
-Decoder output is limited to 64 GiB per layer (`FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`).
-At most two layer decoders run process-wide, and each zstd decoder has a 128 MiB window.
+- Plain, gzip, and zstd streams are decoded to `.oci/layers/sha256/<diff-id>/<compressed-digest>.<codec>.tar`.
+- The manifest descriptor digest covers the registry bytes; the config `rootfs.diff_ids` entry covers the uncompressed tar.
+- A tar is published only after its diff ID matches.
+- Cache hits are rehashed; a corrupt entry is rebuilt from the verified blob.
+- Output is limited to 64 GiB per layer (`FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES`).
+- At most two decoders run process-wide, each zstd window 128 MiB.
 
 ## Layer safety preflight
 
-Before extraction, the internal pipeline scans every decompressed tar using GNU long-name/link metadata and PAX overrides.
-Member names must be relative paths without parent components; only a directory may name the archive root as `.` or `./`.
-Character devices, block devices, and FIFOs are skipped; unsupported special entries are rejected.
-Links must name a target; hard-link targets stay archive-root-relative.
-Regular whiteout files remain valid for the later merge stage.
+Every decompressed tar is scanned before extraction, reading GNU long-name/link metadata and PAX overrides.
 
-Malformed headers, repeated PAX path/link records, sparse extensions,
-missing end records, and truncated member bodies stop the import.
-PAX `size` overrides and global PAX path/link/size overrides are rejected.
-Each GNU or PAX metadata entry is limited to 1 MiB.
+- Member names are relative and free of parent components; only a directory may name the root as `.` or `./`.
+- Character devices, block devices, and FIFOs are skipped; other special entries are rejected.
+- Links must name a target; hard-link targets stay archive-root-relative.
+- Regular whiteout files stay valid for the merge stage.
+
+Rejected outright, stopping the import:
+
+- Malformed headers, repeated PAX path/link records, sparse extensions.
+- Missing end records and truncated member bodies.
+- PAX `size` overrides, and global PAX path/link/size overrides.
+- Any GNU or PAX metadata entry over 1 MiB.
+
 Rejection keeps the verified blob and decompressed tar as cache entries.
 
 ## Layer merge
 
-The internal merge stage consumes validated, uncompressed tar streams in
-manifest order. It reopens each stream without following a cache-path symlink,
-then rechecks its exact size, config `diff_id`, and archive safety before
-changing the filesystem tree.
-
-The host staging tree preserves ordinary and sticky permissions but remains
-owned by the unprivileged API service. It does not activate image-supplied
-set-ID bits or apply numeric ownership and extended attributes; those guest
-filesystem attributes belong to the later ext4 construction stage.
-
-For each layer, `.wh.<name>` removes the named sibling from lower layers and
-`.wh..wh..opq` removes lower-layer children from its directory. Whiteouts are
-applied before that layer's ordinary members regardless of archive order, so a
-same-layer replacement remains present and marker files never appear in the
-result.
-
-Merging builds a private sibling partial tree and atomically publishes it only
-after every layer succeeds; the destination must not already exist. Failures
-attempt to remove the partial tree and always retain verified blob and decompressed-layer cache entries.
+- Validated tars are consumed in manifest order.
+- Each stream is reopened without following a cache-path symlink, then rechecked for size, `diff_id`, and archive safety.
+- The staging tree keeps ordinary and sticky permissions, owned by the unprivileged API service.
+- Image set-ID bits, numeric ownership, and extended attributes are not applied here; they belong to the ext4 stage.
+- `.wh.<name>` removes the named sibling from lower layers; `.wh..wh..opq` removes lower-layer children of its directory.
+- Whiteouts are applied before that layer's ordinary members, so a same-layer replacement survives and markers never appear.
+- The tree is built as a private sibling and published atomically; the destination must not already exist.
+- A failure removes the partial tree and retains verified blob and layer cache entries.
 
 ## Guest toolbox
 
-A container image is an application, not an operating system: it has no PID 1,
-no DHCP client, and nothing that reports readiness. The internal pipeline
-supplies all three from one static program before a merged tree can become a bootable image.
+A container image is an application, not an operating system: no PID 1, no DHCP client, nothing that reports readiness.
+One static program supplies all three before a merged tree can boot.
 
-That program is taken from a digest-pinned busybox image, pulled through the
-same verified stages as the image being imported. It must be a 64-bit
-executable for this host with no dynamic loader recorded in it, because a
-merged container tree has no loader to satisfy. Only the first import on a host
-reaches the registry; the program is then cached at
-`<FIRECRAB_IMAGE_ROOT>/.oci/toolbox/`, re-verified on every reuse, and rebuilt
-when it no longer passes. Operators can name a mirror with
-`FIRECRAB_OCI_TOOLBOX_IMAGE` or an already-present program with
-`FIRECRAB_OCI_TOOLBOX_PATH`.
+- Taken from a digest-pinned busybox image, pulled through the same verified stages as the image being imported.
+- Must be a 64-bit executable for this host with no dynamic loader recorded, because the merged tree has none to satisfy.
+- Cached at `<FIRECRAB_IMAGE_ROOT>/.oci/toolbox/`, re-verified on every reuse, rebuilt when it no longer passes.
+- `FIRECRAB_OCI_TOOLBOX_IMAGE` names a mirror; `FIRECRAB_OCI_TOOLBOX_PATH` names a program already on the host.
 
 ## Guest activation
 
-Activation installs an init at `/sbin/init` and the toolbox at
-`/etc/firecrab/busybox` (basename `busybox`, so the multiplexer runs), so the
-image boots on the same kernel command line every other template uses. It also
-installs a boot script that mounts `/proc`, `/sys`, `/dev` (with `/dev/fd`) and `/run`, brings
-the interface up before asking for a lease, reports `FIRECRAB_NETWORK_READY`
-with the address it received or `FIRECRAB_NETWORK_FAILED` with a reason, and
-starts the metrics agent that reports guest CPU and memory. Missing PATH
-tools (`ping`, `wget`, `vi`, `nc`) become busybox symlinks. After DHCP, the
-first boot installs a small set through apt/dnf/apk/zypper/pacman and stamps
-`/etc/firecrab/base-packages.ok`. When the image ships util-linux `agetty`
-and bash, the serial console is `ttyS0 → agetty → login → bash`; otherwise
-the injected wrapper prints MOTD and drops into ash. When the image has a
-glibc dynamic loader, activation also copies a digest-pinned official
-fastfetch (polyfilled, GLIBC_2.17) to `/usr/bin/fastfetch`, cached at
-`<FIRECRAB_IMAGE_ROOT>/.oci/fastfetch/`. Operators can name a host binary
-with `FIRECRAB_OCI_FASTFETCH_PATH`. A missing program is not an import failure.
-`/etc/firecrab/services.d` is created empty for the image's own entrypoint, which a later stage translates into an ordinary service under that init rather than PID 1.
-
-Images that place `/sbin` or `/etc` behind a symbolic link are activated through it.
-Resolution is clamped to the tree, and an entry already occupying a guest path is replaced without writing through it.
-A failed activation restores every path it touched.
+- Installs an init at `/sbin/init` and the toolbox at `/etc/firecrab/busybox` (basename `busybox`, so the multiplexer runs).
+- The image then boots on the same kernel command line every other template uses.
+- The boot script mounts `/proc`, `/sys`, `/dev` (with `/dev/fd`), and `/run`.
+- The interface comes up before the lease is asked for; the result is `FIRECRAB_NETWORK_READY` with the address or `FIRECRAB_NETWORK_FAILED` with a reason.
+- The metrics agent reporting guest CPU and memory is started.
+- Missing PATH tools (`ping`, `wget`, `vi`, `nc`) become busybox symlinks.
+- After DHCP, the first boot installs a small set through apt/dnf/apk/zypper/pacman and stamps `/etc/firecrab/base-packages.ok`.
+- With util-linux `agetty` and bash, the serial console is `ttyS0 → agetty → login → bash`; otherwise the wrapper prints MOTD and drops into ash.
+- With a glibc loader, a digest-pinned official fastfetch (polyfilled, GLIBC_2.17) is copied to `/usr/bin/fastfetch`, cached at `<FIRECRAB_IMAGE_ROOT>/.oci/fastfetch/`.
+- `FIRECRAB_OCI_FASTFETCH_PATH` names a host binary; a missing program is not an import failure.
+- `/etc/firecrab/services.d` is created empty for the image entrypoint, which a later stage runs as a service rather than PID 1.
+- Images that place `/sbin` or `/etc` behind a symbolic link are activated through it.
+- Resolution is clamped to the tree; an entry already occupying a guest path is replaced without writing through it.
+- A failed activation restores every path it touched.
 
 ## Ext4 image
 
-The internal pipeline sizes the ext4 from the provisioned tree rather than from a fixed image length.
-Payload bytes count each regular inode once and include symlink targets;
-hard links are not added again.
+- The image is sized from the provisioned tree, not from a fixed length.
+- Payload counts each regular inode once and includes symlink targets; hard links are not counted again.
+- Size is payload plus a quarter for metadata plus 32 MiB headroom, rounded up to a mebibyte, never below 8 MiB.
+- One image is limited to 32 GiB (`FIRECRAB_OCI_MAX_ROOTFS_BYTES`).
+- Created sparse, formatted with `mkfs.ext4 -d`, published only after `tune2fs` shows free space remains.
+- A full image, a failed format, or an existing destination is an error; the partial file is removed and the tree left in place.
+- This stage pairs no kernel and registers nothing.
 
-The image is the payload plus a quarter for ext4 metadata plus 32 MiB of
-headroom, rounded up to a whole mebibyte and never below 8 MiB.
-One image is limited to 32 GiB by default; operators can change this with
-`FIRECRAB_OCI_MAX_ROOTFS_BYTES`.
+## Kernel
 
-The file is created sparse, formatted with `mkfs.ext4 -d`, and published
-only after `tune2fs` shows free space remains.
-A full image, a failed format, or an existing destination is an error;
-the partial file is removed and the provisioned tree is left in place.
-This stage still pairs no kernel and registers nothing.
+The packed ext4 is paired with the kernel firecrab publishes for this architecture, so no catalog image has to be installed first.
 
-## Kernel, name, register
+- `virtio_blk`, `virtio_net`, `virtio_mmio`, and `ext4` are built in, and there is no initrd.
+- Pinned by digest, fetched once from `FIRECRAB_IMAGE_BASE_URL`, cached at `<FIRECRAB_IMAGE_ROOT>/.oci/kernel/<arch>/`.
+- Re-verified on every reuse; a failed entry is refetched.
+- `FIRECRAB_OCI_KERNEL_PATH` names a host copy, which must match the same digest.
+- A host that cannot reach the registry falls back to an installed catalog kernel.
 
-The packed ext4 is paired with the kernel Firecrab publishes for this architecture — `virtio_blk`, `virtio_net`, `virtio_mmio`, and `ext4` built in, no initrd — so no catalog image has to be installed first.
-It is pinned by digest, fetched once from `FIRECRAB_IMAGE_BASE_URL`, cached at `<FIRECRAB_IMAGE_ROOT>/.oci/kernel/<arch>/`, and re-verified on every reuse.
-`FIRECRAB_OCI_KERNEL_PATH` names a host copy, which must match the same digest.
-A host that cannot reach the registry falls back to an installed catalog kernel.
-The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
-A catalog or installed alias is refused; the ext4 is copied to `rootfs/<alias>.ext4`.
-That local template is not a MicroRegistry row; register it as in [Images](images.md) and [API](api.md).
+## Name and register
+
+- The alias is the repository and tag — `nginx:1.27` becomes `nginx-1.27`.
+- A catalog or installed alias is refused.
+- The ext4 is copied to `rootfs/<alias>.ext4`.
+- The result is a local template, not a MicroRegistry row; register it as in [Images](images.md) and [API](api.md).
 
 ## Service
 
-Entrypoint, Cmd, Env, and WorkingDir become `/etc/firecrab/services.d/app`.
-The injected init starts it after the sentinel. It is never PID 1.
-On start, a `# >>> firecrab vm env` block sources `/etc/firecrab/vm.env`; guest paths are in [API](api.md).
+- Entrypoint, Cmd, Env, and WorkingDir become `/etc/firecrab/services.d/app`.
+- The injected init starts it after the sentinel. It is never PID 1.
+- On start, a `# >>> firecrab vm env` block sources `/etc/firecrab/vm.env`; guest paths are in [API](api.md).
 
 ## Related
 

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -7,6 +7,7 @@ The pipeline caches layers, merges them, injects a guest runtime, writes ext4, p
 
 | Section | Content |
 | --- | --- |
+| [Architecture](#architecture) | The stages an import runs through |
 | [Inspect](#inspect) | Ask whether an image can run here |
 | [Import](#import) | Start and poll the background job |
 | [Blob cache](#blob-cache) | Verified registry bytes on disk |
@@ -20,6 +21,53 @@ The pipeline caches layers, merges them, injects a guest runtime, writes ext4, p
 | [Name and register](#name-and-register) | Alias rules and the local template |
 | [Service](#service) | The image entrypoint as a service |
 | [Related](#related) | Other documents |
+
+## Architecture
+
+An import is a chain of stages. Each one verifies its input, publishes its output atomically, and hands a typed value to the next; nothing is registered until the last one succeeds.
+
+```mermaid
+flowchart TB
+    Ref["Reference (nginx:1.27)"]
+    Registry["Container registry"]
+    Blobs[("Blob cache<br/>.oci/blobs")]
+    Layers[("Layer cache<br/>.oci/layers")]
+    Merge["Merged tree"]
+    Toolbox[("Toolbox cache<br/>.oci/toolbox")]
+    Provision["Guest activation"]
+    Ext4["ext4 image"]
+    Kernel[("Kernel cache<br/>.oci/kernel")]
+    MicroRegistry["MicroRegistry"]
+    Template["Registered template"]
+    Ref -->|resolve, select platform| Registry
+    Registry -->|verified bytes| Blobs
+    Blobs -->|decompress, check diff ID| Layers
+    Layers -->|safety preflight, whiteouts| Merge
+    Registry -->|digest-pinned busybox| Toolbox
+    Toolbox --> Provision
+    Merge --> Provision
+    Provision -->|mkfs.ext4 -d| Ext4
+    MicroRegistry -->|digest-pinned kernel| Kernel
+    Ext4 --> Template
+    Kernel --> Template
+```
+
+| Stage | Input | Output | Cached at |
+| --- | --- | --- | --- |
+| Resolve | Reference | Manifest digest, architecture | — |
+| Blob cache | Manifest | Verified config and layer bytes | `.oci/blobs/sha256/` |
+| Decompress | Layer blob | Verified uncompressed tar | `.oci/layers/sha256/` |
+| Preflight | Tar | The same tar, proven safe | — |
+| Merge | Tars in manifest order | Staging tree | — |
+| Toolbox | busybox image | Static program | `.oci/toolbox/` |
+| Activate | Staging tree | Bootable tree with init | — |
+| Ext4 | Bootable tree | Packed image | — |
+| Kernel | MicroRegistry package | Kernel image | `.oci/kernel/<arch>/` |
+| Register | ext4 + kernel | `TemplateSpec` under an alias | `rootfs/<alias>.ext4` |
+
+- Caches are content-addressed and re-verified on reuse, so a repeated import contacts the network only for what it does not already hold.
+- Every cache lives under `<FIRECRAB_IMAGE_ROOT>/.oci/`; a partial write never lands at a final path.
+- The kernel is the only stage that reads the MicroRegistry rather than the container registry.
 
 ## Inspect
 

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -45,6 +45,7 @@ systemctl restart firecrab-api
 | `FIRECRAB_OCI_MAX_UNCOMPRESSED_LAYER_BYTES` | 64 GiB | Maximum decoded size of one OCI layer tar stream |
 | `FIRECRAB_OCI_MAX_ROOTFS_BYTES` | 32 GiB | Maximum size of one OCI-imported ext4 image |
 | `FIRECRAB_OCI_FASTFETCH_PATH` | (unset) | Host path of a fastfetch binary to copy into glibc guests |
+| `FIRECRAB_OCI_KERNEL_PATH` | (unset) | Host path of the pinned OCI import kernel, for mirrors and air-gapped hosts |
 | `FIRECRAB_STATIC_ROOT` | Installed dashboard | Static UI path |
 | `FIRECRAB_STORAGE_ROOTS` | `default=data` | Fixed storage roots |
 | `FIRECRAB_NET_HELPER_SOCK` | `/run/firecrab/net-helper.sock` | Helper socket |

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -7,7 +7,10 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 PUBLIC_DOCS = REPO / "public-docs"
-MAX_LINES = 170
+# A page is capped so it stays readable in one sitting, not to make authors
+# compress sentences: a contents table, one-fact lines, and a diagram all cost
+# lines that a reader gets back.
+MAX_LINES = 300
 # API is the contract page and may list guest paths in full.
 LINE_LIMIT_EXEMPT = frozenset({"api.md"})
 


### PR DESCRIPTION
## Summary

An OCI import no longer needs a catalog image installed. The packed ext4 is paired with the kernel Firecrab publishes on `registry.firecrab.dev`, pinned by digest, fetched once, and cached under the image root.

Closes #144.

## Contents

| Section | Content |
| --- | --- |
| [Motivation](#motivation) | Why the import borrowed Ubuntu's kernel and what it cost |
| [What landed](#what-landed) | Kernel source, cache, and fallback |
| [Pin](#pin) | The artifact this build trusts |
| [Verification rules](#verification-rules) | What every kernel must satisfy before it is used |
| [Not in this PR](#not-in-this-pr) | aarch64 |
| [Testing](#testing) | Commands and results |
| [Acceptance criteria](#acceptance-criteria) | #144's list |

## Motivation

- A container image carries no kernel, so pairing took the first catalog artifact without an initrd — only ever Ubuntu's.
- Importing a 50 MB `nginx:1.27` required Ubuntu's 890 MB package to read one file out of it. The rootfs was never used.
- The dependency was implicit: it surfaced only after layers were pulled, merged, and packed.

```text
import failed: no architecture-matched kernel at kernel/vmlinux-ubuntu-26.04-x86_64;
               install ubuntu-26.04 for x86_64
```

## What landed

- New `firecrab-api/src/oci/kernel.rs`, shaped after the guest toolbox (`busybox.rs`).
- Source order: `FIRECRAB_OCI_KERNEL_PATH` override → cache → registry download → installed catalog kernel.
- Cache: `<FIRECRAB_IMAGE_ROOT>/.oci/kernel/<arch>/vmlinux-7.1.8-x86_64`, recorded in the `TemplateSpec` as an image-root-relative path.
- Base URL is the existing `FIRECRAB_IMAGE_BASE_URL`, so a private mirror and `none` already cover the kernel.
- `pair_ext4_with_host_kernel` is now async; `boot::verify_kernel_architecture` is shared by pairing and the cache.
- The registry kernel is preferred even where Ubuntu is installed; the catalog kernel is the fallback, not the default.

## Pin

| Field | Value |
| --- | --- |
| Package | `kernel/7.1.8/x86_64/vmlinux-7.1.8.tar.zst` |
| Package sha256 | `eb2efc87…c11f53` |
| Kernel sha256 | `1d693ebb…293cdb` |
| Boot args | `console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw` |
| Size | 14 MB compressed, 51 MB on disk (Ubuntu's package is 890 MB) |

Digests, not a version tag — a repointed object cannot change what a host boots.

## Verification rules

- Package digest is calculated from the bytes actually written, before anything is unpacked.
- The lifted kernel is hashed and re-verified on every reuse; a failed cache entry is deleted and refetched.
- The ELF or arm64 header must name this host's architecture.
- An operator-supplied kernel skips the network but not the digest.
- Ceilings: 512 MiB on the downloaded package, 256 MiB on the kernel inside it.

## Not in this PR

- aarch64 has no published artifact yet (`kernel/7.1.8/aarch64/…` is 404), so it has no pin and keeps using the installed catalog kernel exactly as today.
- Adding the pin once the arm64 build is published is a constant, not a code change.

## Testing

- `cargo fmt --all`
- `cargo clippy -p firecrab-api --all-targets` — no new warnings
- `cargo test --workspace --offline --locked -- --test-threads=2` — 795 passed, 0 failed
- At full parallelism the two known load-sensitive VM timing tests flake and pass isolated; `handlers::bootstrap::…microboot_is_registered` needs 4 GiB free on `TMPDIR`
- `cargo llvm-cov` — `oci/kernel.rs` 84.0% lines, `oci/boot.rs` 90.0% lines
- rustdoc `--show-coverage` — `oci/kernel.rs` 93.8%, `oci/boot.rs` 92.9%
- `python3 scripts/check-doc-links.py`, `python3 scripts/check-changelog.py`
- 12 new tests in `oci/kernel_tests.rs`, 2 new in `oci/boot_tests.rs`

## Acceptance criteria

| #144 | State |
| --- | --- |
| Import completes with no catalog image installed | Kernel is fetched from the registry |
| Fetched once per host and architecture, reused with verification | Cache is re-verified every call |
| A corrupt cache entry is refetched | Covered by `a_corrupt_cached_kernel_is_refetched` |
| x86_64 never accepts the aarch64 artifact, and the reverse | Header check refuses it and publishes nothing |
| Ubuntu installed and registry unreachable still imports | Falls back to the installed catalog kernel |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OCI imports now automatically obtain a verified, architecture-specific kernel.
  * Added cached kernel downloads, configurable mirrors, and optional host-provided kernel files.
  * Added fallback to an installed kernel when remote retrieval is unavailable.
  * Added validation for kernel architecture, integrity, package contents, and cache safety.
  * Added clear errors for unavailable, invalid, or incomplete kernel packages.

* **Documentation**
  * Documented kernel caching, verification, fallback behavior, and the host-kernel configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->