### PR TITLE
test(vm): remove microboot startup timing flake

### DIFF
--- a/firecrab-api/src/handlers/vms.rs
+++ b/firecrab-api/src/handlers/vms.rs
@@ -2975,16 +2975,16 @@ while True:
         vm.template = crate::microboot::MICROBOOT_ALIAS.to_owned();
         seed_vm(&state, &vm);
 
-        let Json(started) = tokio::time::timeout(
-            Duration::from_secs(2),
-            start_vm(
-                State(state.clone()),
-                Extension(RequestId(Uuid::new_v4())),
-                axum::extract::Path(vm.id.to_string()),
-            ),
+        // `network_ready_timeout` is already 300 ms in this fixture, so a
+        // regression still fails quickly. Do not cap the whole start path:
+        // rootfs specialization under coverage instrumentation can exceed a
+        // wall-clock deadline even when the MicroBoot wait is correctly skipped.
+        let Json(started) = start_vm(
+            State(state.clone()),
+            Extension(RequestId(Uuid::new_v4())),
+            axum::extract::Path(vm.id.to_string()),
         )
         .await
-        .expect("start_vm should not hang waiting on a network-ready sentinel that never arrives")
         .unwrap();
 
         assert_eq!(started.state, VmState::Running);


### PR DESCRIPTION
## Bug Fixes

- Remove the coverage-sensitive two-second timeout from the MicroBoot startup test
- Preserve regression detection through the fixture's 300 ms network-ready timeout

#### Tests

- Check Rust formatting across the workspace:

```sh
cargo fmt --all -- --check
```

- Run Clippy against all workspace crates and targets:

```sh
cargo clippy --workspace --all-targets
```

- Run the focused MicroBoot regression tests:

```sh
cargo test -p firecrab-api --locked -- microboot
```

- Run the complete `firecrab-api` test suite:

```sh
cargo test -p firecrab-api --locked
```

- Run workspace tests with coverage instrumentation and generate the LCOV report. The known host-state-dependent teardown test is skipped according to the repository's local testing guidance:

```sh
cargo llvm-cov --workspace --locked --lcov \
  --output-path /tmp/firecrab-lcov.info \
  -- --quiet --skip teardown_all_is_a_no_op
```

- Build private workspace documentation while treating rustdoc warnings as errors:

```sh
RUSTDOCFLAGS="-D warnings" \
  cargo doc --workspace --no-deps --document-private-items
```

- Measure workspace rustdoc coverage:

```sh
RUSTC_BOOTSTRAP=1 \
RUSTDOCFLAGS="-Z unstable-options --show-coverage" \
  cargo doc --workspace --no-deps --document-private-items
```

- Validate links in the public documentation:

```sh
python3 scripts/check-doc-links.py
```

Results:

- 681/681 `firecrab-api` tests passed
- 14/14 MicroBoot-focused tests passed
- Patch coverage: 100% (8/8)
- Rustdoc coverage: 77.3% (2411/3119)