### PR TITLE
chore(net-helper): clear the 2 clippy warnings in firecrab-net-helper

### DIFF
--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -116,7 +116,7 @@ struct FirewallState {
     /// currently installed. Keeping the full value lets an identical
     /// re-apply be a true no-op, while a changed lease, egress setting, or
     /// uplink can be replaced atomically. The uplink has to be part of this
-    /// key too: `render_vm_policy` bakes it into the DNAT rules' `iifname`
+    /// key too: `render_vm_policy_for_network` bakes it into the DNAT rules' `iifname`
     /// match, so an uplink change with an otherwise-identical `VmPolicy`
     /// still needs a real reapply, not a no-op.
     applied_vms: std::collections::HashMap<Uuid, (String, VmPolicy)>,
@@ -365,7 +365,7 @@ fn offline_subnet_cidrs(micro_networks: &[MicroNetworkSpec]) -> Vec<String> {
 /// lives.
 ///
 /// Per-VM rules live in separate named chains + verdict-map elements (see
-/// [`render_vm_policy`]) so replacing one VM's policy never disturbs another.
+/// [`render_vm_policy_for_network`]) so replacing one VM's policy never disturbs another.
 /// The complete desired VM snapshot is appended to this recreation in the
 /// same transaction by [`render_reconciled_ruleset`].
 fn render_apply_ruleset(
@@ -462,15 +462,6 @@ fn render_apply_ruleset(
          \t}}\n\
          }}\n"
     ))
-}
-
-/// Renders one VM's isolation rules: L2 anti-spoofing tied to the lease, plus
-/// L3 egress/ingress verdicts. Every per-VM object is named after the vm_id.
-/// An identical policy is skipped by [`apply_vm_policy`]; a changed one is
-/// rendered through [`render_vm_policy_replacement`] so it cannot disturb
-/// any other VM's chains or map elements.
-fn render_vm_policy(uplink: &str, policy: &VmPolicy) -> String {
-    render_vm_policy_for_network(uplink, policy, true)
 }
 
 fn render_vm_policy_for_network(uplink: &str, policy: &VmPolicy, internet_enabled: bool) -> String {
@@ -578,7 +569,7 @@ fn render_vm_policy_replacement(
     )
 }
 
-/// Removes every object [`render_vm_policy`] created for `vm_id`, and nothing
+/// Removes every object [`render_vm_policy_for_network`] created for `vm_id`, and nothing
 /// else. Each map element is deleted before the chain it jumps to, so nft
 /// never rejects a still-referenced chain.
 fn render_vm_policy_removal(vm_id: Uuid, ipv4: Ipv4Addr) -> String {
@@ -894,7 +885,7 @@ mod tests {
     #[test]
     fn global_ruleset_dispatches_bridge_traffic_from_accept_policy_base_chains() {
         let network = sample_network(0x1234, "172.31.0.1", 24);
-        let ruleset = render_apply_ruleset("eth0", &[network.clone()]).unwrap();
+        let ruleset = render_apply_ruleset("eth0", std::slice::from_ref(&network)).unwrap();
         assert!(ruleset.contains("policy accept"));
         let bridge = network.bridge_name();
         assert!(ruleset.contains(&format!("iifname \"{bridge}\" jump firecrab_egress")));
@@ -979,7 +970,7 @@ mod tests {
     #[test]
     fn vm_policy_pins_l2_source_to_the_lease_and_blocks_ipv6_vlan() {
         let policy = sample_policy(EgressPolicy::Internet, false);
-        let ruleset = render_vm_policy("eth0", &policy);
+        let ruleset = render_vm_policy_for_network("eth0", &policy, true);
         let mac = "02:fc:aa:bb:cc:dd";
         // Spoofed source MAC / ARP sender / IPv4 source are all dropped.
         assert!(ruleset.contains(&format!("ether saddr != {mac} drop")));
@@ -992,7 +983,11 @@ mod tests {
 
     #[test]
     fn vm_policy_allows_only_the_two_dhcp_exceptions() {
-        let ruleset = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, false));
+        let ruleset = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, false),
+            true,
+        );
         // DHCP discover/request from an unconfigured client (src 0.0.0.0).
         assert!(ruleset.contains(
             "ether saddr 02:fc:aa:bb:cc:dd ip saddr 0.0.0.0 udp sport 68 udp dport 67 accept"
@@ -1005,11 +1000,19 @@ mod tests {
 
     #[test]
     fn internet_egress_accepts_but_isolated_falls_through_to_default_drop() {
-        let internet = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, false));
+        let internet = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, false),
+            true,
+        );
         let tag = Uuid::from_u128(0x1234).simple();
         assert!(internet.contains(&format!("add rule inet firecrab vm_{tag}_eg accept")));
 
-        let isolated = render_vm_policy("eth0", &sample_policy(EgressPolicy::Isolated, false));
+        let isolated = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Isolated, false),
+            true,
+        );
         // Isolated leaves the egress chain empty (no accept rule for it).
         assert!(!isolated.contains(&format!("add rule inet firecrab vm_{tag}_eg accept")));
         // But the chain and its dispatch element still exist.
@@ -1020,12 +1023,20 @@ mod tests {
     #[test]
     fn host_ssh_is_allowed_only_when_requested() {
         let tag = Uuid::from_u128(0x1234).simple();
-        let with_ssh = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, true));
+        let with_ssh = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, true),
+            true,
+        );
         assert!(with_ssh.contains(&format!(
             "add rule inet firecrab vm_{tag}_in tcp dport 22 ct state new,established accept"
         )));
 
-        let without = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, false));
+        let without = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, false),
+            true,
+        );
         assert!(!without.contains("tcp dport 22"));
     }
 
@@ -1045,7 +1056,7 @@ mod tests {
                 protocol: "udp".to_owned(),
             },
         ];
-        let ruleset = render_vm_policy("eth0", &policy);
+        let ruleset = render_vm_policy_for_network("eth0", &policy, true);
         assert!(ruleset.contains(&format!(
             "add chain inet firecrab vm_{tag}_dnat {{ type nat hook prerouting priority dstnat; policy accept; }}"
         )));
@@ -1087,7 +1098,7 @@ mod tests {
             guest_port: 80,
             protocol: "tcp".to_owned(),
         }];
-        let ruleset = render_vm_policy("eth0", &policy);
+        let ruleset = render_vm_policy_for_network("eth0", &policy, true);
         assert!(
             ruleset.contains("vm_")
                 && ruleset.contains("_dnat_out fib daddr type local tcp dport 8080")
@@ -1155,7 +1166,7 @@ mod tests {
             guest_port: 80,
             protocol: "tcp".to_owned(),
         }];
-        let ruleset = render_vm_policy("wan0", &policy);
+        let ruleset = render_vm_policy_for_network("wan0", &policy, true);
         // Prerouting DNAT only matches traffic arriving on the uplink, so
         // routed traffic between VMs (or any other host-forwarded traffic)
         // hitting the same destination port cannot be hijacked to this VM.
@@ -1166,7 +1177,11 @@ mod tests {
 
     #[test]
     fn vm_policy_objects_are_namespaced_so_replacing_one_vm_cannot_touch_another() {
-        let a = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, false));
+        let a = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, false),
+            true,
+        );
         let tag_a = Uuid::from_u128(0x1234).simple();
         let tag_b = Uuid::from_u128(0x9999).simple();
         // A's rendered ruleset only ever names A's objects.
@@ -1369,7 +1384,7 @@ mod tests {
 
     #[tokio::test]
     async fn applying_the_same_policy_under_a_different_uplink_is_not_a_no_op() {
-        // `render_vm_policy` bakes the uplink into the DNAT rules' `iifname`
+        // `render_vm_policy_for_network` bakes the uplink into the DNAT rules' `iifname`
         // match, so a changed uplink with an otherwise byte-identical
         // `VmPolicy` must still be treated as a real change, not skipped.
         let actor = FirewallActor::new();

--- a/firecrab-net-helper/src/main.rs
+++ b/firecrab-net-helper/src/main.rs
@@ -451,7 +451,7 @@ fn validate_uplinks(micro_networks: &[MicroNetworkSpec]) -> Result<(), HelperFai
 /// `validate_micro_networks` and the `egress_policy` allowlist lookup) and
 /// does not assume the caller's own check already caught a malformed value.
 /// In particular, an unrecognized protocol must be rejected outright:
-/// `firewall::render_vm_policy` treats anything that isn't `"udp"` as TCP,
+/// `firewall::render_vm_policy_for_network` treats anything that isn't `"udp"` as TCP,
 /// so a bad value silently reaching it would render a DNAT rule the caller
 /// never asked for instead of failing loudly.
 fn validate_port_forwards(


### PR DESCRIPTION
render_vm_policy was production dead code: every caller lived under #[cfg(test)] while the apply path goes through
render_vm_policy_for_network directly. Delete the wrapper and switch its 10 test call sites to render_vm_policy_for_network(uplink, policy, true), per the delete-and-rename option in #192. Update the doc cross-references that named the wrapper (firewall.rs x4, main.rs x1) to the surviving name.

Replace &[network.clone()] with std::slice::from_ref(&network) in the global_ruleset test, avoiding the throwaway clone clippy flags as cloned_ref_to_slice_refs.

Gates:
- cargo clippy -p firecrab-net-helper --all-targets: 0 warnings
- cargo fmt --all -- --check: clean
- cargo test -p firecrab-net-helper --locked: 119 passed

Closes #192