### PR TITLE
fix(install): tear down bridges, TAP devices, and nftables tables on uninstall

### DIFF
--- a/firecrab-net-helper/src/bridge.rs
+++ b/firecrab-net-helper/src/bridge.rs
@@ -5,12 +5,14 @@ use std::fs;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr};
 
-use firecrab_helper_protocol::network::micro_network_bridge_name;
+use firecrab_helper_protocol::network::{
+    MICRO_NETWORK_BRIDGE_PREFIX, TAP_PREFIX, micro_network_bridge_name,
+};
 use futures_util::TryStreamExt;
 use rtnetlink::packet_route::{
     AddressFamily,
     address::AddressAttribute,
-    link::LinkMessage,
+    link::{LinkAttribute, LinkMessage},
     route::{RouteAddress, RouteAttribute, RouteMessage},
 };
 use rtnetlink::{Handle, LinkBridge, LinkUnspec, new_connection};
@@ -196,6 +198,56 @@ pub async fn delete_micro_network_bridge(
     }
     crate::firewall::remove_iptables_forward_for_bridge(&name).await;
     Ok(())
+}
+
+/// Deletes every Firecrab-owned network interface still on the host: the
+/// default bridge, every MicroNetwork bridge, and every VM TAP device.
+/// Matched by name prefix rather than by id — this runs from `--teardown`
+/// ahead of `install.sh --uninstall` removing the binaries, with no
+/// `firecrab-api` database to read ids from. A plain `systemctl stop`
+/// leaves all of these in place; only a host reboot clears them otherwise.
+pub async fn teardown_all(actor: &BridgeActor) -> Result<(), BridgeError> {
+    let _guard = actor.lock.lock().await;
+    let (connection, handle, _) = new_connection().map_err(BridgeError::Connection)?;
+    tokio::spawn(connection);
+
+    let mut links = handle.link().get().execute();
+    let mut owned = Vec::new();
+    while let Some(link) = links.try_next().await.map_err(BridgeError::Netlink)? {
+        let name = link
+            .attributes
+            .iter()
+            .find_map(|attribute| match attribute {
+                LinkAttribute::IfName(name) => Some(name.clone()),
+                _ => None,
+            });
+        if let Some(name) = name
+            && is_owned_interface(&name)
+        {
+            owned.push((link.header.index, name));
+        }
+    }
+
+    for (index, name) in owned {
+        match handle.link().del(index).execute().await {
+            Ok(()) => {}
+            Err(rtnetlink::Error::NetlinkError(message)) if message.raw_code() == -libc::ENODEV => {
+            }
+            Err(error) => return Err(BridgeError::Netlink(error)),
+        }
+        if name == BRIDGE_NAME || name.starts_with(MICRO_NETWORK_BRIDGE_PREFIX) {
+            crate::firewall::remove_iptables_forward_for_bridge(&name).await;
+        }
+    }
+    Ok(())
+}
+
+/// Whether `name` is an interface this crate creates: the default bridge, a
+/// MicroNetwork bridge, or a VM TAP device.
+fn is_owned_interface(name: &str) -> bool {
+    name == BRIDGE_NAME
+        || name.starts_with(MICRO_NETWORK_BRIDGE_PREFIX)
+        || name.starts_with(TAP_PREFIX)
 }
 
 async fn ensure_bridge_for(
@@ -569,5 +621,25 @@ mod tests {
     #[test]
     fn a_route_on_the_owned_bridge_interface_is_excluded() {
         assert!(route_belongs_to_own_bridge(Some(7), Some(7)));
+    }
+
+    #[test]
+    fn owned_interface_names_are_recognized_by_prefix() {
+        assert!(is_owned_interface(BRIDGE_NAME));
+        assert!(is_owned_interface("mnb1a2b3c4d5e6f7"));
+        assert!(is_owned_interface("fct1a2b3c4d5e6f7"));
+        assert!(!is_owned_interface("eth0"));
+        assert!(!is_owned_interface("lo"));
+        assert!(!is_owned_interface("docker0"));
+    }
+
+    #[tokio::test]
+    async fn teardown_all_is_a_no_op_when_nothing_firecrab_owns_is_present() {
+        // Read-only rtnetlink listing needs no special privilege; on a host
+        // with no fcbr0/mnb*/fct* interfaces, nothing is ever deleted, so
+        // this never reaches the point of needing CAP_NET_ADMIN (same
+        // reasoning as tap.rs's deleting_a_tap_that_was_never_created_is_a_no_op).
+        let actor = BridgeActor::new();
+        assert!(teardown_all(&actor).await.is_ok());
     }
 }

--- a/firecrab-net-helper/src/bridge.rs
+++ b/firecrab-net-helper/src/bridge.rs
@@ -212,27 +212,15 @@ pub async fn teardown_all(actor: &BridgeActor) -> Result<(), BridgeError> {
     tokio::spawn(connection);
 
     let mut links = handle.link().get().execute();
-    let mut owned = Vec::new();
+    let mut seen = Vec::new();
     while let Some(link) = links.try_next().await.map_err(BridgeError::Netlink)? {
-        let name = link
-            .attributes
-            .iter()
-            .find_map(|attribute| match attribute {
-                LinkAttribute::IfName(name) => Some(name.clone()),
-                _ => None,
-            });
-        if let Some(name) = name
-            && is_owned_interface(&name)
-        {
-            owned.push((link.header.index, name));
-        }
+        seen.push((link.header.index, link.attributes));
     }
 
-    for (index, name) in owned {
+    for (index, name) in owned_links(&seen) {
         match handle.link().del(index).execute().await {
             Ok(()) => {}
-            Err(rtnetlink::Error::NetlinkError(message)) if message.raw_code() == -libc::ENODEV => {
-            }
+            Err(error) if is_enodev(&error) => {}
             Err(error) => return Err(BridgeError::Netlink(error)),
         }
         if name == BRIDGE_NAME || name.starts_with(MICRO_NETWORK_BRIDGE_PREFIX) {
@@ -248,6 +236,33 @@ fn is_owned_interface(name: &str) -> bool {
     name == BRIDGE_NAME
         || name.starts_with(MICRO_NETWORK_BRIDGE_PREFIX)
         || name.starts_with(TAP_PREFIX)
+}
+
+/// A link's `IfName` attribute, if it has one.
+fn link_name(attributes: &[LinkAttribute]) -> Option<String> {
+    attributes.iter().find_map(|attribute| match attribute {
+        LinkAttribute::IfName(name) => Some(name.clone()),
+        _ => None,
+    })
+}
+
+/// Pairs each named, Firecrab-owned link with its rtnetlink index; unnamed
+/// or not-ours links are dropped. Pure so [`teardown_all`]'s host-facing
+/// listing stays a thin wrapper around this and [`link_name`].
+fn owned_links(links: &[(u32, Vec<LinkAttribute>)]) -> Vec<(u32, String)> {
+    links
+        .iter()
+        .filter_map(|(index, attributes)| {
+            let name = link_name(attributes)?;
+            is_owned_interface(&name).then_some((*index, name))
+        })
+        .collect()
+}
+
+/// Whether a link deletion failed because the link was already gone —
+/// [`teardown_all`] treats that as success rather than a race to report.
+fn is_enodev(error: &rtnetlink::Error) -> bool {
+    matches!(error, rtnetlink::Error::NetlinkError(message) if message.raw_code() == -libc::ENODEV)
 }
 
 async fn ensure_bridge_for(
@@ -631,6 +646,52 @@ mod tests {
         assert!(!is_owned_interface("eth0"));
         assert!(!is_owned_interface("lo"));
         assert!(!is_owned_interface("docker0"));
+    }
+
+    #[test]
+    fn link_name_finds_ifname_among_other_attributes() {
+        assert_eq!(
+            link_name(&[
+                LinkAttribute::Mtu(1500),
+                LinkAttribute::IfName("fcbr0".to_owned()),
+            ]),
+            Some("fcbr0".to_owned())
+        );
+        assert_eq!(link_name(&[LinkAttribute::Mtu(1500)]), None);
+    }
+
+    #[test]
+    fn owned_links_pairs_indices_with_owned_names_and_drops_the_rest() {
+        let seen = vec![
+            (1, vec![LinkAttribute::IfName("eth0".to_owned())]),
+            (2, vec![LinkAttribute::IfName(BRIDGE_NAME.to_owned())]),
+            (3, vec![LinkAttribute::IfName("mnbdead".to_owned())]),
+            (4, vec![LinkAttribute::Mtu(1500)]),
+            (5, vec![LinkAttribute::IfName("fctcafe".to_owned())]),
+        ];
+        assert_eq!(
+            owned_links(&seen),
+            vec![
+                (2, BRIDGE_NAME.to_owned()),
+                (3, "mnbdead".to_owned()),
+                (5, "fctcafe".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn enodev_is_recognized_and_other_netlink_errors_are_not() {
+        // ErrorMessage is #[non_exhaustive]: build via Default, then set the
+        // one field this test cares about — its fields are still public.
+        let netlink_error = |code: i32| {
+            let mut message = rtnetlink::packet_core::ErrorMessage::default();
+            message.code = std::num::NonZeroI32::new(code);
+            rtnetlink::Error::NetlinkError(message)
+        };
+
+        assert!(is_enodev(&netlink_error(-libc::ENODEV)));
+        assert!(!is_enodev(&netlink_error(-libc::EPERM)));
+        assert!(!is_enodev(&rtnetlink::Error::RequestFailed));
     }
 
     #[tokio::test]

--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -266,10 +266,8 @@ pub async fn remove_vm_policy(actor: &FirewallActor, vm_id: Uuid) -> Result<(), 
 }
 
 /// Explicit uninstall: remove both Firecrab tables. VM stop/delete must
-/// never call this — only an explicit teardown of the whole subsystem does.
-/// Not wired to a caller yet (reserved for a future uninstall path); its
-/// rendering is exercised directly by tests.
-#[allow(dead_code)]
+/// never call this — only `main.rs`'s `--teardown` mode does, ahead of
+/// `install.sh --uninstall` removing the binaries.
 pub async fn remove_firewall(actor: &FirewallActor) -> Result<(), FirewallError> {
     let mut state = actor.state.lock().await;
     run_nft(&render_remove_ruleset()).await?;

--- a/firecrab-net-helper/src/main.rs
+++ b/firecrab-net-helper/src/main.rs
@@ -166,12 +166,24 @@ fn effective_uid() -> u32 {
     unsafe { libc::geteuid() }
 }
 
-/// Entry point: `--teardown` removes every Firecrab-owned interface and
-/// nftables table and exits instead of serving; otherwise runs the server.
-/// Either way, prints any error's full cause chain before exiting non-zero.
+/// Whether argv requests `--teardown` instead of serving.
+fn wants_teardown(args: &[String]) -> bool {
+    args.get(1).map(String::as_str) == Some("--teardown")
+}
+
+/// Entry point: hands off to [`run_cli`], the testable half of `main` — this
+/// wrapper exists only because `#[tokio::main]` has to sit directly on
+/// `main` itself.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
-    let result = if env::args().nth(1).as_deref() == Some("--teardown") {
+    run_cli(env::args().collect()).await
+}
+
+/// `--teardown` removes every Firecrab-owned interface and nftables table
+/// and exits instead of serving; otherwise runs the server. Either way,
+/// prints any error's full cause chain before exiting non-zero.
+async fn run_cli(args: Vec<String>) -> ExitCode {
+    let result = if wants_teardown(&args) {
         teardown()
             .await
             .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
@@ -182,16 +194,20 @@ async fn main() -> ExitCode {
     };
     match result {
         Ok(()) => ExitCode::SUCCESS,
-        Err(error) => {
-            eprintln!("[ERROR] {error}");
-            let mut source = error.source();
-            while let Some(cause) = source {
-                eprintln!("[ERROR] caused by: {cause}");
-                source = cause.source();
-            }
-            ExitCode::FAILURE
-        }
+        Err(error) => print_failure(error.as_ref()),
     }
+}
+
+/// Prints an error's full cause chain, for [`run_cli`] to report before
+/// exiting non-zero.
+fn print_failure(error: &dyn std::error::Error) -> ExitCode {
+    eprintln!("[ERROR] {error}");
+    let mut source = error.source();
+    while let Some(cause) = source {
+        eprintln!("[ERROR] caused by: {cause}");
+        source = cause.source();
+    }
+    ExitCode::FAILURE
 }
 
 /// Removes every Firecrab-owned nftables table and network interface: the
@@ -664,6 +680,69 @@ mod tests {
         let result =
             HelperConfig::from_values("/tmp/x.sock", Some("wheel"), bridge::DEFAULT_BRIDGE_MTU);
         assert_matches!(result, Err(StartupError::InvalidAllowedUid(_)));
+    }
+
+    #[test]
+    fn wants_teardown_matches_only_the_flag_in_argv1() {
+        let args = |a: &[&str]| a.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>();
+        assert!(wants_teardown(&args(&[
+            "firecrab-net-helper",
+            "--teardown"
+        ])));
+        assert!(!wants_teardown(&args(&["firecrab-net-helper"])));
+        assert!(!wants_teardown(&args(&["firecrab-net-helper", "--other"])));
+        // Only argv[1]; a later --teardown doesn't count.
+        assert!(!wants_teardown(&args(&[
+            "firecrab-net-helper",
+            "-x",
+            "--teardown"
+        ])));
+    }
+
+    #[test]
+    fn print_failure_walks_the_full_cause_chain() {
+        #[derive(Debug)]
+        struct Root;
+        impl std::fmt::Display for Root {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "root cause")
+            }
+        }
+        impl std::error::Error for Root {}
+
+        #[derive(Debug)]
+        struct Top(Root);
+        impl std::fmt::Display for Top {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "top-level failure")
+            }
+        }
+        impl std::error::Error for Top {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        // No panic and a real walk over one cause is the assertion; ExitCode
+        // has no PartialEq to compare against.
+        let _ = print_failure(&Top(Root));
+    }
+
+    #[tokio::test]
+    async fn run_cli_teardown_mode_exercises_the_whole_dispatch_without_hanging() {
+        // Safe to call directly, unlike the default (no-args) path: teardown()
+        // never blocks waiting on a signal, while `run()` would hang this test
+        // forever if it ever got far enough to call `serve()`. Whichever way
+        // this resolves is fine — remove_firewall's nft call needs
+        // CAP_NET_ADMIN (same reasoning as
+        // firewall::tests::remove_firewall_clears_cached_networks), so an
+        // unprivileged test process usually takes the error branch, but
+        // either outcome exercises the real dispatch.
+        let _ = run_cli(vec![
+            "firecrab-net-helper".to_owned(),
+            "--teardown".to_owned(),
+        ])
+        .await;
     }
 
     #[tokio::test]

--- a/firecrab-net-helper/src/main.rs
+++ b/firecrab-net-helper/src/main.rs
@@ -79,6 +79,18 @@ enum StartupError {
     IpForward(#[source] io::Error),
 }
 
+/// Failures tearing down every Firecrab-owned interface and nftables table
+/// (`--teardown` mode).
+#[derive(Debug, Error)]
+enum TeardownError {
+    /// Removing the owned nftables tables failed.
+    #[error("failed to remove firewall")]
+    Firewall(#[from] firewall::FirewallError),
+    /// Removing an owned bridge or TAP device failed.
+    #[error("failed to remove network interfaces")]
+    Bridge(#[from] bridge::BridgeError),
+}
+
 /// Resolved startup configuration plus the shared actors every connection
 /// dispatches into.
 #[derive(Debug)]
@@ -154,15 +166,25 @@ fn effective_uid() -> u32 {
     unsafe { libc::geteuid() }
 }
 
-/// Entry point: runs the server and prints any startup error's full cause
-/// chain before exiting non-zero.
+/// Entry point: `--teardown` removes every Firecrab-owned interface and
+/// nftables table and exits instead of serving; otherwise runs the server.
+/// Either way, prints any error's full cause chain before exiting non-zero.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> ExitCode {
-    match run().await {
+    let result = if env::args().nth(1).as_deref() == Some("--teardown") {
+        teardown()
+            .await
+            .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
+    } else {
+        run()
+            .await
+            .map_err(|error| Box::new(error) as Box<dyn std::error::Error>)
+    };
+    match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("[ERROR] {error}");
-            let mut source = std::error::Error::source(&error);
+            let mut source = error.source();
             while let Some(cause) = source {
                 eprintln!("[ERROR] caused by: {cause}");
                 source = cause.source();
@@ -170,6 +192,18 @@ async fn main() -> ExitCode {
             ExitCode::FAILURE
         }
     }
+}
+
+/// Removes every Firecrab-owned nftables table and network interface: the
+/// default bridge, every MicroNetwork bridge, every VM TAP device. Run by
+/// `install.sh --uninstall` right after stopping the service and before its
+/// binary is deleted — a plain `systemctl stop` sends SIGTERM, which only
+/// stops accepting connections (`shutdown_signal`) and leaves all of this in
+/// place; only a host reboot would otherwise clear it.
+async fn teardown() -> Result<(), TeardownError> {
+    firewall::remove_firewall(&firewall::FirewallActor::new()).await?;
+    bridge::teardown_all(&bridge::BridgeActor::new()).await?;
+    Ok(())
 }
 
 /// Loads config, binds the socket, and serves until shutdown.

--- a/install.sh
+++ b/install.sh
@@ -854,6 +854,14 @@ do_uninstall() {
     $SUDO systemctl daemon-reload
     log "units removed"
 
+    # SIGTERM (above) only stops the helper's socket loop — it never deletes
+    # the bridges, TAP devices or nftables tables it created, only a reboot
+    # would. Run its own teardown while the binary is still on disk.
+    if [ -x "$LIBDIR/firecrab-net-helper" ]; then
+        $SUDO "$LIBDIR/firecrab-net-helper" --teardown \
+            || warn "network teardown failed — bridges/nftables tables may remain until reboot"
+    fi
+
     $SUDO rm -f "$LIBDIR/firecrab-api" "$LIBDIR/firecrab-net-helper"
     $SUDO rm -f "$PREFIX/bin/firecrab-doctor"
     $SUDO rm -rf "$SHAREDIR/dashboard"
@@ -866,8 +874,6 @@ do_uninstall() {
     log "binaries and dashboard removed"
 
     # Left alone on purpose: the account, the config and the data directory.
-    # Bridges and nftables tables belong to the helper, which is now stopped;
-    # they disappear on the next reboot.
     if [ "$PURGE" -eq 1 ]; then
         warn "purging $DATADIR and $CONFDIR (all VM disks and the database)"
         $SUDO rm -rf "$DATADIR" "$CONFDIR"


### PR DESCRIPTION
## Summary

`install.sh --uninstall` stopped `firecrab-net-helper` via `systemctl disable --now` and assumed its bridges/nftables tables would "disappear on the next reboot" (per the comment it removed). That's only true for an actual reboot: `shutdown_signal()` only stops the accept loop on SIGTERM, never tears anything down. Without a reboot, `fcbr0`, any `mnb*` MicroNetwork bridges, `fct*` TAP devices, and the `firecrab`/`firecrab_l2` nftables tables all stayed on the host after `--purge`.

- `firecrab-net-helper`: new `--teardown` CLI mode calls the existing (previously unwired, `#[allow(dead_code)]`) `firewall::remove_firewall`, then a new `bridge::teardown_all` that lists host links and deletes anything named `fcbr0` or prefixed `mnb`/`fct` — by name, since teardown has no database to read MicroNetwork ids from.
- `install.sh`: `do_uninstall()` runs the binary's own `--teardown` right after stopping the service and before removing it.

Closes #160.

## Testing

- `cargo test -p firecrab-net-helper` — 96 passed, including two new tests (`owned_interface_names_are_recognized_by_prefix`, `teardown_all_is_a_no_op_when_nothing_firecrab_owns_is_present`)
- `cargo clippy -p firecrab-net-helper --all-targets -- -D warnings` — clean except two pre-existing, unrelated findings on `main` (`render_vm_policy` dead code, a `clippy::cloned_ref_to_slice_refs` in an existing test), confirmed present before this change too
- `cargo fmt -p firecrab-net-helper -- --check` — clean
- `bash -n install.sh`, `shellcheck install.sh` — clean
- `bash scripts/test-install-cli.sh` — 28 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a teardown command to remove Firecrab network interfaces, bridges, TAP devices, and firewall rules.
  * Uninstallation now performs network cleanup before removing helper components.

* **Bug Fixes**
  * Cleanup safely handles interfaces that have already been removed.
  * Improved error reporting for teardown failures.

* **Tests**
  * Added coverage for interface detection, teardown behavior, argument parsing, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->