### PR TITLE
chore(install): remove guest-image preinstall flags in favor of OCI import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
     name: Installer (shellcheck, --check, doctor, install/uninstall)
     # A GitHub-hosted Linux runner is a throwaway VM with systemd, so the whole
     # installer can be exercised for real — the one thing this cannot cover is
-    # booting a guest, which needs an image build (see --no-images below).
+    # booting a guest, since install.sh never installs a guest image itself
+    # (see below); that needs an OCI import, covered by the vm-boot jobs.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -221,10 +222,10 @@ jobs:
         run: ./scripts/ci-prepare-install-payload.sh
 
       - name: Install
-        # --no-images: building a guest rootfs needs sudo/chroot and ~10 minutes.
-        # Everything else — deps, account, directories, units, dashboard — is real.
+        # install.sh never installs a guest image itself now — deps, account,
+        # directories, units, dashboard are all still real.
         run: |
-          sudo -E env "PATH=$PATH" ./install.sh --no-images \
+          sudo -E env "PATH=$PATH" ./install.sh \
             --bin-dir target/release \
             --dashboard-dir firecrab-frontend/dist
 
@@ -243,8 +244,9 @@ jobs:
       - name: Doctor after install
         # Runtime host path must be clean. Run from the unit WorkingDirectory
         # so the checkout's data/firecrab.db is not counted as a second DB.
-        # Images are intentionally absent (--no-images), so the only acceptable
-        # FAIL is the images check. sudo so nft/ufw are not SKIP'd.
+        # Images are intentionally absent (install.sh never fetches one), so
+        # the only acceptable FAIL is the images check. sudo so nft/ufw are
+        # not SKIP'd.
         run: |
           set +e
           out=$(sudo env DATADIR=/var/lib/firecrab \
@@ -267,9 +269,10 @@ jobs:
           test "$code" -eq 1
 
       - name: Dashboard, MicroNetwork, and create-VM API smoke
-        # --no-images: cannot boot a guest here. Still exercise the control-plane
-        # path that PR CI used to skip: create a network, reject bad creates,
-        # and leave a real MicroNetwork for the capability checks below.
+        # No guest image here, so no guest boot. Still exercise the
+        # control-plane path that PR CI used to skip: create a network,
+        # reject bad creates, and leave a real MicroNetwork for the
+        # capability checks below.
         run: |
           set -o pipefail
           curl -fsS -o /dev/null -w 'dashboard %{http_code} %{content_type}\n' http://127.0.0.1:5523/
@@ -298,7 +301,7 @@ jobs:
           grep -q microNetworkId /tmp/create-bad-net.json
           test "$(curl -fsS http://127.0.0.1:5523/api/vms)" = '[]'
 
-          # Valid network but no guest image (--no-images) → template rejected.
+          # Valid network but no guest image installed → template rejected.
           code=$(curl -s -o /tmp/create-no-image.json -w '%{http_code}' -X POST http://127.0.0.1:5523/api/vms \
                -H 'content-type: application/json' \
                -d "{\"name\":\"need-image\",\"template\":\"alpine-3.24\",\"cpu\":1,\"ram\":512,\"diskGb\":2,\"microNetworkId\":\"$NET\"}")
@@ -320,7 +323,7 @@ jobs:
 
       - name: Re-running is safe
         run: |
-          sudo -E env "PATH=$PATH" ./install.sh --no-images \
+          sudo -E env "PATH=$PATH" ./install.sh \
             --bin-dir target/release \
             --dashboard-dir firecrab-frontend/dist
           systemctl is-active --quiet firecrab-api
@@ -467,18 +470,54 @@ jobs:
       - name: Build install payload
         run: ./scripts/ci-prepare-install-payload.sh
 
-      - name: Install firecrab with guest image(s)
-        # Alpine is the default image build; Ubuntu and Rocky 9.8 are opt-in.
+      - name: Install firecrab
+        # Alpine is the M2Image catalog default; install.sh no longer
+        # preinstalls a guest image itself (see the next step).
         run: |
           set -euo pipefail
-          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh
-            --bin-dir target/release
-            --dashboard-dir firecrab-frontend/dist)
+          sudo -E env "PATH=$PATH" ./install.sh \
+            --bin-dir target/release \
+            --dashboard-dir firecrab-frontend/dist
+
+      - name: Import guest image
+        # Ubuntu/Rocky come from OCI import now, replacing install.sh's old
+        # --with-ubuntu-image/--with-rocky-image. The registered alias is the
+        # reference's repository and tag (public-docs/oci.md#name-and-register),
+        # which does not always match matrix.template (e.g. Rocky's Docker Hub
+        # repo is rockylinux/rockylinux, not rocky) — so it is captured into
+        # BOOT_TEMPLATE instead of assumed.
+        run: |
+          set -euo pipefail
           case "${{ matrix.template }}" in
-            ubuntu-*) INSTALL+=(--with-ubuntu-image) ;;
-            rocky-*) INSTALL+=(--with-rocky-image) ;;
+            ubuntu-*) reference=ubuntu:26.04 ;;
+            rocky-*) reference=rockylinux/rockylinux:9.8 ;;
+            *)
+              echo "BOOT_TEMPLATE=${{ matrix.template }}" >>"$GITHUB_ENV"
+              exit 0
+              ;;
           esac
-          "${INSTALL[@]}"
+          alias=$(curl -fsS "http://127.0.0.1:5523/api/oci/inspect?reference=$reference" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["alias"])')
+          body=$(mktemp)
+          code=$(curl -sS -o "$body" -w '%{http_code}' -X POST http://127.0.0.1:5523/api/oci/import \
+            -H 'content-type: application/json' -d "{\"reference\":\"$reference\"}")
+          case "$code" in
+            202) ;;
+            409) echo "BOOT_TEMPLATE=$alias" >>"$GITHUB_ENV"; exit 0 ;;
+            *) echo "oci/import $reference: HTTP $code $(cat "$body")" >&2; exit 1 ;;
+          esac
+          status=unknown
+          for _ in $(seq 1 180); do
+            status=$(curl -fsS "http://127.0.0.1:5523/api/oci/import/$alias" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')
+            case "$status" in
+              succeeded) break ;;
+              failed) echo "oci/import $reference failed" >&2; exit 1 ;;
+              *) sleep 2 ;;
+            esac
+          done
+          test "$status" = succeeded
+          echo "BOOT_TEMPLATE=$alias" >>"$GITHUB_ENV"
 
       - name: Images on disk
         run: |
@@ -488,7 +527,7 @@ jobs:
       - name: Boot M2 guest (create → start → ping → stop)
         run: |
           chmod +x scripts/ci-m2-guest-boot.sh
-          scripts/ci-m2-guest-boot.sh "${{ matrix.template }}"
+          scripts/ci-m2-guest-boot.sh "$BOOT_TEMPLATE"
 
       - name: Console log and journals (on failure)
         if: failure()
@@ -573,22 +612,56 @@ jobs:
       - name: Build install payload
         run: ./scripts/ci-prepare-install-payload.sh
 
-      - name: Install firecrab with guest image(s)
+      - name: Install firecrab
         run: |
           set -euo pipefail
-          INSTALL=(sudo -E env "PATH=$PATH" ./install.sh
-            --bin-dir target/release
-            --dashboard-dir firecrab-frontend/dist)
+          sudo -E env "PATH=$PATH" ./install.sh \
+            --bin-dir target/release \
+            --dashboard-dir firecrab-frontend/dist
+
+      - name: Import guest image
+        # Ubuntu/Rocky come from OCI import; see the vm-boot job for why the
+        # registered alias (BOOT_TEMPLATE) is captured instead of assumed to
+        # equal matrix.template. A self-hosted runner is long-lived, so a
+        # prior nightly's image is expected: 409 (already registered) is not
+        # an error here.
+        run: |
+          set -euo pipefail
           case "${{ matrix.template }}" in
-            ubuntu-*) INSTALL+=(--with-ubuntu-image) ;;
-            rocky-*) INSTALL+=(--with-rocky-image) ;;
+            ubuntu-*) reference=ubuntu:26.04 ;;
+            rocky-*) reference=rockylinux/rockylinux:9.8 ;;
+            *)
+              echo "BOOT_TEMPLATE=${{ matrix.template }}" >>"$GITHUB_ENV"
+              exit 0
+              ;;
           esac
-          "${INSTALL[@]}"
+          alias=$(curl -fsS "http://127.0.0.1:5523/api/oci/inspect?reference=$reference" \
+            | python3 -c 'import json,sys; print(json.load(sys.stdin)["alias"])')
+          body=$(mktemp)
+          code=$(curl -sS -o "$body" -w '%{http_code}' -X POST http://127.0.0.1:5523/api/oci/import \
+            -H 'content-type: application/json' -d "{\"reference\":\"$reference\"}")
+          case "$code" in
+            202) ;;
+            409) echo "BOOT_TEMPLATE=$alias" >>"$GITHUB_ENV"; exit 0 ;;
+            *) echo "oci/import $reference: HTTP $code $(cat "$body")" >&2; exit 1 ;;
+          esac
+          status=unknown
+          for _ in $(seq 1 180); do
+            status=$(curl -fsS "http://127.0.0.1:5523/api/oci/import/$alias" \
+              | python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])')
+            case "$status" in
+              succeeded) break ;;
+              failed) echo "oci/import $reference failed" >&2; exit 1 ;;
+              *) sleep 2 ;;
+            esac
+          done
+          test "$status" = succeeded
+          echo "BOOT_TEMPLATE=$alias" >>"$GITHUB_ENV"
 
       - name: Boot M2 guest
         run: |
           chmod +x scripts/ci-m2-guest-boot.sh
-          scripts/ci-m2-guest-boot.sh "${{ matrix.template }}"
+          scripts/ci-m2-guest-boot.sh "$BOOT_TEMPLATE"
 
       - name: Logs (on failure)
         if: failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,7 +179,7 @@ One logical change per commit is nice; a tidy PR history is more important than 
 | --- | --- | --- |
 | Rust fmt, clippy, test + coverage | yes | Workspace-wide |
 | rustdoc + `check-doc-links.py` + `check-changelog.py` | yes | Doc links, public-docs shape, and changelog sections |
-| Installer shellcheck + install/uninstall smoke | yes | Guest boot skipped (`--no-images`) |
+| Installer shellcheck + install/uninstall smoke | yes | Guest boot skipped (`install.sh` never installs an image) |
 | Frontend lint + build | yes | Node 22 |
 | Multi-distro installer deps | yes | Debian, Fedora, Arch, openSUSE containers |
 | M2 guest boot matrix | no | Nightly / `workflow_dispatch` only (KVM + images) |

--- a/README.ja.md
+++ b/README.ja.md
@@ -102,8 +102,6 @@ curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/instal
 ./install.sh --check                 # 前提条件と予定変更を確認
 ./install.sh --doctor                # KVM、ファイアウォール、socket、ホスト設定を診断
 ./install.sh --bin-dir target/release
-./install.sh --with-ubuntu-image
-./install.sh --with-rocky-image      # Rocky Linux 9.8 をビルド
 ./install.sh --uninstall         # デフォルトではデータを保持
 ./install.sh --uninstall --purge # /var/lib/firecrab も削除
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -197,8 +197,6 @@ curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/instal
 ./install.sh --check                 # 필요 조건과 예정 변경 사항 확인
 ./install.sh --doctor                # KVM, 방화벽, 소켓, 호스트 설정 진단
 ./install.sh --bin-dir target/release
-./install.sh --with-ubuntu-image
-./install.sh --with-rocky-image      # Rocky Linux 9.8 고정 버전 빌드
 ./install.sh --uninstall         # 기본적으로 데이터 유지
 ./install.sh --uninstall --purge # /var/lib/firecrab도 제거
 ```

--- a/README.md
+++ b/README.md
@@ -200,8 +200,6 @@ Useful installer modes:
 ./install.sh --check                 # report prerequisites and planned changes
 ./install.sh --doctor                # diagnose KVM, firewall, socket, and host setup
 ./install.sh --bin-dir target/release
-./install.sh --with-ubuntu-image
-./install.sh --with-rocky-image      # build pinned Rocky Linux 9.8
 ./install.sh --uninstall         # retain data by default
 ./install.sh --uninstall --purge # also remove /var/lib/firecrab
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,8 +96,6 @@ curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/instal
 ./install.sh --check                 # 报告前置条件和计划变更
 ./install.sh --doctor                # 诊断 KVM、防火墙、socket 和主机设置
 ./install.sh --bin-dir target/release
-./install.sh --with-ubuntu-image
-./install.sh --with-rocky-image      # 构建固定版本 Rocky Linux 9.8
 ./install.sh --uninstall         # 默认保留数据
 ./install.sh --uninstall --purge # 同时删除 /var/lib/firecrab
 ```

--- a/install.sh
+++ b/install.sh
@@ -41,9 +41,6 @@ FIRECRAB_RELEASE_TAG="@FIRECRAB_RELEASE_TAG@"
 
 MODE=install
 INSTALL_DEPS=1
-WITH_IMAGES=0
-WITH_UBUNTU_IMAGE=0
-WITH_ROCKY_IMAGE=0
 WITH_FRONTEND=1
 PURGE=0
 BIN_DIR=
@@ -83,10 +80,6 @@ Usage: ./install.sh [OPTIONS]
   --doctor            run host diagnostics (UFW, socket, KVM, nft, …); no root required
   --deps-only         install the dependencies, then stop (no host changes)
   --no-deps           never install packages, only report gaps
-  --no-images         skip guest images (default)
-  --with-images       also install Alpine from MicroRegistry
-  --with-ubuntu-image also install Ubuntu 26.04 (large)
-  --with-rocky-image  also install Rocky Linux 9.8 (large)
   --no-frontend       do not install the dashboard
   --version VER       GitHub Release tag (default: latest, or the baked-in tag)
   --libc gnu|musl     host libc (default: detect; gnu = glibc)
@@ -153,10 +146,6 @@ while [ $# -gt 0 ]; do
             ;;
         --deps-only) MODE=deps ;;
         --no-deps) INSTALL_DEPS=0 ;;
-        --no-images) WITH_IMAGES=0 ;;
-        --with-images) WITH_IMAGES=1 ;;
-        --with-ubuntu-image) WITH_UBUNTU_IMAGE=1 ;;
-        --with-rocky-image) WITH_ROCKY_IMAGE=1 ;;
         --no-frontend) WITH_FRONTEND=0 ;;
         --version)
             [ $# -ge 2 ] || die "--version needs a tag (for example v0.1.0)"
@@ -702,237 +691,9 @@ install_units() {
 
 # --- guest images ----------------------------------------------------------
 
-ensure_image_build_deps() {
-    local failed=0
-
-    ensure chroot coreutils || failed=1
-    ensure file file || failed=1
-    ensure gzip gzip || failed=1
-    ensure install coreutils || failed=1
-    ensure mkfs.ext4 e2fsprogs || failed=1
-    ensure mount util-linux || failed=1
-    ensure curl curl || failed=1
-    ensure sha256sum coreutils || failed=1
-    ensure tar tar || failed=1
-    ensure truncate coreutils || failed=1
-    ensure umount util-linux || failed=1
-    if [ "$WITH_UBUNTU_IMAGE" -eq 1 ]; then
-        ensure find findutils || failed=1
-        ensure sed sed || failed=1
-        ensure sort coreutils || failed=1
-        ensure tail coreutils || failed=1
-        ensure ln coreutils || failed=1
-        ensure chmod coreutils || failed=1
-        ensure chown coreutils || failed=1
-    fi
-    if [ "$WITH_ROCKY_IMAGE" -eq 1 ]; then
-        ensure jq jq || failed=1
-        ensure xz xz || failed=1
-    fi
-    return $failed
-}
-
 # Whether a guest rootfs is already installed.
 images_present() {
     compgen -G "$DATADIR/images/rootfs/*.ext4" >/dev/null 2>&1
-}
-
-image_alias_present() {
-    case "$1" in
-        alpine*) compgen -G "$DATADIR/images/rootfs/alpine*.ext4" >/dev/null 2>&1 ;;
-        ubuntu*) compgen -G "$DATADIR/images/rootfs/ubuntu*.ext4" >/dev/null 2>&1 ;;
-        rocky*)  compgen -G "$DATADIR/images/rootfs/rocky*.ext4" >/dev/null 2>&1 ;;
-        *) return 1 ;;
-    esac
-}
-
-# Checkout-only builder. A piped release installer has no such script.
-guest_builder() {
-    local name=$1
-    local script=$REPO_ROOT/scripts/firecracker-menual/$name
-    [ -f "$script" ] || return 1
-    printf '%s\n' "$script"
-}
-
-# Whether the repo has images that can be copied instead of built.
-repo_images_present() {
-    compgen -G "$REPO_ROOT/images/rootfs/*.ext4" >/dev/null 2>&1
-}
-
-want_guest_images() {
-    [ "$WITH_IMAGES" -eq 1 ] || [ "$WITH_UBUNTU_IMAGE" -eq 1 ] || [ "$WITH_ROCKY_IMAGE" -eq 1 ]
-}
-
-# Report-only counterpart of `ensure_images`, so --check cannot copy, chown or
-# build anything (it is run unprivileged, and a check that mutates is a trap).
-report_images() {
-    if ! want_guest_images; then
-        log "images: skipped (install from the dashboard)"
-        return 0
-    fi
-    if repo_images_present; then
-        log "images: present in the repo, would be copied to $DATADIR/images"
-        return 0
-    fi
-    if images_present; then
-        log "images: already installed in $DATADIR/images"
-        return 0
-    fi
-    if guest_builder install-alpine-rootfs.sh >/dev/null; then
-        ensure_image_build_deps || true
-        warn "no guest image (would build Alpine with sudo + chroot + direct ext4)"
-        return 1
-    fi
-    warn "no guest image (would install Alpine from MicroRegistry for $(uname -m))"
-    return 1
-}
-
-# Optional checkout-only image build. Default host install does not do this.
-ensure_images() {
-    if ! want_guest_images; then
-        log "skipping images"
-        return 0
-    fi
-
-    # Prefer images already built in the repo: copying beats rebuilding.
-    if repo_images_present; then
-        step "copying images from the repo (existing ones are kept)"
-        $SUDO cp -rn "$REPO_ROOT/images/." "$DATADIR/images/" 2>/dev/null || true
-        $SUDO chown -R "$FIRECRAB_USER:$FIRECRAB_GROUP" "$DATADIR/images"
-        log "images ready in $DATADIR/images"
-        return 0
-    fi
-
-    if images_present; then
-        log "images already installed in $DATADIR/images"
-        return 0
-    fi
-
-    if [ "$WITH_IMAGES" -eq 1 ]; then
-        local alpine
-        if ! alpine=$(guest_builder install-alpine-rootfs.sh); then
-            log "no local Alpine builder; will install alpine-3.24.1 from MicroRegistry after the API starts"
-        else
-            if ! ensure_image_build_deps; then
-                warn "missing host-native image build dependencies; build elsewhere and copy into $DATADIR/images"
-                return 1
-            fi
-            step "building the Alpine guest image (this takes a few minutes)"
-            if ! "$alpine"; then
-                warn "image build failed — firecrab will start with no templates; install one from the dashboard"
-                return 1
-            fi
-        fi
-    fi
-
-    local ubuntu rocky
-    if [ "$WITH_UBUNTU_IMAGE" -eq 1 ]; then
-        step "building the Ubuntu guest image (large)"
-        if ubuntu=$(guest_builder install-ubuntu-roofs.sh); then
-            "$ubuntu" || warn "Ubuntu image build failed (the Alpine one is still usable)"
-        else
-            warn "Ubuntu builder missing; will try MicroRegistry after the API starts"
-        fi
-    fi
-
-    if [ "$WITH_ROCKY_IMAGE" -eq 1 ]; then
-        step "building the Rocky Linux 9.8 guest image (large)"
-        if rocky=$(guest_builder install-rocky-rootfs.sh); then
-            "$rocky" || warn "Rocky Linux 9.8 image build failed (the Alpine one is still usable)"
-        else
-            warn "Rocky builder missing; will try MicroRegistry after the API starts"
-        fi
-    fi
-
-    $SUDO cp -rn "$REPO_ROOT/images/." "$DATADIR/images/" 2>/dev/null || true
-    $SUDO chown -R "$FIRECRAB_USER:$FIRECRAB_GROUP" "$DATADIR/images"
-    log "images ready in $DATADIR/images"
-}
-
-api_url() {
-    printf 'http://%s' "${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}"
-}
-
-json_status() {
-    printf '%s' "$1" | sed -n 's/.*"status"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n1
-}
-
-# Poll GET /api/images/{alias}/{package|install} until succeeded or failed.
-poll_image_job() {
-    local path=$1
-    local _i body status
-    for _i in $(seq 1 180); do
-        body=$(curl -fsS "$(api_url)$path") || return 1
-        status=$(json_status "$body")
-        case "$status" in
-            succeeded) return 0 ;;
-            failed)
-                warn "$path failed: $body"
-                return 1
-                ;;
-            *) sleep 2 ;;
-        esac
-    done
-    warn "$path did not finish in time"
-    return 1
-}
-
-# Download + extract one catalog alias via the running API (host arch).
-install_catalog_alias() {
-    local alias=$1
-    local body code
-    body=$(mktemp)
-    code=$(curl -sS -o "$body" -w '%{http_code}' -X POST "$(api_url)/api/images/$alias/package")
-    case "$code" in
-        200|202|409) ;;
-        *)
-            warn "package $alias HTTP $code $(tr '\n' ' ' <"$body")"
-            rm -f "$body"
-            return 1
-            ;;
-    esac
-    if ! poll_image_job "/api/images/$alias/package"; then
-        rm -f "$body"
-        return 1
-    fi
-    code=$(curl -sS -o "$body" -w '%{http_code}' -X POST "$(api_url)/api/images/$alias/install")
-    case "$code" in
-        200|202) ;;
-        409)
-            rm -f "$body"
-            return 0
-            ;;
-        *)
-            warn "install $alias HTTP $code $(tr '\n' ' ' <"$body")"
-            rm -f "$body"
-            return 1
-            ;;
-    esac
-    rm -f "$body"
-    poll_image_job "/api/images/$alias/install"
-}
-
-# After the API is up, install catalog images that were explicitly requested.
-install_release_images() {
-    want_guest_images || return 0
-    local failed=0
-    if [ "$WITH_IMAGES" -eq 1 ] && ! image_alias_present alpine; then
-        step "installing alpine-3.24.1 from MicroRegistry ($(uname -m))"
-        install_catalog_alias alpine-3.24.1 || failed=1
-    fi
-    if [ "$WITH_UBUNTU_IMAGE" -eq 1 ] && ! image_alias_present ubuntu; then
-        step "installing ubuntu-26.04 from MicroRegistry ($(uname -m))"
-        install_catalog_alias ubuntu-26.04 || failed=1
-    fi
-    if [ "$WITH_ROCKY_IMAGE" -eq 1 ] && ! image_alias_present rocky; then
-        step "installing rocky-9.8 from MicroRegistry ($(uname -m))"
-        install_catalog_alias rocky-9.8 || failed=1
-    fi
-    if [ "$failed" -eq 0 ] && images_present; then
-        log "images ready in $DATADIR/images"
-        return 0
-    fi
-    return 1
 }
 
 # --- run -------------------------------------------------------------------
@@ -961,9 +722,9 @@ start_units() {
 # not once it is actually serving. At startup firecrab-api hashes every
 # present template artifact before binding its listener (see
 # TemplateRegistry::from_specs in firecrab-api/src/templates.rs), and a
-# freshly built multi-gigabyte rootfs (--with-ubuntu-image, --with-rocky-image)
-# can take noticeably longer to hash than the process takes to fork. Poll the
-# real HTTP port so callers relying on start_units's return don't race it.
+# large rootfs from a previous OCI import can take noticeably longer to hash
+# than the process takes to fork. Poll the real HTTP port so callers relying
+# on start_units's return don't race it.
 wait_for_api() {
     local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}
     local _attempt
@@ -990,7 +751,6 @@ do_check() {
     report_payload || gaps=1
     check_kvm || gaps=1
     check_systemd || gaps=1
-    report_images || gaps=1
     report_ufw
 
     if [ "$gaps" -eq 0 ]; then
@@ -1025,9 +785,6 @@ do_deps() {
     detect_pkg || die "no known package manager (apt/dnf/zypper/pacman/apk)"
 
     ensure_runtime_deps || die "missing runtime dependencies (see above)"
-    if want_guest_images; then
-        ensure_image_build_deps || die "missing image build dependencies (see above)"
-    fi
     ensure_firecracker  || die "firecracker is required"
     check_kvm || warn "no KVM here; that only matters where VMs actually run"
     report_ufw
@@ -1075,14 +832,9 @@ do_install() {
     label_selinux_binaries
     install_config
     install_units
-    # Guest images are not part of the host install. The dashboard Images
-    # page (or --with-images / --with-ubuntu-image / --with-rocky-image)
-    # installs templates afterwards.
-    ensure_images || warn "optional local image build failed"
+    # Guest images are not part of the host install — import one afterwards
+    # with POST /api/oci/import or the dashboard Images page.
     start_units || die "installed, but a unit did not come up"
-    if want_guest_images; then
-        install_release_images || warn "requested catalog image did not install; use the dashboard Images page"
-    fi
     report_ufw
 
     local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -25,7 +25,7 @@ Run the read-only check first.
 ./install.sh --check
 ```
 
-It checks tools, KVM, systemd, images, and firewall state.
+It checks tools, KVM, systemd, and firewall state.
 
 ## Install
 
@@ -52,8 +52,8 @@ Open the dashboard after the services start.
 http://127.0.0.1:5523/
 ```
 
-The default install does not install a guest image.
-Install images later from the dashboard Images page.
+The install never installs a guest image.
+Import one afterwards with [OCI import](oci.md) or the dashboard Images page.
 
 ## Common options
 
@@ -62,10 +62,6 @@ Install images later from the dashboard Images page.
 | `--check` | Report readiness without changes |
 | `--doctor` | Run runtime diagnostics |
 | `--no-deps` | Do not install missing tools |
-| `--no-images` | Skip guest images (default) |
-| `--with-images` | Also install Alpine from MicroRegistry |
-| `--with-ubuntu-image` | Also install Ubuntu 26.04 |
-| `--with-rocky-image` | Also install Rocky Linux 9.8 |
 | `--no-frontend` | Skip the dashboard |
 | `--version VER` | Use that GitHub Release tag |
 | `--libc gnu` or `--libc musl` | Force glibc or musl instead of auto-detect |

--- a/scripts/test-install-cli.sh
+++ b/scripts/test-install-cli.sh
@@ -107,26 +107,12 @@ else
     fail "baked install.sh pins the tag (got '$got')"
 fi
 
-# Host install prepares the host only. Guest images are a dashboard job.
+# Host install prepares the host only; guest images come from OCI import.
 piped_check=$(cd /tmp && bash -s -- --check --no-deps <"$pub/install.sh" 2>&1 || true)
 if printf '%s\n' "$piped_check" | grep -q 'BASH_SOURCE'; then
     fail "baked --check via stdin must not crash on BASH_SOURCE"
-elif printf '%s\n' "$piped_check" | grep -Eq 'images: skipped|skipping images'; then
-    pass "baked --check via stdin skips guest images by default"
 else
-    fail "baked --check via stdin should skip images (got: $(printf '%s' "$piped_check" | tr '\n' ' ' | tail -c 240))"
-fi
-if printf '%s\n' "$piped_check" | grep -q 'would install Alpine from MicroRegistry'; then
-    fail "baked --check via stdin must not fetch a guest image by default"
-else
-    pass "baked --check via stdin does not fetch a guest image by default"
-fi
-
-help=$("$pub/install.sh" --help)
-if printf '%s\n' "$help" | grep -q -- '--with-images'; then
-    pass "--help mentions --with-images"
-else
-    fail "--help mentions --with-images"
+    pass "baked --check via stdin does not crash on BASH_SOURCE"
 fi
 
 # The advertised one-liner is `curl … | bash`. That leaves BASH_SOURCE unset.


### PR DESCRIPTION
## Summary

`install.sh` no longer preinstalls a guest image. `--no-images`, `--with-images`, `--with-ubuntu-image`, `--with-rocky-image`, and everything only reachable through them are removed; a guest image now comes solely from `POST /api/oci/import` (`public-docs/oci.md`) or the dashboard Images page.

Closes #151.

## Testing

- `bash -n install.sh`, `shellcheck install.sh scripts/*.sh` (same set CI runs) — clean
- `bash scripts/test-install-cli.sh` — 28 passed
- `python3 scripts/check-doc-links.py`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- Repo-wide grep for the removed flag names — only an intentional historical mention in a new comment, and an untouched pre-0.1.1 CHANGELOG entry, remain

## Not verified

- `vm-boot`/`vm-boot-self-hosted` only run on `schedule`/`workflow_dispatch`, so the new OCI-import step has not executed in CI yet — needs a nightly or manual `workflow_dispatch` run to confirm end to end.
