### PR TITLE
feat(dashboard): restyle the serial console inspect rail

### DIFF
--- a/firecrab-e2e/README.md
+++ b/firecrab-e2e/README.md
@@ -5,6 +5,7 @@ Isolated Playwright suite.
 - [#90](https://github.com/SteelCrab/firecrab/issues/90) OCI import
 - [#108](https://github.com/SteelCrab/firecrab/issues/108) MicroRegistry register
 - [#146](https://github.com/SteelCrab/firecrab/issues/146) MicroNetwork IPv6
+- OCI DHCP boot (busybox `udhcpc`, same path as nginx-stable)
 - Local OCI registry fixture only — no Docker Hub
 - Playwright is a test-only dependency of this package, not of `firecrab-frontend`
 
@@ -25,6 +26,7 @@ Isolated Playwright suite.
 4. Optional: create and start a VM from that alias
 5. Optional: assert `FIRECRAB_NETWORK_READY` and `FIRECRAB_OCI_E2E_READY` on the console
 6. Networks: IPv6 select defaults to Off; optional create of IPv4-only and auto-ULA dual-stack
+7. OCI DHCP: import fixture → create network → VM with `80:18888/tcp` → start → `FIRECRAB_NETWORK_READY` and an IPv4 on the detail panel
 
 - `FIRECRAB_E2E_SKIP_GUEST_BOOT=1`: skip guest-boot half
 - Inspect and import still run
@@ -86,6 +88,26 @@ npm run test:ipv6 --prefix firecrab-e2e
 - Needs a helper the API process can connect to (`/run/firecrab/net-helper.sock`)
 - systemd `firecrab-api` runs as user `firecrab`; a debug helper that recreates the socket as `root:pista` makes create return 500
 
+OCI DHCP boot (busybox `udhcpc`, nginx-stable path), form only:
+
+```sh
+FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:dhcp --prefix firecrab-e2e
+```
+
+- Expect **1 passed, 1 skipped**
+
+Create a dedicated network, start the imported guest with `80:18888/tcp`, assert DHCP:
+
+```sh
+./scripts/dev-net-helper.sh    # terminal session 1
+npm run test:dhcp --prefix firecrab-e2e
+```
+
+- Expect **2 passed**
+- `afterAll` deletes `oci-e2e-dhcp` (VM, network, imported alias)
+- An orphan dnsmasq holding `:67` fails the boot half with `FIRECRAB_NETWORK_FAILED no-ipv4-address`
+- Needs a helper the API process can connect to (`/run/firecrab/net-helper.sock`)
+
 Playwright:
 
 - Starts `firecrab-api` on `:5523` unless it already answers
@@ -112,6 +134,7 @@ python3 scripts/oci-e2e-registry.py --port 15555
 | --- | --- | --- |
 | `FIRECRAB_E2E_SKIP_GUEST_BOOT` | unset | Skip VM create/start when `1` / `true` / `yes` |
 | `FIRECRAB_OCI_E2E_PORT` | `15555` | Loopback registry port |
+| `FIRECRAB_OCI_DHCP_E2E_PORT` | `15557` | DHCP-boot spec registry port |
 | `FIRECRAB_E2E_BASE_URL` | `http://localhost:8080` | Dashboard origin |
 | `FIRECRAB_E2E_API_URL` | `http://127.0.0.1:5523` | API used for cleanup |
 

--- a/firecrab-e2e/package.json
+++ b/firecrab-e2e/package.json
@@ -3,12 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Isolated browser E2E for issue #90 (OCI import), #108 (MicroRegistry register), and #146 (MicroNetwork IPv6). Playwright is test-only.",
+  "description": "Isolated browser E2E for issue #90 (OCI import), #108 (MicroRegistry register), #146 (MicroNetwork IPv6), and OCI DHCP boot. Playwright is test-only.",
   "scripts": {
     "test": "playwright test",
     "test:import": "FIRECRAB_E2E_SKIP_GUEST_BOOT=1 playwright test",
     "test:register": "playwright test tests/microregistry-register.spec.ts",
     "test:ipv6": "playwright test tests/network-ipv6.spec.ts",
+    "test:dhcp": "playwright test tests/oci-dhcp-boot.spec.ts",
     "test:headed": "playwright test --headed",
     "install-browsers": "playwright install chromium"
   },

--- a/firecrab-e2e/src/api.ts
+++ b/firecrab-e2e/src/api.ts
@@ -5,6 +5,8 @@ interface VmRow {
   name: string;
   state: string;
   template: string;
+  ipv4?: string | null;
+  portForwards?: Array<{ hostPort: number; guestPort: number; protocol: string }>;
 }
 
 interface ImageRow {
@@ -69,6 +71,14 @@ export class ApiCleanup {
     const { status, json } = await this.request("GET", "/api/vms");
     if (status >= 400 || !Array.isArray(json)) return [];
     return json as VmRow[];
+  }
+
+  async getVm(id: string): Promise<VmRow | null> {
+    const { status, json } = await this.request("GET", `/api/vms/${id}`);
+    if (status >= 400 || !json || typeof json !== "object") return null;
+    const row = json as VmRow;
+    if (typeof row.id !== "string" || typeof row.name !== "string") return null;
+    return row;
   }
 
   async listImages(): Promise<ImageRow[]> {

--- a/firecrab-e2e/src/constants.ts
+++ b/firecrab-e2e/src/constants.ts
@@ -69,6 +69,33 @@ export const IPV6_E2E_V6_NAME = "ipv6-e2e-v6";
 /** Isolated subnet for {@link IPV6_E2E_V6_NAME}. */
 export const IPV6_E2E_V6_CIDR = "172.30.93.0/24";
 
+/** Loopback port for the OCI DHCP-boot spec. Distinct from import/register. */
+export const DHCP_REGISTRY_PORT = Number.parseInt(
+  process.env.FIRECRAB_OCI_DHCP_E2E_PORT ?? "15557",
+  10,
+);
+
+/** Deterministic reference when the DHCP-boot fixture binds {@link DHCP_REGISTRY_PORT}. */
+export const DHCP_FIXED_REFERENCE = `127.0.0.1:${DHCP_REGISTRY_PORT}/firecrab/e2e:ready`;
+
+/** Alias `POST /api/oci/import` claims for {@link DHCP_FIXED_REFERENCE}. */
+export const DHCP_FIXED_ALIAS = `127.0.0.1-${DHCP_REGISTRY_PORT}-firecrab-e2e-ready`;
+
+/** VM created by the OCI DHCP-boot spec (busybox `udhcpc`, same path as nginx-stable). */
+export const DHCP_VM_NAME = "oci-e2e-dhcp";
+
+/** Dedicated MicroNetwork for the OCI DHCP-boot spec. */
+export const DHCP_NETWORK_NAME = "oci-e2e-dhcp";
+
+/** Isolated subnet so this spec does not share {@link NETWORK_CIDR}. */
+export const DHCP_NETWORK_CIDR = "172.30.94.0/24";
+
+/** Host port forwarded to guest 80 — away from a developer's own 8888. */
+export const DHCP_HOST_PORT = 18888;
+
+/** Guest line when DHCP never handed an address. */
+export const NETWORK_FAILED = "FIRECRAB_NETWORK_FAILED";
+
 export const DEFAULT_API_URL = "http://127.0.0.1:5523";
 export const DEFAULT_BASE_URL = "http://localhost:8080";
 

--- a/firecrab-e2e/tests/oci-dhcp-boot.spec.ts
+++ b/firecrab-e2e/tests/oci-dhcp-boot.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { ApiCleanup } from "../src/api.js";
+import {
+  DHCP_FIXED_ALIAS,
+  DHCP_FIXED_REFERENCE,
+  DHCP_HOST_PORT,
+  DHCP_NETWORK_CIDR,
+  DHCP_NETWORK_NAME,
+  DHCP_REGISTRY_PORT,
+  DHCP_VM_NAME,
+  NETWORK_FAILED,
+  NETWORK_READY,
+  SKIP_GUEST_BOOT,
+} from "../src/constants.js";
+import { startLocalOciRegistry, type LocalOciRegistry } from "../src/registry.js";
+
+/**
+ * OCI guest DHCP + port-forward boot — the nginx-stable dashboard path
+ * (busybox `udhcpc`, `FIRECRAB_NETWORK_READY`) without Docker Hub.
+ *
+ *   FIRECRAB_E2E_SKIP_GUEST_BOOT=1 npm run test:dhcp --prefix firecrab-e2e
+ *   npm run test:dhcp --prefix firecrab-e2e
+ *
+ * Guest boot needs a helper the API can connect to
+ * (`./scripts/dev-net-helper.sh`, socket `/run/firecrab/net-helper.sock`).
+ * An orphan dnsmasq holding `:67` reproduces `FIRECRAB_NETWORK_FAILED
+ * no-ipv4-address` — this spec fails loudly in that state.
+ */
+test.describe.configure({ mode: "serial" });
+
+let registry: LocalOciRegistry;
+let createdNetworkId: string | null = null;
+const api = new ApiCleanup();
+
+function reference(): string {
+  return registry.announcement.reference;
+}
+
+function alias(): string {
+  return registry.announcement.alias;
+}
+
+function sentinel(): string {
+  return registry.announcement.ready;
+}
+
+async function openEnglish(page: Page, hash: string): Promise<void> {
+  await page.addInitScript(() => {
+    localStorage.setItem("firecrab.locale", "en");
+  });
+  await page.goto(hash);
+}
+
+async function cleanupOwned(): Promise<void> {
+  const imported = registry?.announcement.alias ?? DHCP_FIXED_ALIAS;
+  await api.deleteOwnedVms(imported, DHCP_VM_NAME);
+  await api.deleteImportedImage(imported);
+  await api.deleteOwnedNetwork(createdNetworkId, DHCP_NETWORK_NAME);
+  createdNetworkId = null;
+}
+
+test.beforeAll(async () => {
+  registry = await startLocalOciRegistry(DHCP_REGISTRY_PORT);
+  expect(registry.announcement.reference).toBe(DHCP_FIXED_REFERENCE);
+  expect(registry.announcement.alias).toBe(DHCP_FIXED_ALIAS);
+  await cleanupOwned();
+});
+
+test.afterAll(async () => {
+  try {
+    await cleanupOwned();
+  } finally {
+    await registry?.stop();
+  }
+});
+
+test("inspects the DHCP-boot fixture and imports it as a registered image", async ({ page }) => {
+  await openEnglish(page, "/#/images");
+  await expect(page.locator("#oci-reference")).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeDisabled();
+
+  await page.locator("#oci-reference").fill(reference());
+  await page.locator("#oci-inspect").click();
+
+  const oci = page.locator("section.panel", { has: page.getByRole("heading", { name: "OCI" }) });
+  await expect(oci.getByText("Compatible with this host.")).toBeVisible({ timeout: 30_000 });
+  await expect(oci.locator("dd", { hasText: alias() }).first()).toBeVisible();
+  await expect(page.locator("#oci-import")).toBeEnabled();
+
+  await page.locator("#oci-import").click();
+  const status = oci.locator(".state-badge");
+  await expect(status).toHaveText(/Imported|Import failed/, { timeout: 180_000 });
+  if ((await status.textContent())?.includes("failed")) {
+    const log = (await oci.locator(".image-install-log").textContent()) ?? "";
+    throw new Error(`OCI import failed for ${reference()}:\n${log}`);
+  }
+
+  await expect(page.locator("table.image-table")).toContainText(alias());
+});
+
+test("starts the imported guest with a port forward and gets a DHCP lease", async ({ page }) => {
+  test.skip(
+    SKIP_GUEST_BOOT,
+    "FIRECRAB_E2E_SKIP_GUEST_BOOT is set — import already covered. Unset the flag (and run ./scripts/dev-net-helper.sh) to boot through DHCP.",
+  );
+
+  await openEnglish(page, "/#/networks");
+  const networkPanel = page.locator("section.panel", {
+    has: page.getByRole("heading", { name: "MicroNetwork" }),
+  });
+  const pendingNetwork = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" && response.url().includes("/api/micro-networks"),
+  );
+  await page.locator("#mn-name").fill(DHCP_NETWORK_NAME);
+  await page.locator("#mn-subnet").fill(DHCP_NETWORK_CIDR);
+  await networkPanel.locator('button[type="submit"]').click();
+  const networkResponse = await pendingNetwork;
+  if (!networkResponse.ok()) {
+    throw new Error(
+      `POST /api/micro-networks ${networkResponse.status()}: ${await networkResponse.text()}`,
+    );
+  }
+  const created = networkPanel
+    .locator("table.vm-table tbody tr")
+    .filter({ hasText: DHCP_NETWORK_NAME });
+  await expect(created).toBeVisible({ timeout: 30_000 });
+  const networks = await api.listNetworks();
+  createdNetworkId = networks.find((network) => network.name === DHCP_NETWORK_NAME)?.id ?? null;
+  expect(createdNetworkId, `API missing ${DHCP_NETWORK_NAME}`).toBeTruthy();
+
+  await openEnglish(page, "/#/vms");
+  await page.locator("#vm-list-add").click();
+  await expect(page).toHaveURL(/#\/vms\/new$/);
+  await expect(page.locator("#vm-image")).toBeEnabled({ timeout: 15_000 });
+  await expect(page.locator(`#vm-image option[value="${alias()}"]`)).toHaveCount(1, {
+    timeout: 15_000,
+  });
+  await page.locator("#vm-name").fill(DHCP_VM_NAME);
+  await page.locator("#vm-image").selectOption(alias());
+  await page
+    .locator("#vm-micro-network")
+    .selectOption({ label: `${DHCP_NETWORK_NAME} (${DHCP_NETWORK_CIDR})` });
+  await page.getByRole("button", { name: /Add Port Forward Rule/ }).click();
+  const hostPort = page.locator(".port-forwards-list input[placeholder='8080']");
+  await expect(hostPort).toHaveValue("8080");
+  await hostPort.fill(String(DHCP_HOST_PORT));
+
+  await page.locator("#vm-create-submit").click();
+  await expect(page).toHaveURL(/#\/vms$/);
+  await expect(page.getByText(`Created: ${DHCP_VM_NAME}`)).toBeVisible({ timeout: 30_000 });
+
+  const row = page.locator("table.vm-table tbody tr", { hasText: DHCP_VM_NAME });
+  await expect(row).toBeVisible();
+  await row.getByRole("button", { name: "start" }).click();
+  await expect(row.locator(".state-badge")).toHaveText(/running|error/, { timeout: 240_000 });
+  if ((await row.locator(".state-badge").textContent()) !== "running") {
+    await row.locator("button.link-button").click();
+    await expect(page.locator(".console-title")).toBeVisible();
+    const logText = (await page.locator("pre.detail-log").textContent()) ?? "";
+    const banner = (await page.locator(".banner").textContent().catch(() => "")) ?? "";
+    throw new Error(
+      `VM ${DHCP_VM_NAME} entered error instead of running.\nbanner: ${banner}\nlog:\n${logText}`,
+    );
+  }
+
+  await row.locator("button.link-button").click();
+  const log = page.locator("pre.detail-log");
+  await expect(log).toContainText(NETWORK_READY, { timeout: 30_000 });
+  await expect(log).not.toContainText(NETWORK_FAILED);
+  await expect(log).toContainText(sentinel(), { timeout: 60_000 });
+  await expect(page.locator("dt").filter({ hasText: /^ip$/ }).locator("+ dd")).toContainText(
+    /^172\.30\.94\./,
+  );
+  await expect(page.locator("dt", { hasText: /^ports$/ })).toBeVisible();
+  await expect(page.getByText(`80:${DHCP_HOST_PORT}/tcp`)).toBeVisible();
+
+  const vms = await api.listVms();
+  const vm = vms.find((row) => row.name === DHCP_VM_NAME);
+  expect(vm, `API missing ${DHCP_VM_NAME}`).toBeTruthy();
+  const detail = await api.getVm(vm!.id);
+  expect(detail?.state).toBe("running");
+  expect(detail?.ipv4 ?? "").toMatch(/^172\.30\.94\./);
+  expect(detail?.portForwards).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        guestPort: 80,
+        hostPort: DHCP_HOST_PORT,
+        protocol: "tcp",
+      }),
+    ]),
+  );
+});

--- a/firecrab-frontend/src/components/Console.tsx
+++ b/firecrab-frontend/src/components/Console.tsx
@@ -76,9 +76,10 @@ const VM_POLL_MS = 3_000;
 interface ConsolePrefs {
   fontSize: number;
   themeId: ThemeId;
+  inspectOpen: boolean;
 }
 
-const DEFAULT_PREFS: ConsolePrefs = { fontSize: 13, themeId: "ember" };
+const DEFAULT_PREFS: ConsolePrefs = { fontSize: 13, themeId: "ember", inspectOpen: true };
 
 function loadPrefs(): ConsolePrefs {
   try {
@@ -90,7 +91,8 @@ function loadPrefs(): ConsolePrefs {
       : DEFAULT_PREFS.fontSize;
     const themeId =
       parsed.themeId && parsed.themeId in THEMES ? parsed.themeId : DEFAULT_PREFS.themeId;
-    return { fontSize, themeId };
+    const inspectOpen = typeof parsed.inspectOpen === "boolean" ? parsed.inspectOpen : true;
+    return { fontSize, themeId, inspectOpen };
   } catch {
     return DEFAULT_PREFS;
   }
@@ -376,9 +378,10 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
   }, [prefs, scheduleFit]);
 
   // Refit when chrome visibility changes (detail panel / bar show·hide).
+  const inspectOpen = prefs.inspectOpen;
   useEffect(() => {
     scheduleFit();
-  }, [terminalOnly, scheduleFit]);
+  }, [terminalOnly, inspectOpen, scheduleFit]);
 
   const reconnectNow = () => {
     clearReconnectTimer();
@@ -399,7 +402,7 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
   };
 
   const canRetry = status === "disconnected" || status === "failed" || status === "reconnecting";
-  const title = vm ? `terminal — ${vm.name}` : `terminal — ${vmId.slice(0, 8)}`;
+  const sessionName = vm?.name ?? vmId.slice(0, 8);
 
   /** Server console.log + startup timeline + live xterm buffer for copy/download. */
   const buildExportText = useCallback(async () => {
@@ -426,20 +429,7 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
       ref={pageRef}
     >
       {!terminalOnly && (
-        <div className="console-bar">
-          <button
-            type="button"
-            className="btn console-bar-btn"
-            onClick={handleClose}
-            title={t("Close window", "창 닫기")}
-          >
-            {t("Close", "창 닫기")}
-          </button>
-
-          <span className="console-title" title={vmId}>
-            {title}
-          </span>
-
+        <div className="console-bar" aria-label={`terminal — ${sessionName}`}>
           <span
             className={`console-status ${STATUS_CLASS[status]}`}
             role="status"
@@ -457,6 +447,17 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
                     : t("Connection failed", "연결 실패")}
           </span>
 
+          <span className="console-session" title={vmId}>
+            <span className="console-session-caret" aria-hidden>
+              ▍
+            </span>
+            <span className="console-session-name">{sessionName}</span>
+            {vm?.hostname ? (
+              <span className="console-session-host">{vm.hostname}</span>
+            ) : null}
+            {vm?.ipv4 ? <span className="console-session-addr">{vm.ipv4}</span> : null}
+          </span>
+
           {canRetry && (
             <button
               type="button"
@@ -468,74 +469,76 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
             </button>
           )}
 
-          <div className="console-settings">
+          <div className="console-bar-actions">
+            <div className="console-settings">
+              <button
+                type="button"
+                className={`btn console-bar-btn${settingsOpen ? " is-active" : ""}`}
+                onClick={() => setSettingsOpen((o) => !o)}
+                aria-expanded={settingsOpen}
+                aria-haspopup="true"
+                title={t("Font · colors", "폰트 · 색상")}
+              >
+                {t("Display", "표시")}
+              </button>
+              {settingsOpen && (
+                <div className="console-settings-pop" role="dialog" aria-label={t("Terminal display settings", "터미널 표시 설정")}>
+                  <label className="console-settings-row">
+                    <span>{t("Font size", "글자 크기")}</span>
+                    <select
+                      value={prefs.fontSize}
+                      onChange={(e) => setPrefs((p) => ({ ...p, fontSize: Number(e.target.value) }))}
+                    >
+                      {FONT_SIZES.map((n) => (
+                        <option key={n} value={n}>
+                          {n}px
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="console-settings-row">
+                    <span>{t("Color theme", "색 테마")}</span>
+                    <select
+                      value={prefs.themeId}
+                      onChange={(e) =>
+                        setPrefs((p) => ({ ...p, themeId: e.target.value as ThemeId }))
+                      }
+                    >
+                      {Object.entries(THEMES).map(([id, { label }]) => (
+                        <option key={id} value={id}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              )}
+            </div>
+
+            <LogExportActions
+              text={buildExportText}
+              filename={logDownloadFilename("console", vm?.name ?? vmId)}
+              buttonClassName="btn console-bar-btn"
+              copyLabel={t("Copy log", "로그 복사")}
+              downloadLabel={t("Save log", "로그 저장")}
+            />
+
             <button
               type="button"
-              className={`btn console-bar-btn${settingsOpen ? " is-active" : ""}`}
-              onClick={() => setSettingsOpen((o) => !o)}
-              aria-expanded={settingsOpen}
-              aria-haspopup="true"
-              title={t("Font · colors", "폰트 · 색상")}
+              className="btn console-bar-btn"
+              onClick={() => {
+                setTerminalOnly(true);
+                setSettingsOpen(false);
+              }}
+              title={t("Hide the toolbar and details; show terminal only (Esc to return)", "툴바·세부정보를 숨기고 터미널만 표시 (Esc로 복귀)")}
             >
-              {t("Display", "표시")}
+              {t("Terminal only", "터미널만")}
             </button>
-            {settingsOpen && (
-              <div className="console-settings-pop" role="dialog" aria-label={t("Terminal display settings", "터미널 표시 설정")}>
-                <label className="console-settings-row">
-                  <span>{t("Font size", "글자 크기")}</span>
-                  <select
-                    value={prefs.fontSize}
-                    onChange={(e) => setPrefs((p) => ({ ...p, fontSize: Number(e.target.value) }))}
-                  >
-                    {FONT_SIZES.map((n) => (
-                      <option key={n} value={n}>
-                        {n}px
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label className="console-settings-row">
-                  <span>{t("Color theme", "색 테마")}</span>
-                  <select
-                    value={prefs.themeId}
-                    onChange={(e) =>
-                      setPrefs((p) => ({ ...p, themeId: e.target.value as ThemeId }))
-                    }
-                  >
-                    {Object.entries(THEMES).map(([id, { label }]) => (
-                      <option key={id} value={id}>
-                        {label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              </div>
-            )}
+
+            <button type="button" className="btn console-close" onClick={handleClose} title={t("Close", "닫기")}>
+              {t("Close", "닫기")}
+            </button>
           </div>
-
-          <LogExportActions
-            text={buildExportText}
-            filename={logDownloadFilename("console", vm?.name ?? vmId)}
-            buttonClassName="btn console-bar-btn"
-            copyLabel={t("Copy log", "로그 복사")}
-            downloadLabel={t("Save log", "로그 저장")}
-          />
-
-          <button
-            type="button"
-            className="btn console-bar-btn"
-            onClick={() => {
-              setTerminalOnly(true);
-              setSettingsOpen(false);
-            }}
-            title={t("Hide the toolbar and details; show terminal only (Esc to return)", "툴바·세부정보를 숨기고 터미널만 표시 (Esc로 복귀)")}
-          >
-            {t("Terminal only", "터미널만")}
-          </button>
-
-          <button type="button" className="btn console-close" onClick={handleClose} title={t("Close", "닫기")}>
-            ✕
-          </button>
         </div>
       )}
 
@@ -560,20 +563,12 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
         </button>
       )}
 
-      {!terminalOnly && (
-        <aside className="console-detail" aria-label={t("VM details", "VM 세부정보")}>
-          <div className="console-detail-head">
-            <h2 className="console-detail-title">{t("Details", "세부정보")}</h2>
-            {vm && <span className={`state-badge ${vm.state}`}>{vm.state}</span>}
-            <button
-              type="button"
-              className="btn console-bar-btn"
-              onClick={() => setTerminalOnly(true)}
-              title={t("Show terminal only", "터미널만 보기")}
-            >
-              {t("Terminal only", "터미널만")}
-            </button>
-          </div>
+      {!terminalOnly && prefs.inspectOpen && (
+        <aside
+          id="console-inspect-rail"
+          className="console-detail"
+          aria-label={t("VM details", "VM 세부정보")}
+        >
           {vmError && !vm ? (
             <p className="console-detail-error">{vmError}</p>
           ) : vm ? (
@@ -607,13 +602,36 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
                 <dl className="console-detail-fields mono">
                   <dt>ipv4</dt>
                   <dd>{vm.ipv4 ?? "—"}</dd>
+                  <dt>ipv6</dt>
+                  <dd>{vm.ipv6 ?? "—"}</dd>
                   <dt>mac</dt>
                   <dd>{vm.mac ?? "—"}</dd>
                   <dt>egress</dt>
                   <dd>{vm.egressPolicy === "internet" ? t("Internet access", "인터넷 허용") : t("Isolated", "격리")}</dd>
                   <dt>network</dt>
-                  <dd title={vm.microNetworkId}>{vm.microNetworkId}</dd>
+                  <dd title={vm.microNetworkId}>{vm.microNetworkId.slice(0, 8)}</dd>
                 </dl>
+              </section>
+              <section
+                className="console-detail-group console-detail-usage-group"
+                aria-label={t("Resource usage", "리소스 관측")}
+              >
+                <h3 className="console-detail-group-title">
+                  {t("Resource usage", "리소스 관측")}
+                </h3>
+                {vm.state === "running" && (vm.usageHistory?.length ?? 0) > 0 ? (
+                  <UsageCharts
+                    history={vm.usageHistory ?? []}
+                    ramMib={vm.ram}
+                    size="compact"
+                  />
+                ) : (
+                  <p className="console-detail-empty">
+                    {vm.state === "running"
+                      ? t("Collecting samples…", "샘플 수집 중…")
+                      : t("Available while running", "running일 때 표시")}
+                  </p>
+                )}
               </section>
               <section className="console-detail-group console-port-forward-group" aria-label="포트 포워딩">
                 <h3 className="console-detail-group-title">{t("Port Forwarding", "포트 포워딩")}</h3>
@@ -621,9 +639,9 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
                   <dl className="console-detail-fields console-port-forward-list mono">
                     {vm.portForwards!.map((pf, index) => (
                       <div key={`${pf.protocol}-${pf.hostPort}-${pf.guestPort}-${index}`} style={{ display: "contents" }}>
-                        <dt>{t(`Rule ${String(index + 1).padStart(2, "0")}`, `규칙 ${String(index + 1).padStart(2, "0")}`)}</dt>
+                        <dt>{String(index + 1).padStart(2, "0")}</dt>
                         <dd>
-                          VM :{pf.guestPort} <span style={{ color: "var(--accent)" }}>→</span> Host :{pf.hostPort} ({pf.protocol.toUpperCase()})
+                          :{pf.guestPort} <span className="console-pf-arrow">→</span> :{pf.hostPort}/{pf.protocol}
                         </dd>
                       </div>
                     ))}
@@ -632,39 +650,39 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
                   <p className="console-detail-empty">{t("No active port forwarding rules.", "설정된 포트 포워딩 규칙이 없습니다.")}</p>
                 )}
               </section>
-              <section className="console-detail-group" aria-label="스토리지">
+              <section className="console-detail-group console-storage-group" aria-label="스토리지">
                 <h3 className="console-detail-group-title">{t("Storage", "스토리지")}</h3>
                 <dl className="console-detail-fields mono">
                   <dt>storage</dt>
                   <dd>{vm.storageRoot || "default"}</dd>
                 </dl>
               </section>
-              {vm.state === "running" && (
-                <section
-                  className="console-detail-group console-detail-usage-group"
-                  aria-label={t("Resource usage", "리소스 관측")}
-                >
-                  <h3 className="console-detail-group-title">
-                    {t("Resource usage", "리소스 관측")}
-                  </h3>
-                  {(vm.usageHistory?.length ?? 0) > 0 ? (
-                    <UsageCharts
-                      history={vm.usageHistory ?? []}
-                      ramMib={vm.ram}
-                      size="default"
-                    />
-                  ) : (
-                    <p className="usage-charts-empty">
-                      {t("Collecting samples…", "샘플 수집 중…")}
-                    </p>
-                  )}
-                </section>
-              )}
             </div>
           ) : (
             <p className="console-detail-loading">{t("Loading…", "불러오는 중…")}</p>
           )}
         </aside>
+      )}
+
+      {!terminalOnly && (
+        <button
+          type="button"
+          className={`console-inspect-bar${prefs.inspectOpen ? " is-open" : ""}`}
+          aria-expanded={prefs.inspectOpen}
+          aria-controls="console-inspect-rail"
+          onClick={() => setPrefs((p) => ({ ...p, inspectOpen: !p.inspectOpen }))}
+          title={
+            prefs.inspectOpen
+              ? t("Hide inspect", "inspect 숨기기")
+              : t("Show inspect", "inspect 보기")
+          }
+        >
+          <span className="console-inspect-chevron" aria-hidden>
+            {prefs.inspectOpen ? "▾" : "▴"}
+          </span>
+          <span className="console-inspect-bar-label">{t("inspect", "inspect")}</span>
+          {vm ? <span className={`state-badge ${vm.state}`}>{vm.state}</span> : null}
+        </button>
       )}
     </div>
   );

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -933,15 +933,18 @@ table.vm-table {
 .detail-usage-panel .panel-title {
   margin-bottom: 0.65rem;
 }
-.console-detail-usage-group {
-  grid-column: 1 / -1;
-}
 .console-detail-usage-group .usage-charts {
   margin: 0;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  max-width: 12.5rem;
+  gap: 0.45rem;
 }
 .console-detail-usage-group .usage-spark {
-  max-width: none;
-  min-width: 10rem;
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: 12.5rem;
+  min-width: 0;
 }
 .vm-table .name { font-weight: 600; }
 .link-button {
@@ -1206,33 +1209,408 @@ table.image-table .image-package-url a:hover {
   font-size: 0.85rem;
 }
 
-/* Full-page serial console (`#/console/<id>`) — usually opened in a new
-   window from the VM list. Toolbar + xterm + bottom detail; "터미널만"
-   collapses chrome so only the surface remains. */
+/* Full-page serial console (`#/console/<id>`). Chrome matches the light
+   dashboard; the xterm well stays dark. Resource sparks stay in one
+   inspect column instead of stretching the full rail. */
 .console-page {
+  --tty-bg: var(--bg);
+  --tty-panel: var(--bg-panel);
+  --tty-line: var(--line);
+  --tty-ink: var(--ink);
+  --tty-dim: var(--shell);
+  --tty-ember: var(--ember);
+  --tty-ready: var(--ready);
+  --tty-warn: var(--amber);
+  --tty-bad: var(--error);
+  --tty-term: #171b22;
   position: fixed;
   inset: 0;
   display: flex;
   flex-direction: column;
-  background: var(--ink);
+  background: var(--tty-panel);
+  color: var(--tty-ink);
   z-index: 20;
   width: 100%;
   height: 100%;
   min-height: 100dvh;
 }
 
-.console-bar {
+.console-page .console-bar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 0.5rem 0.65rem;
-  padding: 0.55rem 0.75rem;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--line);
+  gap: 0.45rem 0.85rem;
+  padding: 0.4rem 0.85rem;
+  background: var(--tty-panel);
+  border-bottom: 1px solid var(--tty-line);
   font-family: var(--font-mono);
-  font-size: 0.78rem;
+  font-size: 0.75rem;
   flex: 0 0 auto;
 }
+.console-session {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.55rem;
+  flex: 1 1 12rem;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-display);
+  font-size: 0.82rem;
+  letter-spacing: 0.01em;
+}
+.console-session-caret {
+  color: var(--tty-ember);
+  font-size: 0.7rem;
+  line-height: 1;
+  transform: translateY(1px);
+}
+.console-session-name {
+  color: var(--tty-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.console-session-host,
+.console-session-addr {
+  color: var(--tty-dim);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+.console-session-addr { color: var(--tty-ink); }
+.console-page .console-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--tty-dim);
+  flex-shrink: 0;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.console-page .console-status-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 1px;
+  background: currentColor;
+}
+.console-page .console-status.connecting { color: var(--tty-warn); }
+.console-page .console-status.connecting .console-status-dot {
+  animation: console-pulse 1.1s ease-in-out infinite;
+}
+.console-page .console-status.connected { color: var(--tty-ready); }
+.console-page .console-status.error { color: var(--tty-bad); }
+
+@keyframes console-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .console-page .console-status.connecting .console-status-dot {
+    animation: none;
+  }
+}
+
+.console-bar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+  margin-left: auto;
+}
+.console-page .console-bar-btn {
+  border: 0;
+  background: transparent;
+  color: var(--tty-dim);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.45rem;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.console-page .console-bar-btn:hover {
+  color: var(--tty-ink);
+  background: var(--tty-bg);
+}
+.console-page .console-bar-btn.is-active {
+  color: var(--tty-ember);
+  background: rgba(196, 62, 18, 0.14);
+}
+
+.console-page .console-settings { position: relative; flex-shrink: 0; }
+.console-page .console-settings-pop {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  right: 0;
+  z-index: 2;
+  min-width: 12rem;
+  padding: 0.7rem 0.8rem;
+  background: var(--tty-panel);
+  border: 1px solid var(--tty-line);
+  border-radius: 2px;
+  box-shadow: 0 0.5rem 1.25rem rgba(23, 27, 34, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+.console-page .console-settings-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--tty-dim);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.console-page .console-settings-row select {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--tty-ink);
+  background: var(--tty-bg);
+  border: 1px solid var(--tty-line);
+  border-radius: 2px;
+  padding: 0.3rem 0.4rem;
+}
+
+.console-page .console-close {
+  border: 0;
+  background: none;
+  color: var(--tty-dim);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.45rem;
+  flex-shrink: 0;
+}
+.console-page .console-close:hover { color: var(--tty-bad); }
+
+/* `flex: 1; min-height: 0` so the surface absorbs leftover height after the
+   detail panel and FitAddon measures the real box on chrome show/hide.
+   A non-zero min-height keeps the first fit() from collapsing to 0 rows. */
+.console-page .console-surface {
+  flex: 1 1 auto;
+  min-height: 12rem;
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  overflow: hidden;
+  position: relative;
+  background: var(--tty-term);
+}
+.console-page.is-terminal-only .console-surface {
+  padding: 0.5rem 0.65rem;
+  min-height: 0;
+}
+.console-page .console-surface .xterm {
+  height: 100% !important;
+  width: 100% !important;
+  padding: 0;
+}
+.console-page .console-surface .xterm-viewport {
+  overflow-y: auto !important;
+}
+.console-page .console-surface .xterm-screen {
+  height: 100%;
+}
+.console-page .console-surface .xterm .xterm-helper-textarea {
+  z-index: 10 !important;
+}
+.console-page .console-surface .xterm .composition-view {
+  background: var(--tty-term);
+  color: #e8ecf1;
+  font-family: var(--font-mono);
+  z-index: 11;
+}
+
+.console-page .console-detail {
+  flex: 0 0 auto;
+  background: var(--tty-panel);
+  border-top: 1px solid var(--tty-line);
+  color: var(--tty-ink);
+  padding: 0.55rem 0.85rem 0.55rem;
+}
+.console-inspect-bar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  margin: 0;
+  padding: 0.38rem 0.85rem;
+  border: 0;
+  border-top: 1px solid var(--tty-line);
+  background: var(--tty-panel);
+  color: var(--tty-dim);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: lowercase;
+  cursor: pointer;
+  text-align: left;
+}
+.console-inspect-bar:hover,
+.console-inspect-bar:focus-visible {
+  color: var(--tty-ink);
+  background: var(--tty-bg);
+}
+.console-inspect-bar.is-open {
+  border-top-color: var(--tty-line);
+}
+.console-inspect-chevron {
+  color: var(--tty-ember);
+  font-size: 0.75rem;
+  line-height: 1;
+  width: 0.9rem;
+}
+.console-inspect-bar-label {
+  flex: 1 1 auto;
+  letter-spacing: 0.16em;
+}
+.console-inspect-bar .state-badge {
+  margin-left: auto;
+}
+.console-page .state-badge {
+  color: var(--tty-dim);
+}
+.console-page .state-badge.running { color: var(--tty-ready); }
+.console-page .state-badge.error { color: var(--tty-bad); }
+.console-page .state-badge.starting,
+.console-page .state-badge.stopping { color: var(--tty-warn); }
+.console-page .console-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  align-items: stretch;
+}
+@media (max-width: 960px) {
+  .console-page .console-detail-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@media (max-width: 520px) {
+  .console-page .console-detail-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+.console-page .console-detail-group {
+  min-width: 0;
+  min-height: 7.25rem;
+  padding: 0.5rem 0.65rem 0.55rem;
+  border: 1px solid var(--tty-line);
+  border-radius: 3px;
+  background: var(--tty-bg);
+}
+.console-page .console-detail-group-title {
+  margin: 0 0 0.4rem;
+  font-family: var(--font-display);
+  font-size: 0.62rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
+  text-transform: lowercase;
+  color: var(--tty-ember);
+}
+.console-page .console-detail-fields {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.18rem 0.7rem;
+  margin: 0;
+  font-size: 0.74rem;
+  align-items: baseline;
+}
+.console-page .console-detail-fields dt {
+  color: var(--tty-dim);
+  text-transform: lowercase;
+  letter-spacing: 0.04em;
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+.console-page .console-detail-fields dd {
+  margin: 0;
+  color: var(--tty-ink);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.console-page .console-pf-arrow {
+  color: var(--tty-ember);
+}
+.console-page .console-port-forward-group,
+.console-page .console-storage-group {
+  grid-column: span 2;
+}
+.console-page .console-port-forward-list {
+  grid-auto-rows: minmax(1.4rem, auto);
+  row-gap: 0.3rem;
+  max-height: 4.8rem;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  scrollbar-gutter: stable;
+}
+@media (max-width: 960px) {
+  .console-page .console-port-forward-group,
+  .console-page .console-storage-group {
+    grid-column: span 1;
+  }
+}
+.console-page .console-detail .mono {
+  font-family: var(--font-mono);
+}
+.console-page .console-detail-loading,
+.console-page .console-detail-error,
+.console-page .console-detail-empty {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--tty-dim);
+}
+.console-page .console-detail-error { color: var(--tty-bad); }
+.console-page .console-detail-usage-group {
+  grid-column: span 1;
+}
+.console-page .console-detail-usage-group .usage-charts {
+  max-width: none;
+  width: 100%;
+}
+.console-page .console-detail-usage-group .usage-spark {
+  max-width: none;
+  width: 100%;
+}
+.console-page .usage-spark-unit { color: var(--tty-ink); }
+.console-page .usage-spark-svg {
+  background: var(--tty-panel);
+  border-color: var(--tty-line);
+}
+
+.console-page .console-exit-only {
+  position: fixed;
+  top: 0.55rem;
+  right: 0.65rem;
+  z-index: 30;
+  border: 1px solid var(--tty-line);
+  border-radius: 2px;
+  background: var(--tty-panel);
+  color: var(--tty-ink);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  box-shadow: none;
+  opacity: 0.7;
+  transition: opacity 0.15s ease;
+}
+.console-page .console-exit-only:hover,
+.console-page .console-exit-only:focus-visible {
+  opacity: 1;
+  color: var(--tty-ember);
+}
+
+/* Shared by the VM detail overlay and Images export buttons (light chrome). */
 .console-title {
   flex: 1 1 auto;
   min-width: 8rem;
@@ -1242,31 +1620,6 @@ table.image-table .image-package-url a:hover {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.console-status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  color: var(--dim);
-  flex-shrink: 0;
-}
-.console-status-dot {
-  width: 0.45rem;
-  height: 0.45rem;
-  border-radius: 50%;
-  background: currentColor;
-}
-.console-status.connecting { color: var(--amber); }
-.console-status.connecting .console-status-dot {
-  animation: console-pulse 1.1s ease-in-out infinite;
-}
-.console-status.connected { color: var(--ready); }
-.console-status.error { color: var(--error); }
-
-@keyframes console-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
-}
-
 .console-bar-btn {
   border: 1px solid var(--line);
   background: var(--bg);
@@ -1285,42 +1638,6 @@ table.image-table .image-package-url a:hover {
   color: var(--ember);
   background: rgba(196, 62, 18, 0.08);
 }
-
-.console-settings { position: relative; flex-shrink: 0; }
-.console-settings-pop {
-  position: absolute;
-  top: calc(100% + 0.35rem);
-  right: 0;
-  z-index: 2;
-  min-width: 12rem;
-  padding: 0.65rem 0.75rem;
-  background: var(--bg-panel);
-  border: 1px solid var(--line);
-  border-radius: 3px;
-  box-shadow: 0 0.5rem 1.25rem rgba(23, 27, 34, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-}
-.console-settings-row {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  color: var(--shell);
-  letter-spacing: 0.04em;
-}
-.console-settings-row select {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--ink);
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: 3px;
-  padding: 0.3rem 0.4rem;
-}
-
 .console-close {
   border: 0;
   background: none;
@@ -1331,176 +1648,6 @@ table.image-table .image-package-url a:hover {
   flex-shrink: 0;
 }
 .console-close:hover { color: var(--error); }
-
-/* `flex: 1; min-height: 0` so the surface absorbs leftover height after the
-   detail panel and FitAddon measures the real box on chrome show/hide.
-   A non-zero min-height keeps the first fit() from collapsing to 0 rows. */
-.console-surface {
-  flex: 1 1 auto;
-  min-height: 12rem;
-  width: 100%;
-  padding: 0.5rem;
-  overflow: hidden;
-  position: relative;
-  background: #171b22;
-}
-.console-page.is-terminal-only .console-surface {
-  padding: 0;
-  min-height: 0;
-}
-.console-surface .xterm {
-  height: 100% !important;
-  width: 100% !important;
-  padding: 0;
-}
-.console-surface .xterm-viewport {
-  overflow-y: auto !important;
-}
-.console-surface .xterm-screen {
-  height: 100%;
-}
-/* IME candidate windows follow the helper textarea. Keep it above the
-   canvas and let xterm position it on the cursor (do not pin left:-9999). */
-.console-surface .xterm .xterm-helper-textarea {
-  z-index: 10 !important;
-}
-.console-surface .xterm .composition-view {
-  background: #171b22;
-  color: #e8ecf1;
-  font-family: var(--font-mono);
-  z-index: 11;
-}
-
-/* Bottom VM metadata — field groups; Resource usage spans full width when running. */
-.console-detail {
-  flex: 0 0 auto;
-  background: var(--bg-panel);
-  border-top: 1px solid var(--line);
-  color: var(--ink);
-  padding: 0.55rem 0.75rem 0.7rem;
-}
-.console-detail-head {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-  margin-bottom: 0.45rem;
-}
-.console-detail-title {
-  margin: 0;
-  flex: 1 1 auto;
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--shell);
-}
-.console-detail-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.65rem 1rem;
-  align-items: start;
-}
-@media (max-width: 960px) {
-  .console-detail-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (max-width: 520px) {
-  .console-detail-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-.console-detail-group {
-  min-width: 0;
-  padding: 0.4rem 0.55rem 0.5rem;
-  border: 1px solid var(--line);
-  border-radius: 3px;
-  background: var(--bg);
-}
-.console-detail-group-title {
-  margin: 0 0 0.35rem;
-  font-family: var(--font-mono);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--shell);
-}
-.console-detail-fields {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0.2rem 0.65rem;
-  margin: 0;
-  font-size: 0.74rem;
-  align-items: baseline;
-}
-.console-detail-fields dt {
-  color: var(--shell);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-size: 0.65rem;
-  white-space: nowrap;
-}
-.console-detail-fields dd {
-  margin: 0;
-  color: var(--ink);
-  min-width: 0;
-  overflow-wrap: anywhere;
-  word-break: break-word;
-}
-.console-port-forward-group {
-  grid-column: span 2;
-}
-.console-port-forward-list {
-  grid-auto-rows: minmax(1.4rem, auto);
-  row-gap: 0.3rem;
-  max-height: 4.8rem;
-  overflow-y: auto;
-  padding-right: 0.35rem;
-  scrollbar-gutter: stable;
-}
-@media (max-width: 520px) {
-  .console-port-forward-group {
-    grid-column: span 1;
-  }
-}
-.console-detail .mono {
-  font-family: var(--font-mono);
-}
-.console-detail-loading,
-.console-detail-error,
-.console-detail-empty {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--dim);
-}
-.console-detail-error { color: var(--error); }
-
-/* Recover chrome after "터미널만" without relying solely on Esc. */
-.console-exit-only {
-  position: fixed;
-  top: 0.6rem;
-  right: 0.6rem;
-  z-index: 30;
-  border: 1px solid var(--line);
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.92);
-  color: var(--ink);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  padding: 0.3rem 0.55rem;
-  cursor: pointer;
-  box-shadow: 0 0.25rem 0.75rem rgba(23, 27, 34, 0.2);
-  opacity: 0.55;
-  transition: opacity 0.15s ease;
-}
-.console-exit-only:hover,
-.console-exit-only:focus-visible {
-  opacity: 1;
-}
 
 /* VM detail still uses the shared overlay chrome (read-only log, not xterm). */
 .console-overlay {
@@ -1524,6 +1671,50 @@ table.image-table .image-package-url a:hover {
   overflow: hidden;
   box-shadow: 0 1.5rem 3rem rgba(23, 27, 34, 0.35);
 }
+.console-panel .console-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.65rem;
+  padding: 0.55rem 0.75rem;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  flex: 0 0 auto;
+}
+.console-panel .console-title {
+  flex: 1 1 auto;
+  min-width: 8rem;
+  color: var(--ink);
+  letter-spacing: 0.02em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.console-panel .console-bar-btn {
+  border: 1px solid var(--line);
+  background: var(--bg);
+  color: var(--shell);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.console-panel .console-bar-btn:hover { border-color: var(--shell); color: var(--ink); }
+.console-panel .console-close {
+  border: 0;
+  background: none;
+  color: var(--shell);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  padding: 0.15rem 0.4rem;
+  flex-shrink: 0;
+}
+.console-panel .console-close:hover { color: var(--error); }
 
 .detail-body {
   padding: 1.25rem;

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -58,6 +58,9 @@ npm run dev --prefix firecrab-frontend
 6. Start
 7. Open Terminal after `running`
 
+- Terminal chrome is light; the serial surface stays dark
+- Inspect rail: four equal cards (general, specs, network, usage) then ports + storage; a bottom white bar toggles it
+- Terminal Network group: ipv4, ipv6 (`—` when the network is IPv4-only), mac, egress, network id
 - List poll: 3 seconds
 - Detail: start progress and logs
 - While `running`, list / detail / terminal show guest OS CPU percent and memory used (MemTotal − MemAvailable) when the Firecrab Metrics Agent is in the guest (systemd on Ubuntu/Rocky, OpenRC on Alpine)


### PR DESCRIPTION
Closes #183

## New Features

- Light session strip on the serial console (status, name, hostname, IPv4)
- Inspect rail as four equal cards (general, specs, network, usage) plus ports and storage
- Bottom white bar toggles inspect; preference stored in `firecrab.console.prefs`

## Bug Fixes

- Resource sparks no longer stretch across the full inspect rail
- Console network card shows ipv6 (`—` on IPv4-only MicroNetworks)

## Docs

- Dashboard terminal bullets for chrome, inspect grid, and the bottom toggle