### PR TITLE
docs: point onboarding docs at port 5523

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Sections are **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**
 
 | Version | Date | Work |
 | --- | --- | --- |
-| [Unreleased](#unreleased) | — | [#145] |
+| [Unreleased](#unreleased) | — | [#145], [#147] |
 | [0.1.1](#011---2026-08-17) | 2026-08-17 | [#141], [#142], [#143] |
 | [0.1.0](#010---2026-08-16) | 2026-08-16 | First public release |
 
@@ -25,6 +25,7 @@ Entries land here as work merges, and move under the next version heading when t
 
 - An unreachable MicroRegistry falls back to an installed catalog kernel ([#145]).
 - Published pages may run to 300 lines, up from 170 ([#145]).
+- README (all locales) and `CONTRIBUTING.md` point at port `5523`, not `3000` ([#147]).
 
 ### Fixed
 
@@ -157,5 +158,6 @@ network helper.
 [#142]: https://github.com/SteelCrab/firecrab/issues/142
 [#143]: https://github.com/SteelCrab/firecrab/issues/143
 [#145]: https://github.com/SteelCrab/firecrab/pull/145
+[#147]: https://github.com/SteelCrab/firecrab/issues/147
 [2493c7d]: https://github.com/SteelCrab/firecrab/commit/2493c7d
 [7eb6740]: https://github.com/SteelCrab/firecrab/commit/7eb6740

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ npm install --prefix firecrab-frontend
 npm run dev --prefix firecrab-frontend
 ```
 
-Production-like (API serves the built SPA on `http://127.0.0.1:3000/`):
+Production-like (API serves the built SPA on `http://127.0.0.1:5523/`):
 
 ```sh
 npm run build --prefix firecrab-frontend
@@ -200,7 +200,7 @@ When you move or rename a public guide, update references in code comments, scri
 
 ## Security and scope notes
 
-- **Default bind is loopback** (`127.0.0.1:3000`). The control plane is meant for a trusted host or a carefully reverse-proxied deployment. Do not assume auth or multi-tenant isolation is present.
+- **Default bind is loopback** (`127.0.0.1:5523`). The control plane is meant for a trusted host or a carefully reverse-proxied deployment. Do not assume auth or multi-tenant isolation is present.
 - **No implicit “open to the LAN”** in contributions. If you expose the API, document the risk.
 - Prefer extending the **helper protocol** over giving the API new host privileges.
 - Avoid expanding into multi-host scheduling, full cloud IAM, or Jailer/VRF unless the change is explicitly agreed — those sit outside the current single-host MVP focus.

--- a/README.ja.md
+++ b/README.ja.md
@@ -115,7 +115,7 @@ KVM を有効化できません。`/dev/kvm` がない場合は、先にハー�
 
 ## クイックスタート
 
-インストール後に `http://127.0.0.1:3000/` を開き、次の順に進めます。
+インストール後に `http://127.0.0.1:5523/` を開き、次の順に進めます。
 
 1. **MicroNetwork** を作成します。
 2. インストール済みイメージを選び、そのネットワークに VM を作成します。
@@ -203,7 +203,7 @@ npm run dev --prefix firecrab-frontend
 ```sh
 npm run build --prefix firecrab-frontend
 FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
-# http://127.0.0.1:3000/
+# http://127.0.0.1:5523/
 ```
 
 Rust のテストスイートは次で実行します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -209,7 +209,7 @@ curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/instal
 
 ## 빠른 시작
 
-설치 후 `http://127.0.0.1:3000/`을 열고 다음 순서로 진행하세요.
+설치 후 `http://127.0.0.1:5523/`을 열고 다음 순서로 진행하세요.
 
 1. **MicroNetwork**를 만듭니다.
 2. 설치된 이미지를 고르고, 그 네트워크에 VM을 생성합니다.
@@ -297,7 +297,7 @@ npm run dev --prefix firecrab-frontend
 ```sh
 npm run build --prefix firecrab-frontend
 FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
-# http://127.0.0.1:3000/
+# http://127.0.0.1:5523/
 ```
 
 Rust 테스트는 다음처럼 실행합니다.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ upgrade detail, and troubleshooting step, read the [installation guide](public-d
 
 ## Quick start
 
-Open `http://127.0.0.1:3000/` after installation, then:
+Open `http://127.0.0.1:5523/` after installation, then:
 
 1. Create a **MicroNetwork**.
 2. Choose an installed image and create a VM in that network.
@@ -306,7 +306,7 @@ For a production-like local run, build the dashboard and let the API serve it:
 ```sh
 npm run build --prefix firecrab-frontend
 FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
-# http://127.0.0.1:3000/
+# http://127.0.0.1:5523/
 ```
 
 Run the Rust test suite with:

--- a/README.zh.md
+++ b/README.zh.md
@@ -107,7 +107,7 @@ curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/instal
 
 ## 快速开始
 
-安装后打开 `http://127.0.0.1:3000/`，然后：
+安装后打开 `http://127.0.0.1:5523/`，然后：
 
 1. 创建 **MicroNetwork**。
 2. 选择已安装的镜像，并在该网络中创建 VM。
@@ -189,7 +189,7 @@ npm run dev --prefix firecrab-frontend
 ```sh
 npm run build --prefix firecrab-frontend
 FIRECRAB_STATIC_ROOT="$PWD/firecrab-frontend/dist" cargo run -p firecrab-api
-# http://127.0.0.1:3000/
+# http://127.0.0.1:5523/
 ```
 
 运行 Rust 测试套件：


### PR DESCRIPTION
## Summary

README (all four locales) and `CONTRIBUTING.md` move from port `3000` to `5523`, matching the new `FIRECRAB_BIND_ADDR` default.

Part of #147.

## What changed

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh.md`: `127.0.0.1:3000` → `127.0.0.1:5523`
- `CONTRIBUTING.md`: dev-mode URL and the loopback-bind note
- `CHANGELOG.md`: Unreleased entry

## Testing

- `python3 scripts/check-doc-links.py`
- `python3 scripts/check-changelog.py`
- `grep -rn 3000 README*.md CONTRIBUTING.md` — no matches
