### PR TITLE
fix(oci): pin latest stable kernels for every architecture

### DIFF
--- a/firecrab-api/src/oci/boot_tests.rs
+++ b/firecrab-api/src/oci/boot_tests.rs
@@ -252,48 +252,44 @@ fn catalog_pair_skips_kernels_that_need_an_initrd() {
 
 /// A base URL nothing listens on, so the fetch fails without a fixture server.
 const UNREACHABLE_BASE_URL: &str = "http://127.0.0.1:1";
-/// The architecture this build pins a kernel for, on either host.
-const PINNED_ARCHITECTURE: Architecture = Architecture::X86_64;
+/// Architectures that must always carry a dedicated compiled kernel pin.
+const PINNED_ARCHITECTURES: [Architecture; 2] = [Architecture::X86_64, Architecture::Aarch64];
 
 #[tokio::test]
 async fn resolution_falls_back_to_an_installed_catalog_kernel_when_the_registry_is_unreachable() {
-    let directory = tempfile::tempdir().expect("create fixture directory");
-    let image_root = directory.path();
-    let catalog = boot::catalog_kernel_pair(PINNED_ARCHITECTURE).expect("catalog pair");
-    write_file(
-        &image_root.join(&catalog.kernel),
-        &kernel_bytes_for(PINNED_ARCHITECTURE),
-    );
+    for architecture in PINNED_ARCHITECTURES {
+        let directory = tempfile::tempdir().expect("create fixture directory");
+        let image_root = directory.path();
+        let catalog = boot::catalog_kernel_pair(architecture).expect("catalog pair");
+        write_file(
+            &image_root.join(&catalog.kernel),
+            &kernel_bytes_for(architecture),
+        );
 
-    let pair = boot::resolve_kernel_pair(
-        image_root,
-        PINNED_ARCHITECTURE,
-        None,
-        Some(UNREACHABLE_BASE_URL),
-    )
-    .await
-    .expect("an installed catalog kernel keeps this host importing");
+        let pair =
+            boot::resolve_kernel_pair(image_root, architecture, None, Some(UNREACHABLE_BASE_URL))
+                .await
+                .expect("an installed catalog kernel keeps this host importing");
 
-    assert_eq!(pair, catalog);
+        assert_eq!(pair, catalog);
+    }
 }
 
 #[tokio::test]
 async fn resolution_reports_the_registry_failure_when_no_catalog_kernel_is_installed() {
-    let directory = tempfile::tempdir().expect("create fixture directory");
-    let image_root = directory.path();
+    for architecture in PINNED_ARCHITECTURES {
+        let directory = tempfile::tempdir().expect("create fixture directory");
+        let image_root = directory.path();
 
-    let error = boot::resolve_kernel_pair(
-        image_root,
-        PINNED_ARCHITECTURE,
-        None,
-        Some(UNREACHABLE_BASE_URL),
-    )
-    .await
-    .expect_err("nothing can supply a kernel");
+        let error =
+            boot::resolve_kernel_pair(image_root, architecture, None, Some(UNREACHABLE_BASE_URL))
+                .await
+                .expect_err("nothing can supply a kernel");
 
-    assert_matches!(
-        error,
-        ResolveError::KernelDownloadFailed { .. },
-        "the registry failure is more actionable than a missing catalog kernel, got {error}"
-    );
+        assert_matches!(
+            error,
+            ResolveError::KernelDownloadFailed { .. },
+            "the registry failure is more actionable than a missing catalog kernel, got {error}"
+        );
+    }
 }

--- a/firecrab-api/src/oci/kernel.rs
+++ b/firecrab-api/src/oci/kernel.rs
@@ -36,6 +36,9 @@ const READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Firecracker command line an imported rootfs boots with on x86_64.
 const X86_64_BOOT_ARGS: &str = "console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw";
+/// Firecracker command line an imported rootfs boots with on aarch64.
+const AARCH64_BOOT_ARGS: &str =
+    "keep_bootcon console=ttyS0 reboot=k panic=1 pci=off root=/dev/vda rw";
 
 /// One published kernel artifact this build trusts.
 ///
@@ -59,21 +62,27 @@ pub(super) struct PinnedKernel<'a> {
 
 /// The kernel this build pins for `architecture`.
 ///
-/// `None` means no dedicated kernel is published for that architecture yet and
-/// the caller must fall back to an installed catalog kernel. aarch64 is `None`
-/// until the arm64 build is published: the artifact is built on a native host,
-/// and a pin without a digest would be a tag by another name.
+/// Every supported architecture carries the latest stable kernel that was
+/// published when this release was built. `None` remains the signal for a
+/// future architecture that has no dedicated artifact yet.
 pub(super) fn pinned_kernel(architecture: Architecture) -> Option<PinnedKernel<'static>> {
     match architecture {
         Architecture::X86_64 => Some(PinnedKernel {
-            alias: "vmlinux-7.1.8",
-            version: "7.1.8",
-            image: "vmlinux-7.1.8-x86_64",
-            package_digest: "sha256:eb2efc87a8b64b9bcf5c4b7365193c578e6cf203c4773060ec157d6f34c11f53",
-            image_digest: "sha256:1d693ebb340ee418127aacf679080671679e455302a8f89ff8d4a45b6d293cdb",
+            alias: "vmlinux-7.1.9",
+            version: "7.1.9",
+            image: "vmlinux-7.1.9-x86_64",
+            package_digest: "sha256:fd058e64d2173b3911ad09a15aa6bcf15531941254ce44ba6e935b876662ba65",
+            image_digest: "sha256:079d2149a9378f5705da46232e99886187fecdd5517428d2c294b6bd1e0dca6b",
             boot_args: X86_64_BOOT_ARGS,
         }),
-        Architecture::Aarch64 => None,
+        Architecture::Aarch64 => Some(PinnedKernel {
+            alias: "vmlinux-7.1.9",
+            version: "7.1.9",
+            image: "Image-7.1.9-aarch64",
+            package_digest: "sha256:3a8576656d45eb051874a4b1cf4b8838d54d96aa268bc53706118e0bbeb727f7",
+            image_digest: "sha256:6d60d06429aa5e244cc5a0eb60383a97fde61f4aa40453d5cc6fecb59a64b58f",
+            boot_args: AARCH64_BOOT_ARGS,
+        }),
     }
 }
 

--- a/firecrab-api/src/oci/kernel_tests.rs
+++ b/firecrab-api/src/oci/kernel_tests.rs
@@ -596,18 +596,37 @@ async fn a_host_with_no_kernel_source_is_told_so() {
 }
 
 #[test]
-fn the_compiled_pin_names_a_digest_and_the_published_registry_layout() {
-    let pinned = kernel::pinned_kernel(Architecture::X86_64).expect("x86_64 kernel is published");
+fn the_compiled_pins_name_the_latest_stable_registry_artifacts() {
+    let expected = [
+        (
+            Architecture::X86_64,
+            "vmlinux-7.1.9-x86_64",
+            "kernel/7.1.9/x86_64/vmlinux-7.1.9.tar.zst",
+            false,
+        ),
+        (
+            Architecture::Aarch64,
+            "Image-7.1.9-aarch64",
+            "kernel/7.1.9/aarch64/vmlinux-7.1.9.tar.zst",
+            true,
+        ),
+    ];
 
-    assert_eq!(pinned.alias, "vmlinux-7.1.8");
-    assert_eq!(pinned.version, "7.1.8");
-    assert_eq!(pinned.image, "vmlinux-7.1.8-x86_64");
-    assert_eq!(
-        kernel::package_key(Architecture::X86_64, &pinned),
-        "kernel/7.1.8/x86_64/vmlinux-7.1.8.tar.zst"
-    );
-    Sha256Digest::parse(pinned.package_digest).expect("package digest is pinned, not a tag");
-    Sha256Digest::parse(pinned.image_digest).expect("kernel digest is pinned, not a tag");
-    assert!(pinned.boot_args.contains("root=/dev/vda"));
-    assert!(pinned.boot_args.contains("console=ttyS0"));
+    for (architecture, image, package_key, needs_keep_bootcon) in expected {
+        let pinned = kernel::pinned_kernel(architecture)
+            .unwrap_or_else(|| panic!("{architecture} kernel is published"));
+
+        assert_eq!(pinned.alias, "vmlinux-7.1.9");
+        assert_eq!(pinned.version, "7.1.9");
+        assert_eq!(pinned.image, image);
+        assert_eq!(kernel::package_key(architecture, &pinned), package_key);
+        Sha256Digest::parse(pinned.package_digest).expect("package digest is pinned, not a tag");
+        Sha256Digest::parse(pinned.image_digest).expect("kernel digest is pinned, not a tag");
+        assert!(pinned.boot_args.contains("root=/dev/vda"));
+        assert!(pinned.boot_args.contains("console=ttyS0"));
+        assert_eq!(
+            pinned.boot_args.contains("keep_bootcon"),
+            needs_keep_bootcon
+        );
+    }
 }

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -190,6 +190,7 @@ One static program supplies all three before a merged tree can boot.
 The packed ext4 is paired with the kernel firecrab publishes for this architecture, so no catalog image has to be installed first.
 
 - `virtio_blk`, `virtio_net`, `virtio_mmio`, and `ext4` are built in, and there is no initrd.
+- Each release pins the newest published stable kernel for both `x86_64` and `aarch64` with architecture-specific package and image digests.
 - Pinned by digest, fetched once from `FIRECRAB_IMAGE_BASE_URL`, cached at `<FIRECRAB_IMAGE_ROOT>/.oci/kernel/<arch>/`.
 - Re-verified on every reuse; a failed entry is refetched.
 - `FIRECRAB_OCI_KERNEL_PATH` names a host copy, which must match the same digest.


### PR DESCRIPTION
## Bug Fixes

- Pin Linux 7.1.9 for both x86_64 and aarch64 OCI imports.
- Use the dedicated aarch64 kernel instead of requiring the Ubuntu M2Image.
- Keep the installed catalog kernel only as the registry-outage fallback.

## Tests

- Cover both architecture pins, package paths, digests, boot arguments, and fallback behavior.

## Docs

- Document per-architecture latest-stable kernel pins for OCI imports.

Closes #174