### PR TITLE
fix(install): silence curl error noise in wait_for_api poll

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -729,7 +729,7 @@ wait_for_api() {
     local bind=${FIRECRAB_BIND_ADDR:-127.0.0.1:5523}
     local _attempt
     for _attempt in $(seq 1 60); do
-        curl -fsS -o /dev/null "http://$bind/" && return 0
+        curl -fs -o /dev/null "http://$bind/" 2>/dev/null && return 0
         sleep 1
     done
     warn "firecrab-api did not answer http://$bind/ within 60s — journalctl -u firecrab-api -n 30"


### PR DESCRIPTION
## Summary

`wait_for_api()` polled with `curl -fsS`, and `-S` forces curl to print its error even under `-s`. Every retry before `firecrab-api` finished binding its listener (~8-9s after fork on a fresh install) printed `curl: (7) Failed to connect to 127.0.0.1 port 3000 after 0 ms: Could not connect to server` to the terminal, reading as an install failure even though the loop went on to succeed.

Drops `-S`, redirects curl's stderr during the retry loop; the existing `warn` on a genuine 60s timeout is unchanged.

Closes #158.

## Testing

- `bash -n install.sh` — clean
- `shellcheck install.sh` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error output while checking API availability during startup.
  * API readiness detection and retry behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->