### PR TITLE
feat(dashboard): log scroll polish + solid nav icons

### DIFF
--- a/firecrab-frontend/src/components/Images.tsx
+++ b/firecrab-frontend/src/components/Images.tsx
@@ -395,6 +395,12 @@ function ImageJobLog({
         ? t("Register log", "등록 로그")
         : t("Image import log", "이미지 가져오기 로그");
 
+  const logRef = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    const el = logRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [job.log]);
+
   return (
     <div className="subpanel">
       <div className="log-export-bar">
@@ -406,7 +412,7 @@ function ImageJobLog({
           disabled={!job.log}
         />
       </div>
-      <pre className="detail-log image-install-log">{job.log}</pre>
+      <pre className="detail-log image-install-log" ref={logRef}>{job.log}</pre>
     </div>
   );
 }
@@ -436,6 +442,11 @@ function MicroBootPanel({
   const sessionActive =
     session !== null && session.status !== "succeeded" && session.status !== "failed";
   const bootstrapBusy = startingAlias !== null || sessionActive;
+  const sessionLogRef = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    const el = sessionLogRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [session?.log]);
 
   return (
     <section className="panel microboot-panel">
@@ -586,7 +597,7 @@ function MicroBootPanel({
               )}
             </p>
           )}
-          <pre className="detail-log">{session.log}</pre>
+          <pre className="detail-log" ref={sessionLogRef}>{session.log}</pre>
         </div>
       )}
       {install && install.status !== "idle" && (

--- a/firecrab-frontend/src/components/NavIcons.tsx
+++ b/firecrab-frontend/src/components/NavIcons.tsx
@@ -1,0 +1,67 @@
+import type { ViewId } from "../navigation";
+
+/**
+ * One hand-drawn solid icon per nav destination (24x24, `fill: currentColor`
+ * so it tracks the button's text color through hover/active states exactly
+ * like the glyph it replaces). `shells` keeps its own bash.png brand mark in
+ * `Shell.tsx` and has no entry here.
+ */
+export type NavIconId = Exclude<ViewId, "shells">;
+
+export default function NavIcon({ id, className }: { id: NavIconId; className?: string }) {
+  switch (id) {
+    // Compute instance: a chip with four pins — MicroVMs are the workload
+    // running on virtualized "hardware".
+    case "vms":
+      return (
+        <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+          <rect x="7" y="7" width="10" height="10" rx="1.5" />
+          <rect x="10.4" y="1.5" width="3.2" height="4" rx="1" />
+          <rect x="10.4" y="18.5" width="3.2" height="4" rx="1" />
+          <rect x="1.5" y="10.4" width="4" height="3.2" rx="1" />
+          <rect x="18.5" y="10.4" width="4" height="3.2" rx="1" />
+        </svg>
+      );
+    // Three linked nodes — subnets and bridges as a small mesh.
+    case "networks":
+      return (
+        <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+          <line x1="12" y1="4.5" x2="4.5" y2="18" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+          <line x1="12" y1="4.5" x2="19.5" y2="18" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+          <line x1="4.5" y1="18" x2="19.5" y2="18" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" />
+          <circle cx="12" cy="4.5" r="2.6" />
+          <circle cx="4.5" cy="18" r="2.6" />
+          <circle cx="19.5" cy="18" r="2.6" />
+        </svg>
+      );
+    // Disk canister — M2Image/rootfs volumes.
+    case "storages":
+      return (
+        <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+          <rect x="4" y="6" width="16" height="14" rx="2" />
+          <ellipse cx="12" cy="6" rx="8" ry="2.6" />
+        </svg>
+      );
+    // Picture frame with a sun and a mountain ridge — MicroImage catalog.
+    case "images":
+      return (
+        <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+          <rect x="2.5" y="4" width="19" height="2" rx="1" />
+          <rect x="2.5" y="18" width="19" height="2" rx="1" />
+          <rect x="2.5" y="4" width="2" height="16" rx="1" />
+          <rect x="19.5" y="4" width="2" height="16" rx="1" />
+          <circle cx="8" cy="9.5" r="1.8" />
+          <path d="M5 17l4.5-5.5L13 15l2.5-3L19 17z" />
+        </svg>
+      );
+    // Desktop + stand — this host machine, as distinct from the VMs it runs.
+    case "host":
+      return (
+        <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+          <rect x="3" y="4" width="18" height="12" rx="1.5" />
+          <rect x="9.5" y="17.5" width="5" height="2" rx="1" />
+          <rect x="6.5" y="20" width="11" height="1.6" rx="0.8" />
+        </svg>
+      );
+  }
+}

--- a/firecrab-frontend/src/components/Shell.tsx
+++ b/firecrab-frontend/src/components/Shell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { VIEWS, viewLabel } from "../navigation";
 import type { ViewId } from "../navigation";
+import NavIcon, { type NavIconId } from "./NavIcons";
 import { useI18n } from "../i18n";
 
 interface ShellProps {
@@ -65,9 +66,7 @@ export default function Shell({ view, onSelectView, children }: ShellProps) {
                       aria-hidden="true"
                     />
                   ) : (
-                    <span className="shell-nav-glyph" aria-hidden="true">
-                      {item.glyph}
-                    </span>
+                    <NavIcon id={item.id as NavIconId} className="shell-nav-icon" />
                   )}
                   <span className="shell-nav-label">{label}</span>
                 </button>

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -1027,7 +1027,6 @@ table.image-table .state-cell {
 .pipeline-step.pending .step-bar { opacity: 0.45; }
 
 .image-install-log {
-  max-height: 28vh;
   min-height: 8rem;
 }
 

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -122,7 +122,6 @@ body {
   background: rgba(196, 62, 18, 0.08);
   color: var(--ember);
 }
-.shell-nav-glyph { font-size: 0.9rem; line-height: 1; }
 .shell-nav-icon {
   width: 1.15rem;
   height: 1.15rem;

--- a/firecrab-frontend/src/navigation.ts
+++ b/firecrab-frontend/src/navigation.ts
@@ -2,24 +2,20 @@ import { useCallback, useEffect, useState } from "react";
 import type { Locale } from "./i18n";
 
 /**
- * Dashboard destinations. `glyph` is the text rail mark; optional `icon`
- * is a small image (e.g. Shell repository bash cube) shown instead.
+ * Dashboard destinations. Rendered as a `NavIcon` (see `NavIcons.tsx`) in the
+ * rail, except `shells`, whose `icon` is a small image (the Shell repository
+ * bash cube) shown instead.
  *
  * Kept out of `components/Shell.tsx` so that file exports only its component
  * — mixing constants and hooks in there breaks Vite's fast refresh.
  */
 export const VIEWS = [
-  { id: "vms", labels: { en: "MicroVM", ko: "MicroVM" }, glyph: "▣" },
-  { id: "networks", labels: { en: "Networks", ko: "네트워크" }, glyph: "◇" },
-  { id: "storages", labels: { en: "Storage", ko: "스토리지" }, glyph: "▤" },
-  { id: "images", labels: { en: "Images", ko: "이미지" }, glyph: "◈" },
-  {
-    id: "shells",
-    labels: { en: "Shells", ko: "Shell" },
-    glyph: "$",
-    icon: "/bash.png",
-  },
-  { id: "host", labels: { en: "Host", ko: "호스트" }, glyph: "◉" },
+  { id: "vms", labels: { en: "MicroVM", ko: "MicroVM" } },
+  { id: "networks", labels: { en: "Networks", ko: "네트워크" } },
+  { id: "storages", labels: { en: "Storage", ko: "스토리지" } },
+  { id: "images", labels: { en: "Images", ko: "이미지" } },
+  { id: "shells", labels: { en: "Shells", ko: "Shell" }, icon: "/bash.png" },
+  { id: "host", labels: { en: "Host", ko: "호스트" } },
 ] as const;
 
 export type ViewId = (typeof VIEWS)[number]["id"];


### PR DESCRIPTION
## Summary

- OCI/Image import logs and MicroBoot session logs now auto-scroll to the bottom on new lines (consistent with `VmDetailModal` behavior).
- Removed the `max-height: 28vh` constraint on the OCI log box — unified to `40vh` to match VM console and bootstrap logs.
- Replaced Unicode shape glyphs (▣ ◇ ▤ ◈ ◉) in the left navigation rail with solid SVG icons tailored to each feature:
  - MicroVM: chip + pins
  - Networks: 3-node mesh
  - Storage: cylinder
  - Images: frame + mountain + sun
  - Host: monitor + stand
  - Shells: retained existing `bash.png` brand icon

## Testing

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npm run preview`로 실제 브라우저에서 6개 네비게이션 아이콘 렌더링 및 active/hover 색상 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent visual icons for virtual machines, networks, storage, images, and host navigation.
  - Updated navigation entries to use destination-specific icons.
  - Logs now automatically scroll to the latest content as entries are added.

- **Bug Fixes**
  - Improved visibility of image installation logs by removing the previous height restriction.
  - Updated shell navigation to use the new shared icon styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->