### PR TITLE
chore(cli): clear the 8 clippy warnings in firecrab-cli

### DIFF
--- a/firecrab-cli/src/api_client.rs
+++ b/firecrab-cli/src/api_client.rs
@@ -32,10 +32,10 @@ pub fn resolve_api_base(flag: Option<&str>) -> String {
     if let Some(f) = flag {
         return f.trim_end_matches('/').to_owned();
     }
-    if let Ok(env_val) = std::env::var("FIRECRAB_API") {
-        if !env_val.is_empty() {
-            return env_val.trim_end_matches('/').to_owned();
-        }
+    if let Ok(env_val) = std::env::var("FIRECRAB_API")
+        && !env_val.is_empty()
+    {
+        return env_val.trim_end_matches('/').to_owned();
     }
     DEFAULT_API_BASE.to_owned()
 }

--- a/firecrab-cli/src/doctor/checks.rs
+++ b/firecrab-cli/src/doctor/checks.rs
@@ -91,10 +91,10 @@ fn find_databases(env: &DoctorEnv) -> Vec<PathBuf> {
         Path::new(&env.datadir).join("data/firecrab.db"),
         Path::new(&env.datadir).join("firecrab.db"),
     ];
-    if let Some(image_root) = &env.image_root {
-        if let Some(parent) = Path::new(image_root).parent() {
-            candidates.push(abs_dir(parent).join("data/firecrab.db"));
-        }
+    if let Some(image_root) = &env.image_root
+        && let Some(parent) = Path::new(image_root).parent()
+    {
+        candidates.push(abs_dir(parent).join("data/firecrab.db"));
     }
 
     let mut seen = std::collections::HashSet::new();
@@ -308,21 +308,18 @@ pub fn check_dnsmasq(env: &DoctorEnv, runner: &dyn CommandRunner) -> Vec<CheckRe
     let mut alive = false;
     if let Ok(pid_raw) = fs::read_to_string(&env.dnsmasq_pid) {
         let pid = pid_raw.trim();
-        if !pid.is_empty() && Path::new(&format!("/proc/{pid}")).is_dir() {
-            if let Ok(cmdline) = fs::read(format!("/proc/{pid}/cmdline")) {
-                if String::from_utf8_lossy(&cmdline)
-                    .replace('\0', " ")
-                    .contains("dnsmasq")
-                {
-                    alive = true;
-                }
-            }
+        if !pid.is_empty()
+            && Path::new(&format!("/proc/{pid}")).is_dir()
+            && let Ok(cmdline) = fs::read(format!("/proc/{pid}/cmdline"))
+            && String::from_utf8_lossy(&cmdline)
+                .replace('\0', " ")
+                .contains("dnsmasq")
+        {
+            alive = true;
         }
     }
-    if !alive {
-        if let Ok(out) = runner.run("pgrep", &["-af", "dnsmasq.*firecrab"]) {
-            alive = out.status.success();
-        }
+    if !alive && let Ok(out) = runner.run("pgrep", &["-af", "dnsmasq.*firecrab"]) {
+        alive = out.status.success();
     }
 
     let conf_ifaces: Vec<String> = fs::read_to_string(&env.dnsmasq_conf)
@@ -532,15 +529,15 @@ pub fn check_ufw(runner: &dyn CommandRunner) -> Vec<CheckResult> {
                 Some(&format!("sudo ufw allow in on {br} to any port 53")),
             ));
         }
-        if let Some(up) = &uplink {
-            if !ufw_has_route_allow(br, up, &status) {
-                any_fail = true;
-                results.push(CheckResult::fail(
-                    format!("ufw: no route allow {br} → {up}"),
-                    Some("guest outbound new connections time out (DEFAULT_FORWARD_POLICY=DROP)"),
-                    Some(&format!("sudo ufw route allow in on {br} out on {up}")),
-                ));
-            }
+        if let Some(up) = &uplink
+            && !ufw_has_route_allow(br, up, &status)
+        {
+            any_fail = true;
+            results.push(CheckResult::fail(
+                format!("ufw: no route allow {br} → {up}"),
+                Some("guest outbound new connections time out (DEFAULT_FORWARD_POLICY=DROP)"),
+                Some(&format!("sudo ufw route allow in on {br} out on {up}")),
+            ));
         }
     }
     if uplink.is_none() {
@@ -921,14 +918,14 @@ pub fn check_image_install_tools(env: &DoctorEnv, runner: &dyn CommandRunner) ->
             Some("install packages: tar zstd  (then retry dashboard image install)"),
         )];
     }
-    if let Some(base_url) = &env.image_base_url {
-        if matches!(base_url.as_str(), "none" | "NONE" | "-") {
-            return vec![CheckResult::skip(
-                format!("image-install: remote disabled (FIRECRAB_IMAGE_BASE_URL={base_url})"),
-                Some("dashboard will not download packages; seed images/ on the host"),
-                Some("see public-docs/installation.md (M2Image)"),
-            )];
-        }
+    if let Some(base_url) = &env.image_base_url
+        && matches!(base_url.as_str(), "none" | "NONE" | "-")
+    {
+        return vec![CheckResult::skip(
+            format!("image-install: remote disabled (FIRECRAB_IMAGE_BASE_URL={base_url})"),
+            Some("dashboard will not download packages; seed images/ on the host"),
+            Some("see public-docs/installation.md (M2Image)"),
+        )];
     }
     vec![CheckResult::pass("image_install_tools")]
 }

--- a/firecrab-cli/src/shell.rs
+++ b/firecrab-cli/src/shell.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io;
 use std::process::Output;
 
@@ -24,7 +23,7 @@ impl CommandRunner for RealCommandRunner {
 #[cfg(test)]
 #[derive(Default)]
 pub(crate) struct FakeCommandRunner {
-    responses: HashMap<String, (i32, String, String)>,
+    responses: std::collections::HashMap<String, (i32, String, String)>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Collapse the 7 nested if sites flagged by clippy::collapsible_if into let-chain conditions (api_client.rs:35, doctor/checks.rs:94, 311, 312, 322, 535, 924). Short-circuit order is unchanged.

The unused-import warning on shell.rs was subtler than a plain delete: the HashMap import is only referenced by the test-only FakeCommandRunner, so it is unused in the bin target but required when building tests. Fully qualify std::collections::HashMap at that one use site so both targets stay clean without a cfg-gated import.

Gates:
- cargo clippy -p firecrab-cli --all-targets: 0 warnings
- cargo fmt --all -- --check: clean
- cargo test -p firecrab-cli --locked: 132 passed

Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal command-line diagnostics and configuration handling without changing observable behavior.
  * Preserved existing checks for database discovery, DNSMasq status, firewall routes, and image installation.
* **Chores**
  * Removed an unused internal import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->