### PR TITLE
chore(config): move default bind port from 3000 to 5523

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,39 +272,39 @@ jobs:
         # and leave a real MicroNetwork for the capability checks below.
         run: |
           set -o pipefail
-          curl -fsS -o /dev/null -w 'dashboard %{http_code} %{content_type}\n' http://127.0.0.1:3000/
-          test "$(curl -fsS http://127.0.0.1:3000/api/vms)" = '[]'
+          curl -fsS -o /dev/null -w 'dashboard %{http_code} %{content_type}\n' http://127.0.0.1:5523/
+          test "$(curl -fsS http://127.0.0.1:5523/api/vms)" = '[]'
 
           # Fresh install has zero MicroNetworks (no implicit fcbr0).
-          NET=$(curl -fsS -X POST http://127.0.0.1:3000/api/micro-networks \
-                 -H 'Origin: http://127.0.0.1:3000' -H 'content-type: application/json' \
+          NET=$(curl -fsS -X POST http://127.0.0.1:5523/api/micro-networks \
+                 -H 'Origin: http://127.0.0.1:5523' -H 'content-type: application/json' \
                  -d '{"name":"ci","subnetCidr":"172.31.0.0/24","internetEnabled":true}' \
                | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
           echo "NET=$NET"
-          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:3000/api/micro-networks \
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:5523/api/micro-networks \
                -H 'Origin: http://evil.example' -H 'content-type: application/json' \
                -d '{"name":"nope","subnetCidr":"172.32.0.0/24","internetEnabled":true}')" = 403
 
           # microNetworkId is required (serde) — omit it → 400.
-          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:3000/api/vms \
+          test "$(curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:5523/api/vms \
                -H 'content-type: application/json' \
                -d '{"name":"no-net","template":"alpine-3.24","cpu":1,"ram":512,"diskGb":2}')" = 400
 
           # Unknown MicroNetwork → 400 field error, no VM row left behind.
-          code=$(curl -s -o /tmp/create-bad-net.json -w '%{http_code}' -X POST http://127.0.0.1:3000/api/vms \
+          code=$(curl -s -o /tmp/create-bad-net.json -w '%{http_code}' -X POST http://127.0.0.1:5523/api/vms \
                -H 'content-type: application/json' \
                -d '{"name":"bad-net","template":"alpine-3.24","cpu":1,"ram":512,"diskGb":2,"microNetworkId":"00000000-0000-0000-0000-000000000099"}')
           test "$code" = 400
           grep -q microNetworkId /tmp/create-bad-net.json
-          test "$(curl -fsS http://127.0.0.1:3000/api/vms)" = '[]'
+          test "$(curl -fsS http://127.0.0.1:5523/api/vms)" = '[]'
 
           # Valid network but no guest image (--no-images) → template rejected.
-          code=$(curl -s -o /tmp/create-no-image.json -w '%{http_code}' -X POST http://127.0.0.1:3000/api/vms \
+          code=$(curl -s -o /tmp/create-no-image.json -w '%{http_code}' -X POST http://127.0.0.1:5523/api/vms \
                -H 'content-type: application/json' \
                -d "{\"name\":\"need-image\",\"template\":\"alpine-3.24\",\"cpu\":1,\"ram\":512,\"diskGb\":2,\"microNetworkId\":\"$NET\"}")
           test "$code" = 400
           grep -q template /tmp/create-no-image.json
-          test "$(curl -fsS http://127.0.0.1:3000/api/vms)" = '[]'
+          test "$(curl -fsS http://127.0.0.1:5523/api/vms)" = '[]'
 
       - name: Capability set is sufficient at runtime
         # After at least one MicroNetwork exists, the helper has exercised
@@ -325,7 +325,7 @@ jobs:
             --dashboard-dir firecrab-frontend/dist
           systemctl is-active --quiet firecrab-api
           # The MicroNetwork created above has to survive a re-install.
-          curl -fsS http://127.0.0.1:3000/api/micro-networks | grep -q '"ci"'
+          curl -fsS http://127.0.0.1:5523/api/micro-networks | grep -q '"ci"'
 
       - name: Uninstall keeps data, purge removes it
         run: |
@@ -483,7 +483,7 @@ jobs:
       - name: Images on disk
         run: |
           sudo ls -l /var/lib/firecrab/images/rootfs/ || true
-          curl -fsS http://127.0.0.1:3000/api/vms
+          curl -fsS http://127.0.0.1:5523/api/vms
 
       - name: Boot M2 guest (create → start → ping → stop)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Sections are **Added**, **Changed**, **Deprecated**, **Fixed**, and **Improved**
 
 | Version | Date | Work |
 | --- | --- | --- |
-| [Unreleased](#unreleased) | — | [#145] |
+| [Unreleased](#unreleased) | — | [#145], [#147] |
 | [0.1.1](#011---2026-08-17) | 2026-08-17 | [#141], [#142], [#143] |
 | [0.1.0](#010---2026-08-16) | 2026-08-16 | First public release |
 
@@ -25,6 +25,7 @@ Entries land here as work merges, and move under the next version heading when t
 
 - An unreachable MicroRegistry falls back to an installed catalog kernel ([#145]).
 - Published pages may run to 300 lines, up from 170 ([#145]).
+- Default `FIRECRAB_BIND_ADDR` moves from `127.0.0.1:3000` to `127.0.0.1:5523` ([#147]).
 
 ### Fixed
 
@@ -157,5 +158,6 @@ network helper.
 [#142]: https://github.com/SteelCrab/firecrab/issues/142
 [#143]: https://github.com/SteelCrab/firecrab/issues/143
 [#145]: https://github.com/SteelCrab/firecrab/pull/145
+[#147]: https://github.com/SteelCrab/firecrab/issues/147
 [2493c7d]: https://github.com/SteelCrab/firecrab/commit/2493c7d
 [7eb6740]: https://github.com/SteelCrab/firecrab/commit/7eb6740

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -51,7 +51,7 @@ pub struct HttpConfig {
 
 impl HttpConfig {
     pub fn load() -> Result<Self, ConfigError> {
-        let bind = env::var("FIRECRAB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:5523".to_owned());
+        let bind = bind_addr_or_default(env::var("FIRECRAB_BIND_ADDR").ok());
         let authentication_enabled = env_flag("FIRECRAB_AUTHENTICATION_ENABLED");
         let tls_enabled = env_flag("FIRECRAB_TLS_ENABLED");
         let production = env::var("FIRECRAB_ENV").is_ok_and(|value| value == "production");
@@ -114,6 +114,10 @@ fn resolve_static_root(configured: Option<String>) -> Option<PathBuf> {
         "FIRECRAB_STATIC_ROOT has no index.html; serving the API only"
     );
     None
+}
+
+fn bind_addr_or_default(configured: Option<String>) -> String {
+    configured.unwrap_or_else(|| "127.0.0.1:5523".to_owned())
 }
 
 fn env_flag(name: &str) -> bool {
@@ -450,6 +454,19 @@ mod tests {
     fn rejects_insecure_non_loopback_bind() {
         let result = HttpConfig::from_values("0.0.0.0:3000", "", false, false);
         assert_matches!(result, Err(ConfigError::InsecureNonLoopbackBind));
+    }
+
+    #[test]
+    fn bind_addr_defaults_when_unset() {
+        assert_eq!(bind_addr_or_default(None), "127.0.0.1:5523");
+    }
+
+    #[test]
+    fn bind_addr_honors_override() {
+        assert_eq!(
+            bind_addr_or_default(Some("0.0.0.0:9999".to_owned())),
+            "0.0.0.0:9999"
+        );
     }
 
     #[test]

--- a/firecrab-api/src/server.rs
+++ b/firecrab-api/src/server.rs
@@ -51,7 +51,7 @@ pub struct HttpConfig {
 
 impl HttpConfig {
     pub fn load() -> Result<Self, ConfigError> {
-        let bind = env::var("FIRECRAB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3000".to_owned());
+        let bind = env::var("FIRECRAB_BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:5523".to_owned());
         let authentication_enabled = env_flag("FIRECRAB_AUTHENTICATION_ENABLED");
         let tls_enabled = env_flag("FIRECRAB_TLS_ENABLED");
         let production = env::var("FIRECRAB_ENV").is_ok_and(|value| value == "production");

--- a/firecrab-e2e/README.md
+++ b/firecrab-e2e/README.md
@@ -54,7 +54,7 @@ FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:register --prefix firecrab-e2e
 Expect **2 passed, 2 skipped** (import + register/409; failed-job and reinstall/boot are product-gated).
 A leftover `127.0.0.1-15556-firecrab-e2e-ready` catalog row fails `beforeAll` until L3 grows a DELETE.
 
-Playwright starts `firecrab-api` on `:3000` and Vite on `:8080` unless those
+Playwright starts `firecrab-api` on `:5523` and Vite on `:8080` unless those
 ports already answer.
 Open the dashboard as `http://localhost:8080`.
 `127.0.0.1:8080` is a different CORS origin and will fail.
@@ -85,7 +85,7 @@ imported template, or MicroNetwork this suite created.
 | `FIRECRAB_E2E_SKIP_GUEST_BOOT` | unset | Skip VM create/start when `1` / `true` / `yes` |
 | `FIRECRAB_OCI_E2E_PORT` | `15555` | Loopback registry port |
 | `FIRECRAB_E2E_BASE_URL` | `http://localhost:8080` | Dashboard origin |
-| `FIRECRAB_E2E_API_URL` | `http://127.0.0.1:3000` | API used for cleanup |
+| `FIRECRAB_E2E_API_URL` | `http://127.0.0.1:5523` | API used for cleanup |
 
 The suite does not infer `/dev/kvm`.
 Unset the skip flag only on a host that can actually boot a guest.

--- a/firecrab-e2e/playwright.config.ts
+++ b/firecrab-e2e/playwright.config.ts
@@ -26,7 +26,7 @@ const baseURL = (process.env.FIRECRAB_E2E_BASE_URL ?? "http://localhost:8080").r
  *   # FIRECRAB_OCI_E2E_READY on the console:
  *   npm test --prefix firecrab-e2e
  *
- * Playwright starts firecrab-api (unless :3000 already answers) and Vite
+ * Playwright starts firecrab-api (unless :5523 already answers) and Vite
  * (unless :8080 already answers). Guest boot also needs KVM, firecracker on
  * PATH, and a *responsive* `./scripts/dev-net-helper.sh` (Unix socket
  * /run/firecrab/net-helper.sock). Skip guest boot only via
@@ -60,7 +60,7 @@ export default defineConfig({
     {
       command: "node firecrab-e2e/scripts/ensure-api.mjs",
       cwd: repoRoot,
-      url: "http://127.0.0.1:3000/api/host",
+      url: "http://127.0.0.1:5523/api/host",
       reuseExistingServer: !process.env.CI,
       timeout: 180_000,
     },

--- a/firecrab-e2e/src/constants.ts
+++ b/firecrab-e2e/src/constants.ts
@@ -57,7 +57,7 @@ export const REGISTER_NETWORK_NAME = "register-e2e";
 /** Isolated subnet so the register spec does not share {@link NETWORK_CIDR}. */
 export const REGISTER_NETWORK_CIDR = "172.30.91.0/24";
 
-export const DEFAULT_API_URL = "http://127.0.0.1:3000";
+export const DEFAULT_API_URL = "http://127.0.0.1:5523";
 export const DEFAULT_BASE_URL = "http://localhost:8080";
 
 export function envFlag(name: string): boolean {

--- a/firecrab-frontend/vite.config.ts
+++ b/firecrab-frontend/vite.config.ts
@@ -22,14 +22,14 @@ export default defineConfig({
     allowedHosts: true,
     proxy: {
       '/api': {
-        target: 'http://127.0.0.1:3000',
+        target: 'http://127.0.0.1:5523',
         changeOrigin: true,
       },
       // Kept as its own path prefix (not nested under /api) because Vite's
       // proxy, like trunk's, is HTTP-or-WebSocket per prefix rather than
       // per-request — see the matching comment in firecrab-api/src/server.rs.
       '/ws': {
-        target: 'ws://127.0.0.1:3000',
+        target: 'ws://127.0.0.1:5523',
         ws: true,
       },
     },

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Downloads a host bundle from a GitHub Release (or installs local binaries
 # via --bin-dir), then lays out systemd units so the dashboard is served on
-# http://127.0.0.1:3000/.
+# http://127.0.0.1:5523/.
 #
 # Bundles are Linux x86_64/aarch64 × gnu (glibc) / musl. glibc hosts get the
 # gnu bundle; musl hosts (Alpine) get musl. Override with --libc.
@@ -663,7 +663,7 @@ install_config() {
 # firecrab API settings. The unit already sets the image root, the dashboard
 # assets and the working directory; uncomment only what you want to change.
 #
-# FIRECRAB_BIND_ADDR=127.0.0.1:3000
+# FIRECRAB_BIND_ADDR=127.0.0.1:5523
 # A non-loopback address requires authentication AND TLS to be enabled.
 # FIRECRAB_ALLOWED_ORIGINS=
 # Empty is correct while the dashboard is served from this same origin.
@@ -850,7 +850,7 @@ ensure_images() {
 }
 
 api_url() {
-    printf 'http://%s' "${FIRECRAB_BIND_ADDR:-127.0.0.1:3000}"
+    printf 'http://%s' "${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}"
 }
 
 json_status() {
@@ -965,7 +965,7 @@ start_units() {
 # can take noticeably longer to hash than the process takes to fork. Poll the
 # real HTTP port so callers relying on start_units's return don't race it.
 wait_for_api() {
-    local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:3000}
+    local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}
     local _attempt
     for _attempt in $(seq 1 60); do
         curl -fsS -o /dev/null "http://$bind/" && return 0
@@ -1085,7 +1085,7 @@ do_install() {
     fi
     report_ufw
 
-    local bind=127.0.0.1:3000
+    local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}
     log "done — dashboard at http://$bind/"
     if ! images_present; then
         step "guest images: install from the dashboard Images page"

--- a/scripts/ci-m2-guest-boot.sh
+++ b/scripts/ci-m2-guest-boot.sh
@@ -5,12 +5,12 @@
 # Usage: scripts/ci-m2-guest-boot.sh <template-alias>
 #   e.g. scripts/ci-m2-guest-boot.sh alpine-3.24.1
 #
-# Prerequisites: firecrab-api listening on :3000, a registered template,
+# Prerequisites: firecrab-api listening on :5523, a registered template,
 # KVM available, micro_network create works (explicit networks only).
 set -euo pipefail
 
 TEMPLATE=${1:?template alias required (e.g. alpine-3.24.1)}
-API=${FIRECRAB_API:-http://127.0.0.1:3000}
+API=${FIRECRAB_API:-http://127.0.0.1:5523}
 # Unique /24 per template hash so parallel matrix jobs on one host would not
 # collide if ever co-located (each CI job is its own runner today).
 SUBNET_THIRD=$(printf '%s' "$TEMPLATE" | cksum | awk '{print ($1 % 200) + 20}')

--- a/scripts/vm-batch.sh
+++ b/scripts/vm-batch.sh
@@ -5,7 +5,7 @@
 
 set -u
 
-API="${FIRECRAB_API:-http://127.0.0.1:3000}"
+API="${FIRECRAB_API:-http://127.0.0.1:5523}"
 ORIGIN="${FIRECRAB_ORIGIN:-http://localhost:8080}"
 STATE_FILE="${FIRECRAB_BATCH_STATE:-/tmp/firecrab-vm-batch.ids}"
 


### PR DESCRIPTION
## Summary

- Default FIRECRAB_BIND_ADDR moves from 127.0.0.1:3000 to 127.0.0.1:5523.

## Test plan

 - cargo test -p firecrab-api server:: — 8 passed
 -  cargo fmt -p firecrab-api -- --check
 - cargo clippy -p firecrab-api --all-targets -- -D warnings 
 - shellcheck install.sh scripts/vm-batch.sh scripts/ci-m2-guest-boot.sh
 -  bash install.sh --help, bash install.sh --check
 - CI Installer (shellcheck, --check, doctor, install/uninstall) job
 codecov/patch ≥ 80%