### PR TITLE
fix: chore: bump the pinned Rust toolchain to 1.97.1

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,7 +1,0 @@
-fix: chore: bump the pinned Rust toolchain to 1.97.1
-
-- rust-toolchain.toml: bump pinned Rust toolchain
-
-Fixes #131
-
-Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,7 @@
+fix: chore: bump the pinned Rust toolchain to 1.97.1
+
+- rust-toolchain.toml: bump pinned Rust toolchain
+
+Fixes #131
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"
 profile = "minimal"
 components = ["clippy", "rustfmt", "llvm-tools"]
 


### PR DESCRIPTION
## Summary

chore: bump the pinned Rust toolchain to 1.97.1

## Changes

- rust-toolchain.toml: bump pinned Rust toolchain

Fixes #131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust toolchain to version 1.97.1.
  * Added documentation recording the toolchain update and related issue reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->