### PR TITLE
docs: point public-docs examples at port 5523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Sections are **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**
 
 | Version | Date | Work |
 | --- | --- | --- |
-| [Unreleased](#unreleased) | — | [#145] |
+| [Unreleased](#unreleased) | — | [#145], [#147] |
 | [0.1.1](#011---2026-08-17) | 2026-08-17 | [#141], [#142], [#143] |
 | [0.1.0](#010---2026-08-16) | 2026-08-16 | First public release |
 
@@ -25,6 +25,7 @@ Entries land here as work merges, and move under the next version heading when t
 
 - An unreachable MicroRegistry falls back to an installed catalog kernel ([#145]).
 - Published pages may run to 300 lines, up from 170 ([#145]).
+- `public-docs/` API examples and check lists reference port `5523`, not `3000` ([#147]).
 
 ### Fixed
 
@@ -157,5 +158,6 @@ network helper.
 [#142]: https://github.com/SteelCrab/firecrab/issues/142
 [#143]: https://github.com/SteelCrab/firecrab/issues/143
 [#145]: https://github.com/SteelCrab/firecrab/pull/145
+[#147]: https://github.com/SteelCrab/firecrab/issues/147
 [2493c7d]: https://github.com/SteelCrab/firecrab/commit/2493c7d
 [7eb6740]: https://github.com/SteelCrab/firecrab/commit/7eb6740

--- a/public-docs/api.md
+++ b/public-docs/api.md
@@ -1,7 +1,7 @@
 # API
 
 `firecrab-api` provides REST endpoints and one console WebSocket.
-It listens on `127.0.0.1:3000` by default.
+It listens on `127.0.0.1:5523` by default.
 
 ## Run
 
@@ -38,7 +38,7 @@ Use `RUST_LOG=firecrab_api=debug` for detailed logs.
 Create a MicroNetwork first.
 
 ```sh
-NETWORK_ID=$(curl -s -X POST http://127.0.0.1:3000/api/micro-networks \
+NETWORK_ID=$(curl -s -X POST http://127.0.0.1:5523/api/micro-networks \
   -H 'Content-Type: application/json' \
   -d '{"name":"lab","subnetCidr":"172.30.0.0/24"}' \
   | jq -r '.id')
@@ -47,7 +47,7 @@ NETWORK_ID=$(curl -s -X POST http://127.0.0.1:3000/api/micro-networks \
 Create the VM with the returned network ID.
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/vms \
+curl -s -X POST http://127.0.0.1:5523/api/vms \
   -H 'Content-Type: application/json' \
   -d "{
     \"name\": \"demo\",
@@ -185,7 +185,7 @@ With no local rows and no catalog, GET is 503.
 Register an already-installed custom image.
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/microregistry/register \
+curl -s -X POST http://127.0.0.1:5523/api/microregistry/register \
   -H 'Content-Type: application/json' \
   -d '{"alias":"nginx-1.27","version":"1"}'
 ```
@@ -216,7 +216,7 @@ One shared egress IP spends that quota, and OCI inspect or import then answers `
 Save one account so pulls count against it instead.
 
 ```sh
-curl -s -X PUT http://127.0.0.1:3000/api/microregistry/docker-hub \
+curl -s -X PUT http://127.0.0.1:5523/api/microregistry/docker-hub \
   -H 'Content-Type: application/json' \
   -d '{"username":"pista","secret":"dckr_pat_..."}'
 ```

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -80,12 +80,12 @@ FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" \
   cargo run -p firecrab-api
 ```
 
-Open `http://127.0.0.1:3000/`.
+Open `http://127.0.0.1:5523/`.
 The host installer configures this mode.
 
 ## Check
 
-- Confirm that ports `3000` and `8080` are not used by old processes.
+- Confirm that ports `5523` and `8080` are not used by old processes.
 - Run the API from the repository root.
 - Start the helper before starting a VM.
 - Forward WebSocket upgrades for `/ws` through a reverse proxy.

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -49,7 +49,7 @@ cargo build --release -p firecrab-api -p firecrab-net-helper
 Open the dashboard after the services start.
 
 ```text
-http://127.0.0.1:3000/
+http://127.0.0.1:5523/
 ```
 
 The default install does not install a guest image.
@@ -98,8 +98,8 @@ DATADIR=/srv/firecrab PREFIX=/opt ./install.sh
 ```sh
 systemctl status firecrab-net-helper firecrab-api
 firecrab-doctor
-curl -s http://127.0.0.1:3000/api/vms
-curl -s http://127.0.0.1:3000/api/micro-networks
+curl -s http://127.0.0.1:5523/api/vms
+curl -s http://127.0.0.1:5523/api/micro-networks
 ```
 
 A new host has no MicroNetwork.

--- a/public-docs/networking.md
+++ b/public-docs/networking.md
@@ -6,7 +6,7 @@ It gives VMs a bridge, DHCP, NAT, and firewall policy.
 ## Create
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/micro-networks \
+curl -s -X POST http://127.0.0.1:5523/api/micro-networks \
   -H 'Content-Type: application/json' \
   -d '{
     "name": "lab",
@@ -33,7 +33,7 @@ Its TAP interface is attached to the network bridge.
 The network field `internetEnabled` controls NAT for the subnet.
 
 ```sh
-curl -s -X PATCH http://127.0.0.1:3000/api/micro-networks/<id> \
+curl -s -X PATCH http://127.0.0.1:5523/api/micro-networks/<id> \
   -H 'Content-Type: application/json' \
   -d '{"internetEnabled":false}'
 ```
@@ -43,7 +43,7 @@ Omit it, or send `null`, to use the host default-route interface.
 An empty string on PATCH resets the stored name back to that auto default.
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/micro-networks \
+curl -s -X POST http://127.0.0.1:5523/api/micro-networks \
   -H 'Content-Type: application/json' \
   -d '{"name":"edge","subnetCidr":"172.32.0.0/24","uplink":"eth1"}'
 ```
@@ -88,8 +88,8 @@ Traffic between different MicroNetworks is blocked.
 ## Inspect
 
 ```sh
-curl -s http://127.0.0.1:3000/api/micro-networks
-curl -s http://127.0.0.1:3000/api/micro-networks/<id>
+curl -s http://127.0.0.1:5523/api/micro-networks
+curl -s http://127.0.0.1:5523/api/micro-networks/<id>
 ```
 
 The detail response shows address use, bridge state, NAT, policy, and member VMs.
@@ -97,7 +97,7 @@ The detail response shows address use, bridge state, NAT, policy, and member VMs
 ## Delete
 
 ```sh
-curl -i -X DELETE http://127.0.0.1:3000/api/micro-networks/<id>
+curl -i -X DELETE http://127.0.0.1:5523/api/micro-networks/<id>
 ```
 
 Deletion returns `409` while a VM belongs to the network.

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -78,7 +78,7 @@ flowchart TB
 - HTTPS only, except `localhost` and `127.0.0.1`.
 
 ```sh
-curl -s 'http://127.0.0.1:3000/api/oci/inspect?reference=nginx:1.27'
+curl -s 'http://127.0.0.1:5523/api/oci/inspect?reference=nginx:1.27'
 ```
 
 - Docker Hub's anonymous quota is per source address, so a shared egress IP answers `429`.
@@ -92,7 +92,7 @@ curl -s 'http://127.0.0.1:3000/api/oci/inspect?reference=nginx:1.27'
 - Success adds the alias to `GET /api/images`.
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/oci/import \
+curl -s -X POST http://127.0.0.1:5523/api/oci/import \
   -H 'Content-Type: application/json' \
   -d '{"reference":"nginx:1.27"}'
 ```

--- a/public-docs/operations.md
+++ b/public-docs/operations.md
@@ -37,7 +37,7 @@ systemctl restart firecrab-api
 
 | Variable | Default | Job |
 | --- | --- | --- |
-| `FIRECRAB_BIND_ADDR` | `127.0.0.1:3000` | HTTP listen address |
+| `FIRECRAB_BIND_ADDR` | `127.0.0.1:5523` | HTTP listen address |
 | `FIRECRAB_ALLOWED_ORIGINS` | Development origin | Browser origin list |
 | `FIRECRAB_IMAGE_ROOT` | Installed image path | Kernels and rootfs files |
 | `FIRECRAB_IMAGE_BASE_URL` | Public MicroRegistry | Image package base URL; `none` disables remote installs |

--- a/public-docs/storage.md
+++ b/public-docs/storage.md
@@ -83,7 +83,7 @@ FIRECRAB_STORAGE_ROOTS='local=data:fast=/mnt/fast' \
 ## Find mounts
 
 ```sh
-curl -s http://127.0.0.1:3000/api/storage/devices
+curl -s http://127.0.0.1:5523/api/storage/devices
 ```
 
 This endpoint lists mounted filesystems and free space.
@@ -92,7 +92,7 @@ It does not change the host.
 ## Register
 
 ```sh
-curl -s -X POST http://127.0.0.1:3000/api/micro-storages \
+curl -s -X POST http://127.0.0.1:5523/api/micro-storages \
   -H 'Content-Type: application/json' \
   -d '{"name":"fast","path":"/mnt/fast"}'
 ```
@@ -113,7 +113,7 @@ A VM request cannot contain an arbitrary host path.
 Storage can change before the VM disk exists.
 
 ```sh
-curl -s -X PUT http://127.0.0.1:3000/api/vms/<vm-id>/storage \
+curl -s -X PUT http://127.0.0.1:5523/api/vms/<vm-id>/storage \
   -H 'Content-Type: application/json' \
   -d '{"storageRoot":"<storage-id>"}'
 ```

--- a/public-docs/troubleshooting.md
+++ b/public-docs/troubleshooting.md
@@ -22,11 +22,11 @@ df -h
 Check the API directly.
 
 ```sh
-curl -i http://127.0.0.1:3000/api/vms
+curl -i http://127.0.0.1:5523/api/vms
 ```
 
 Use `http://localhost:8080` for Vite development — `127.0.0.1:8080` is a
-different browser origin. Check for old processes on ports `3000` and `8080`.
+different browser origin. Check for old processes on ports `5523` and `8080`.
 
 ## Data appears empty
 
@@ -72,7 +72,7 @@ Use separate MicroStorage pools when one disk is saturated.
 Inspect the network and host bridge.
 
 ```sh
-curl -s http://127.0.0.1:3000/api/micro-networks/<id>
+curl -s http://127.0.0.1:5523/api/micro-networks/<id>
 ip -br link show type bridge
 sudo ss -lunp | grep ':67'
 ```


### PR DESCRIPTION
## Summary

`public-docs/` API examples and checklists move from port `3000` to `5523`, matching the new `FIRECRAB_BIND_ADDR` default.

Part of #147.

## What changed

- `public-docs/api.md`, `dashboard.md`, `installation.md`, `networking.md`, `oci.md`, `operations.md`, `storage.md`, `troubleshooting.md`: `127.0.0.1:3000` → `127.0.0.1:5523` in `curl` examples and checklists
- `CHANGELOG.md`: Unreleased entry

## Testing

- `python3 scripts/check-doc-links.py`
- `python3 scripts/check-changelog.py`
- `grep -rn 3000 public-docs/` — no matches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API, dashboard, installation, networking, OCI, operations, storage, and troubleshooting examples to use port **5523** instead of **3000**.
  - Updated default server addresses, dashboard links, port checks, and port-conflict guidance.
  - Added the related change to the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->