### PR TITLE
fix(console): restore mobile scroll and clipboard

### DIFF
--- a/firecrab-api/src/oci/cache_tests.rs
+++ b/firecrab-api/src/oci/cache_tests.rs
@@ -3,7 +3,7 @@ use core::assert_matches;
 
 use std::collections::HashMap;
 use std::convert::Infallible;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -13,6 +13,7 @@ use axum::extract::{Path as AxumPath, State};
 use axum::http::{Response, StatusCode, header::CONTENT_TYPE};
 use axum::routing::get;
 use tempfile::tempdir;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
 const REPOSITORY: &str = "team/app";
@@ -109,11 +110,46 @@ fn ordinary_manifest(config: &FixtureBlob, layers: &[FixtureBlob]) -> Vec<u8> {
     )
 }
 
+/// Sticky gate so a fixture blob cannot finish until the test releases it.
+/// `Notify` alone drops a signal that arrives before `notified().await`.
+struct BlobHold {
+    released: AtomicBool,
+    notify: Notify,
+}
+
+impl BlobHold {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            released: AtomicBool::new(false),
+            notify: Notify::new(),
+        })
+    }
+
+    async fn wait(&self) {
+        loop {
+            if self.released.load(Ordering::SeqCst) {
+                return;
+            }
+            let notified = self.notify.notified();
+            if self.released.load(Ordering::SeqCst) {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    fn release(&self) {
+        self.released.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+}
+
 #[derive(Clone)]
 struct BlobReply {
     bytes: Arc<Vec<u8>>,
     digest_header: Option<String>,
     delay: Duration,
+    hold: Option<Arc<BlobHold>>,
 }
 
 impl BlobReply {
@@ -122,6 +158,7 @@ impl BlobReply {
             bytes: Arc::new(descriptor.bytes.clone()),
             digest_header: Some(descriptor.digest.to_string()),
             delay: Duration::ZERO,
+            hold: None,
         }
     }
 
@@ -130,16 +167,21 @@ impl BlobReply {
             bytes: Arc::new(bytes.into()),
             digest_header: Some(digest.to_string()),
             delay: Duration::ZERO,
+            hold: None,
         }
     }
 
-    fn delayed(mut self) -> Self {
-        self.delay = Duration::from_millis(40);
-        self
+    fn delayed(self) -> Self {
+        self.with_delay(Duration::from_millis(40))
     }
 
     fn with_delay(mut self, delay: Duration) -> Self {
         self.delay = delay;
+        self
+    }
+
+    fn with_hold(mut self, hold: Arc<BlobHold>) -> Self {
+        self.hold = Some(hold);
         self
     }
 }
@@ -294,6 +336,9 @@ async fn serve_blob(
         .max_active_blob_requests
         .fetch_max(active, Ordering::SeqCst);
     let _active_request = ActiveBlobRequest(Arc::clone(&state.active_blob_requests));
+    if let Some(hold) = &reply.hold {
+        hold.wait().await;
+    }
     if !reply.delay.is_zero() {
         tokio::time::sleep(reply.delay).await;
     }
@@ -634,41 +679,59 @@ async fn parallel_downloads_are_bounded_and_return_manifest_order() {
     let first = FixtureBlob::new(LAYER_MEDIA_TYPE, b"slow first layer".to_vec());
     let second = FixtureBlob::new(LAYER_MEDIA_TYPE, b"quick second layer".to_vec());
     let third = FixtureBlob::new(LAYER_MEDIA_TYPE, b"quickest third layer".to_vec());
+    let hold_first = BlobHold::new();
     let registry = TestRegistry::start(
         ordinary_manifest(&config, &[first.clone(), second.clone(), third.clone()]),
         [
-            (
-                config.digest.clone(),
-                BlobReply::for_descriptor(&config).with_delay(Duration::from_millis(10)),
-            ),
+            (config.digest.clone(), BlobReply::for_descriptor(&config)),
             (
                 first.digest.clone(),
-                BlobReply::for_descriptor(&first).with_delay(Duration::from_millis(200)),
+                BlobReply::for_descriptor(&first).with_hold(Arc::clone(&hold_first)),
             ),
-            (
-                second.digest.clone(),
-                BlobReply::for_descriptor(&second).with_delay(Duration::from_millis(25)),
-            ),
-            (
-                third.digest.clone(),
-                BlobReply::for_descriptor(&third).with_delay(Duration::from_millis(5)),
-            ),
+            (second.digest.clone(), BlobReply::for_descriptor(&second)),
+            (third.digest.clone(), BlobReply::for_descriptor(&third)),
         ],
     )
     .await;
     let directory = tempdir().expect("create image root");
     let cache = BlobCache::new(directory.path());
+    let reference = registry.reference();
+    let cache_for_pull = cache.clone();
 
-    let cached = cache_image_blobs_with_parallelism(
-        &registry.reference(),
-        Architecture::X86_64,
-        true,
-        &cache,
-        None,
-        2,
-    )
+    let pull = tokio::spawn(async move {
+        cache_image_blobs_with_parallelism(
+            &reference,
+            Architecture::X86_64,
+            true,
+            &cache_for_pull,
+            None,
+            2,
+        )
+        .await
+    });
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let completions = registry.blob_completions();
+            let done = |digest: &Sha256Digest| {
+                completions
+                    .iter()
+                    .any(|completed| completed == digest.as_str())
+            };
+            if done(&second.digest) && done(&third.digest) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
     .await
-    .expect("cache blobs with bounded parallelism");
+    .expect("fast layers finish while the first layer is held");
+
+    hold_first.release();
+    let cached = pull
+        .await
+        .expect("join bounded pull")
+        .expect("cache blobs with bounded parallelism");
 
     assert_eq!(registry.max_active_blob_requests(), 2);
     let completions = registry.blob_completions();

--- a/firecrab-frontend/package-lock.json
+++ b/firecrab-frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19.2.4",
         "@vitejs/plugin-react": "^6.0.5",
         "oxlint": "^1.75.0",
+        "tsx": "^4.23.12",
         "typescript": "~7.0.2",
         "vite": "^8.1.1"
       }
@@ -55,6 +56,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -1154,6 +1597,48 @@
         "node": ">=8"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1672,6 +2157,25 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "7.0.2",

--- a/firecrab-frontend/package.json
+++ b/firecrab-frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "oxlint",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsx --test src/lib/textExport.test.ts src/lib/terminal.test.ts"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -21,6 +22,7 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
     "oxlint": "^1.75.0",
+    "tsx": "^4.23.12",
     "typescript": "~7.0.2",
     "vite": "^8.1.1"
   }

--- a/firecrab-frontend/src/api/client.ts
+++ b/firecrab-frontend/src/api/client.ts
@@ -115,8 +115,17 @@ export function getSshHostKey(id: string): Promise<SshHostKeyResponse> {
   return fetchJson(`/api/vms/${id}/ssh-host-key`);
 }
 
+const sshKeyPemCache = new Map<string, string>();
+
+/** Sync cache hit so a copy click can call `clipboard` in the same user gesture. */
+export function peekSshKeyPem(id: string): string | undefined {
+  return sshKeyPemCache.get(id);
+}
+
 /** Reads the operator private key as text, for copying it to the clipboard. */
 export async function fetchSshKeyPem(id: string): Promise<string> {
+  const cached = sshKeyPemCache.get(id);
+  if (cached !== undefined) return cached;
   let response: Response;
   try {
     response = await fetch(`/api/vms/${id}/ssh-key`);
@@ -126,7 +135,9 @@ export async function fetchSshKeyPem(id: string): Promise<string> {
   if (!response.ok) {
     throw await fail(response);
   }
-  return response.text();
+  const text = await response.text();
+  sshKeyPemCache.set(id, text);
+  return text;
 }
 
 /** Downloads the operator private key. Filename comes from Content-Disposition. */

--- a/firecrab-frontend/src/components/Console.tsx
+++ b/firecrab-frontend/src/components/Console.tsx
@@ -13,6 +13,7 @@ import { useI18n } from "../i18n";
 import {
   defaultInteractiveTerminalOptions,
   enableTerminalIme,
+  enableTerminalTouchScroll,
   isImeComposing,
 } from "../lib/terminal";
 
@@ -234,6 +235,7 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
     term.loadAddon(fitAddon);
     term.open(container);
     enableTerminalIme(term, container);
+    const stopTouchScroll = enableTerminalTouchScroll(term, container);
     termRef.current = term;
     fitRef.current = fitAddon;
     scheduleFit();
@@ -347,6 +349,7 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
       window.clearTimeout(bootTimer);
       clearReconnectTimer();
       dataListener.dispose();
+      stopTouchScroll();
       ro.disconnect();
       window.removeEventListener("resize", onWinResize);
       window.removeEventListener("keydown", onKey);
@@ -389,6 +392,28 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
     clearReconnectTimer();
     reconnectAttemptRef.current = 0;
     setReconnectKey((k) => k + 1);
+  };
+
+  /** Clipboard API, then a prompt — phones on HTTP have no `readText`. */
+  const pasteIntoTerminal = async () => {
+    const term = termRef.current;
+    if (!term) return;
+    let text = "";
+    try {
+      if (window.isSecureContext && navigator.clipboard?.readText) {
+        text = await navigator.clipboard.readText();
+      }
+    } catch {
+      text = "";
+    }
+    if (!text) {
+      const typed = window.prompt(
+        t("Paste into the serial console", "시리얼 콘솔에 붙여넣을 텍스트"),
+      );
+      if (typed === null) return;
+      text = typed;
+    }
+    if (text) term.paste(text);
   };
 
   /**
@@ -545,6 +570,14 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
               copyLabel={t("Copy log", "로그 복사")}
               downloadLabel={t("Save log", "로그 저장")}
             />
+            <button
+              type="button"
+              className="btn console-bar-btn"
+              onClick={() => void pasteIntoTerminal()}
+              title={t("Paste into the serial console", "시리얼 콘솔에 붙여넣기")}
+            >
+              {t("Paste", "붙여넣기")}
+            </button>
             <button
               type="button"
               className="btn console-bar-btn"

--- a/firecrab-frontend/src/components/Console.tsx
+++ b/firecrab-frontend/src/components/Console.tsx
@@ -394,28 +394,6 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
     setReconnectKey((k) => k + 1);
   };
 
-  /** Clipboard API, then a prompt — phones on HTTP have no `readText`. */
-  const pasteIntoTerminal = async () => {
-    const term = termRef.current;
-    if (!term) return;
-    let text = "";
-    try {
-      if (window.isSecureContext && navigator.clipboard?.readText) {
-        text = await navigator.clipboard.readText();
-      }
-    } catch {
-      text = "";
-    }
-    if (!text) {
-      const typed = window.prompt(
-        t("Paste into the serial console", "시리얼 콘솔에 붙여넣을 텍스트"),
-      );
-      if (typed === null) return;
-      text = typed;
-    }
-    if (text) term.paste(text);
-  };
-
   /**
    * Prefer closing a script-opened popup (`window.open` from the list).
    * If the browser refuses (normal tab / no script opener), fall back to
@@ -567,17 +545,9 @@ export default function Console({ vmId, onClose }: ConsoleProps) {
               text={buildExportText}
               filename={logDownloadFilename("console", vm?.name ?? vmId)}
               buttonClassName="btn console-bar-btn"
-              copyLabel={t("Copy log", "로그 복사")}
+              showCopy={false}
               downloadLabel={t("Save log", "로그 저장")}
             />
-            <button
-              type="button"
-              className="btn console-bar-btn"
-              onClick={() => void pasteIntoTerminal()}
-              title={t("Paste into the serial console", "시리얼 콘솔에 붙여넣기")}
-            >
-              {t("Paste", "붙여넣기")}
-            </button>
             <button
               type="button"
               className="btn console-bar-btn"

--- a/firecrab-frontend/src/components/ConsoleSshTab.tsx
+++ b/firecrab-frontend/src/components/ConsoleSshTab.tsx
@@ -1,6 +1,6 @@
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { PortForward, VmResponse } from "../bindings";
-import { downloadSshKey, fetchSshKeyPem, updateVmPortForwards } from "../api/client";
+import { downloadSshKey, fetchSshKeyPem, peekSshKeyPem, updateVmPortForwards } from "../api/client";
 import { isValidPort } from "../lib/portForward";
 import { copyText } from "../lib/textExport";
 import { useI18n } from "../i18n";
@@ -155,14 +155,14 @@ function CopyableBlock({
   action?: ReactNode;
 }) {
   const { t } = useI18n();
-  const [copied, setCopied] = useState(false);
+  const [status, setStatus] = useState<"idle" | "copied" | "failed">("idle");
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const onCopy = async () => {
     const ok = await copyText(command);
     if (timer.current !== null) clearTimeout(timer.current);
-    setCopied(ok);
-    timer.current = setTimeout(() => setCopied(false), 2_000);
+    setStatus(ok ? "copied" : "failed");
+    timer.current = setTimeout(() => setStatus("idle"), 2_000);
   };
 
   return (
@@ -170,7 +170,11 @@ function CopyableBlock({
       <div className="console-ssh-block-head">
         <span className="console-ssh-block-label">{label}</span>
         <button type="button" className="btn console-bar-btn" onClick={() => void onCopy()}>
-          {copied ? t("Copied", "복사됨") : t("Copy", "복사")}
+          {status === "copied"
+            ? t("Copied", "복사됨")
+            : status === "failed"
+              ? t("Failed", "실패")
+              : t("Copy", "복사")}
         </button>
         {action}
       </div>
@@ -190,9 +194,9 @@ export default function ConsoleSshTab({ vm }: ConsoleSshTabProps) {
   const { t } = useI18n();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [keyCopied, setKeyCopied] = useState(false);
+  const [keyCopied, setKeyCopied] = useState<"idle" | "copied" | "failed">("idle");
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  /** PEM body, fetched only once the operator asks to see or copy it. */
+  /** PEM body. Prefetched so Copy key can write the clipboard in the same tap. */
   const [keyText, setKeyText] = useState<string | null>(null);
   const [keyShown, setKeyShown] = useState(false);
   /**
@@ -202,6 +206,34 @@ export default function ConsoleSshTab({ vm }: ConsoleSshTabProps) {
    */
   const [written, setWritten] = useState<{ id: string; forwards: PortForward[] } | null>(null);
   const [hostPort, setHostPort] = useState("22022");
+
+  // Prefetch so Copy key can write the clipboard in the same tap. An `await
+  // fetch` before `writeText` drops the user gesture on iOS / HTTP.
+  const vmId = vm?.id;
+  useEffect(() => {
+    setKeyShown(false);
+    if (!vmId) {
+      setKeyText(null);
+      return;
+    }
+    const cached = peekSshKeyPem(vmId);
+    if (cached !== undefined) {
+      setKeyText(cached);
+      return;
+    }
+    setKeyText(null);
+    let cancelled = false;
+    fetchSshKeyPem(vmId)
+      .then((pem) => {
+        if (!cancelled) setKeyText(pem);
+      })
+      .catch(() => {
+        /* eye / copy still fetch on demand */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [vmId]);
 
   if (!vm) {
     return (
@@ -230,8 +262,6 @@ export default function ConsoleSshTab({ vm }: ConsoleSshTabProps) {
       .finally(() => setBusy(false));
   };
 
-  // The private key reaches the browser only when asked for, and is kept for
-  // the rest of the session so the eye and the copy button share one fetch.
   const loadKey = async (): Promise<string> => {
     if (keyText !== null) return keyText;
     const pem = await fetchSshKeyPem(vm.id);
@@ -258,14 +288,22 @@ export default function ConsoleSshTab({ vm }: ConsoleSshTabProps) {
 
   // The PEM never lands on disk this way — handy on a host reached through a
   // browser, where the download would sit on the wrong machine.
+  const flashKeyCopy = (ok: boolean) => {
+    if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+    setKeyCopied(ok ? "copied" : "failed");
+    copyTimer.current = setTimeout(() => setKeyCopied("idle"), 2_000);
+  };
+
   const onCopyKey = async () => {
     setError(null);
+    const ready = keyText ?? peekSshKeyPem(vm.id);
+    if (ready !== undefined) {
+      flashKeyCopy(await copyText(ready));
+      return;
+    }
     setBusy(true);
     try {
-      const copied = await copyText(await loadKey());
-      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
-      setKeyCopied(copied);
-      copyTimer.current = setTimeout(() => setKeyCopied(false), 2_000);
+      flashKeyCopy(await copyText(await loadKey()));
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -339,7 +377,11 @@ export default function ConsoleSshTab({ vm }: ConsoleSshTabProps) {
             onClick={() => void onCopyKey()}
             title={t("Copy the private key text", "개인 키 본문을 클립보드로 복사")}
           >
-            {keyCopied ? t("Key copied", "키 복사됨") : t("Copy key", "키 복사")}
+            {keyCopied === "copied"
+              ? t("Key copied", "키 복사됨")
+              : keyCopied === "failed"
+                ? t("Failed", "실패")
+                : t("Copy key", "키 복사")}
           </button>
         </div>
         <pre className={`console-ssh-code${keyShown ? "" : " is-masked"}`}>

--- a/firecrab-frontend/src/components/InlineConsole.tsx
+++ b/firecrab-frontend/src/components/InlineConsole.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
-import { defaultInteractiveTerminalOptions } from "../lib/terminal";
+import { defaultInteractiveTerminalOptions, enableTerminalTouchScroll } from "../lib/terminal";
 
 type Status = "connecting" | "connected" | "reconnecting" | "disconnected";
 
@@ -104,6 +104,7 @@ export default function InlineConsole({ vmId }: { vmId: string }) {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(container);
+    const stopTouchScroll = enableTerminalTouchScroll(term, container);
     termRef.current = term;
     fitRef.current = fitAddon;
     scheduleFit();
@@ -181,6 +182,7 @@ export default function InlineConsole({ vmId }: { vmId: string }) {
       intentionalCloseRef.current = true;
       window.clearTimeout(bootTimer);
       clearReconnectTimer();
+      stopTouchScroll();
       observer.disconnect();
       window.removeEventListener("resize", onWinResize);
       const socket = socketRef.current;

--- a/firecrab-frontend/src/components/LogExportActions.tsx
+++ b/firecrab-frontend/src/components/LogExportActions.tsx
@@ -15,6 +15,8 @@ interface LogExportActionsProps {
   buttonClassName?: string;
   copyLabel?: string;
   downloadLabel?: string;
+  /** Hide the copy button (serial console uses hold-drag copy instead). */
+  showCopy?: boolean;
 }
 
 type Feedback = "idle" | "busy" | "copied" | "saved" | "failed" | "empty";
@@ -38,6 +40,7 @@ export default function LogExportActions({
   buttonClassName = "btn",
   copyLabel,
   downloadLabel,
+  showCopy = true,
 }: LogExportActionsProps) {
   const { t } = useI18n();
   const [feedback, setFeedback] = useState<Feedback>("idle");
@@ -89,15 +92,17 @@ export default function LogExportActions({
 
   return (
     <div className={`log-export-actions ${className}`.trim()} role="group" aria-label={t("Export log", "로그 내보내기")}>
-      <button
-        type="button"
-        className={buttonClassName}
-        disabled={disabled || feedback === "busy"}
-        onClick={() => void run("copy")}
-        title={t("Copy the full log to the clipboard", "로그 전체를 클립보드에 복사")}
-      >
-        {copyLabel ?? t("Copy", "복사")}
-      </button>
+      {showCopy ? (
+        <button
+          type="button"
+          className={buttonClassName}
+          disabled={disabled || feedback === "busy"}
+          onClick={() => void run("copy")}
+          title={t("Copy the full log to the clipboard", "로그 전체를 클립보드에 복사")}
+        >
+          {copyLabel ?? t("Copy", "복사")}
+        </button>
+      ) : null}
       <button
         type="button"
         className={buttonClassName}

--- a/firecrab-frontend/src/components/VmDetailModal.tsx
+++ b/firecrab-frontend/src/components/VmDetailModal.tsx
@@ -16,6 +16,7 @@ import {
   assignVmStorage,
   downloadSshKey,
   fetchSshKeyPem,
+  peekSshKeyPem,
   getVm,
   getVmLog,
   listImages,
@@ -633,13 +634,19 @@ export default function VmDetailModal({ vmId, vms, onClose }: VmDetailModalProps
                   title={t("Copy the private key text", "개인 키 본문을 클립보드로 복사")}
                   onClick={() => {
                     setSshKeyError(null);
+                    const ready = peekSshKeyPem(vm.id);
+                    const flash = (copied: boolean) => {
+                      setSshKeyCopied(copied);
+                      setTimeout(() => setSshKeyCopied(false), 2_000);
+                    };
+                    if (ready !== undefined) {
+                      void copyText(ready).then(flash);
+                      return;
+                    }
                     setSshKeyBusy(true);
                     fetchSshKeyPem(vm.id)
                       .then(copyText)
-                      .then((copied) => {
-                        setSshKeyCopied(copied);
-                        setTimeout(() => setSshKeyCopied(false), 2_000);
-                      })
+                      .then(flash)
                       .catch((error: unknown) => {
                         setSshKeyError(error instanceof Error ? error.message : String(error));
                       })

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -1248,7 +1248,10 @@ table.image-table .image-package-url a:hover {
   z-index: 20;
   width: 100%;
   height: 100%;
+  height: 100dvh;
+  max-height: 100dvh;
   min-height: 100dvh;
+  overflow: hidden;
 }
 
 .console-tabs {
@@ -1411,17 +1414,24 @@ table.image-table .image-package-url a:hover {
 }
 .console-page .console-close:hover { color: var(--tty-bad); }
 
-/* `flex: 1; min-height: 0` so the surface absorbs leftover height after the
-   detail panel and FitAddon measures the real box on chrome show/hide.
-   A non-zero min-height keeps the first fit() from collapsing to 0 rows. */
+/* `flex: 1 1 0; min-height: 0` so the surface absorbs leftover height after
+   the inspect rail. A content-sized min-height overflowed the fixed page on
+   phones and left no page scroll. */
 .console-page .console-surface {
-  flex: 1 1 auto;
-  min-height: 12rem;
+  flex: 1 1 0;
+  min-height: 0;
   width: 100%;
   padding: 0.5rem 0.65rem;
   overflow: hidden;
   position: relative;
   background: var(--tty-term);
+  touch-action: none;
+}
+.console-page .console-surface .xterm,
+.console-page .console-surface .xterm-viewport,
+.console-page .console-surface .xterm-screen,
+.console-page .console-surface .xterm-rows {
+  touch-action: none;
 }
 .console-page.is-terminal-only .console-surface {
   padding: 0.5rem 0.65rem;
@@ -1433,7 +1443,9 @@ table.image-table .image-package-url a:hover {
   padding: 0;
 }
 .console-page .console-surface .xterm-viewport {
-  overflow-y: auto !important;
+  /* xterm 6 uses a custom scrollbar; native overflow here has nothing to
+     scroll (scrollHeight === clientHeight) and steals the finger pan. */
+  overflow: hidden !important;
 }
 .console-page .console-surface .xterm-screen {
   height: 100%;
@@ -1454,6 +1466,7 @@ table.image-table .image-package-url a:hover {
   border-top: 1px solid var(--tty-line);
   color: var(--tty-ink);
   padding: 0.55rem 0.85rem 0.55rem;
+  min-height: 0;
 }
 .console-inspect-bar {
   flex: 0 0 auto;
@@ -1516,6 +1529,23 @@ table.image-table .image-package-url a:hover {
 @media (max-width: 520px) {
   .console-page .console-detail-grid {
     grid-template-columns: minmax(0, 1fr);
+  }
+}
+@media (max-width: 720px) {
+  .console-page .console-detail {
+    flex: 0 1 auto;
+    max-height: 36vh;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
+  }
+  .console-page .console-detail-group {
+    min-height: 0;
+  }
+  .console-page .console-bar-btn,
+  .console-page .console-close {
+    min-height: 2.25rem;
+    padding: 0.4rem 0.55rem;
   }
 }
 .console-page .console-detail-group {
@@ -1685,11 +1715,13 @@ table.image-table .image-package-url a:hover {
   min-height: 0;
 }
 .console-ssh {
-  flex: 1 1 auto;
-  min-height: 12rem;
+  flex: 1 1 0;
+  min-height: 0;
   overflow: auto;
   padding: 1.1rem 1.25rem 1.25rem;
   background: var(--bg);
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 .console-ssh-lead {
   margin: 0 0 0.85rem;
@@ -1753,6 +1785,8 @@ table.image-table .image-package-url a:hover {
   font-family: var(--font-mono);
   font-size: 0.82rem;
   line-height: 1.45;
+  user-select: text;
+  -webkit-user-select: text;
 }
 .console-ssh-code code {
   font-family: inherit;
@@ -1928,9 +1962,18 @@ table.image-table .image-package-url a:hover {
 }
 
 .inline-console-surface {
+  touch-action: none;
   height: 16rem;
   padding: 0.4rem;
   background: #171b22;
+}
+.inline-console-surface .xterm,
+.inline-console-surface .xterm-viewport,
+.inline-console-surface .xterm-screen {
+  touch-action: none;
+}
+.inline-console-surface .xterm-viewport {
+  overflow: hidden !important;
 }
 
 .inline-console-ended {

--- a/firecrab-frontend/src/index.css
+++ b/firecrab-frontend/src/index.css
@@ -1451,7 +1451,8 @@ table.image-table .image-package-url a:hover {
   height: 100%;
 }
 .console-page .console-surface .xterm .xterm-helper-textarea {
-  z-index: 10 !important;
+  /* No !important — xterm raises this for the OS copy/paste menu. */
+  z-index: 10;
 }
 .console-page .console-surface .xterm .composition-view {
   background: var(--tty-term);

--- a/firecrab-frontend/src/lib/terminal.test.ts
+++ b/firecrab-frontend/src/lib/terminal.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
+  classifyTerminalGesture,
+  linearSelect,
   linesFromPointerDelta,
   shouldPanTerminalPointer,
 } from "./terminal";
@@ -24,4 +26,17 @@ test("pointer delta keeps a sub-cell remainder so slow drags still accumulate", 
 
   const combined = linesFromPointerDelta(8, 10, partial.acc);
   assert.equal(combined.lines, -1);
+});
+
+test("a quick drag pans; a still hold then drag stays hold", () => {
+  assert.equal(classifyTerminalGesture(80, 24, "pending"), "pan");
+  assert.equal(classifyTerminalGesture(80, 2, "pending"), "pending");
+  assert.equal(classifyTerminalGesture(520, 2, "pending"), "hold");
+  assert.equal(classifyTerminalGesture(600, 40, "hold"), "hold");
+  assert.equal(classifyTerminalGesture(600, 40, "pan"), "pan");
+});
+
+test("linearSelect spans cells across rows", () => {
+  assert.deepEqual(linearSelect(10, 2, 3, 5, 3), { column: 2, row: 3, length: 4 });
+  assert.deepEqual(linearSelect(10, 8, 1, 1, 2), { column: 8, row: 1, length: 4 });
 });

--- a/firecrab-frontend/src/lib/terminal.test.ts
+++ b/firecrab-frontend/src/lib/terminal.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  linesFromPointerDelta,
+  shouldPanTerminalPointer,
+} from "./terminal";
+
+test("touch and pen pan; mouse pans only when the device has no hover", () => {
+  assert.equal(shouldPanTerminalPointer({ isPrimary: true, pointerType: "touch" }, false), true);
+  assert.equal(shouldPanTerminalPointer({ isPrimary: true, pointerType: "pen" }, false), true);
+  assert.equal(shouldPanTerminalPointer({ isPrimary: true, pointerType: "mouse" }, false), false);
+  assert.equal(shouldPanTerminalPointer({ isPrimary: true, pointerType: "mouse" }, true), true);
+  assert.equal(shouldPanTerminalPointer({ isPrimary: false, pointerType: "touch" }, false), false);
+});
+
+test("pointer delta keeps a sub-cell remainder so slow drags still accumulate", () => {
+  const whole = linesFromPointerDelta(20, 10, 0);
+  assert.equal(whole.lines, -2);
+  assert.ok(whole.acc === 0);
+
+  const partial = linesFromPointerDelta(8, 10, 0);
+  assert.equal(partial.lines, 0);
+  assert.ok(partial.acc < 0);
+
+  const combined = linesFromPointerDelta(8, 10, partial.acc);
+  assert.equal(combined.lines, -1);
+});

--- a/firecrab-frontend/src/lib/terminal.ts
+++ b/firecrab-frontend/src/lib/terminal.ts
@@ -53,3 +53,114 @@ export function enableTerminalIme(term: Terminal, container: HTMLElement): void 
 export function isImeComposing(event: KeyboardEvent): boolean {
   return event.isComposing || event.key === "Process" || event.keyCode === 229;
 }
+
+/** Finger/pen always pan. Mouse pans only on phones (`hover: none`). */
+export function shouldPanTerminalPointer(
+  event: { isPrimary: boolean; pointerType: string },
+  hoverNone: boolean,
+): boolean {
+  if (!event.isPrimary) return false;
+  if (event.pointerType === "touch" || event.pointerType === "pen") return true;
+  return hoverNone && event.pointerType === "mouse";
+}
+
+/** Convert a vertical pointer delta into whole xterm rows, keeping the remainder. */
+export function linesFromPointerDelta(
+  deltaY: number,
+  cellHeight: number,
+  accumulated: number,
+): { lines: number; acc: number } {
+  const height = cellHeight > 0 ? cellHeight : 16;
+  let acc = accumulated + -deltaY / height;
+  const raw = acc < 0 ? Math.ceil(acc) : Math.floor(acc);
+  const lines = raw === 0 ? 0 : raw;
+  return { lines, acc: acc - lines };
+}
+
+/**
+ * xterm 6 paints a fixed viewport and scrolls with a custom wheel handler —
+ * the `.xterm-viewport` box is not a native scroller (`scrollHeight ===
+ * clientHeight`), so a finger drag does nothing. Capture non-mouse pointers
+ * (and mouse on `hover: none` devices) and map pans to `scrollLines`.
+ */
+export function enableTerminalTouchScroll(term: Terminal, container: HTMLElement): () => void {
+  const element = term.element ?? container;
+  const PAN_THRESHOLD_PX = 8;
+  let pointerId: number | null = null;
+  let lastY = 0;
+  let startY = 0;
+  let acc = 0;
+  let panning = false;
+
+  const cellHeight = (): number => {
+    const screen = element.querySelector(".xterm-screen");
+    const height =
+      screen instanceof HTMLElement && screen.clientHeight > 0
+        ? screen.clientHeight
+        : element.clientHeight;
+    const rows = term.rows;
+    if (rows < 1 || height < 1) return 16;
+    return height / rows;
+  };
+
+  const hoverNone = (): boolean =>
+    typeof window.matchMedia === "function" && window.matchMedia("(hover: none)").matches;
+
+  const onPointerDown = (event: PointerEvent) => {
+    if (!shouldPanTerminalPointer(event, hoverNone())) return;
+    pointerId = event.pointerId;
+    lastY = event.clientY;
+    startY = event.clientY;
+    acc = 0;
+    panning = false;
+    term.focus();
+    event.preventDefault();
+    try {
+      element.setPointerCapture(event.pointerId);
+    } catch {
+      /* capture is best-effort: the node may not be connected */
+    }
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    if (pointerId !== event.pointerId) return;
+    const y = event.clientY;
+    const dy = y - lastY;
+    lastY = y;
+    if (!panning) {
+      if (Math.abs(y - startY) < PAN_THRESHOLD_PX) return;
+      panning = true;
+    }
+    const next = linesFromPointerDelta(dy, cellHeight(), acc);
+    acc = next.acc;
+    if (next.lines !== 0) term.scrollLines(next.lines);
+    event.preventDefault();
+  };
+
+  const onPointerUp = (event: PointerEvent) => {
+    if (pointerId !== event.pointerId) return;
+    pointerId = null;
+    panning = false;
+    acc = 0;
+    try {
+      element.releasePointerCapture(event.pointerId);
+    } catch {
+      /* already released */
+    }
+  };
+
+  const opts: AddEventListenerOptions = { capture: true, passive: false };
+  element.addEventListener("pointerdown", onPointerDown, opts);
+  element.addEventListener("pointermove", onPointerMove, opts);
+  element.addEventListener("pointerup", onPointerUp, opts);
+  element.addEventListener("pointercancel", onPointerUp, opts);
+  element.addEventListener("lostpointercapture", onPointerUp, opts);
+
+  return () => {
+    element.removeEventListener("pointerdown", onPointerDown, opts);
+    element.removeEventListener("pointermove", onPointerMove, opts);
+    element.removeEventListener("pointerup", onPointerUp, opts);
+    element.removeEventListener("pointercancel", onPointerUp, opts);
+    element.removeEventListener("lostpointercapture", onPointerUp, opts);
+  };
+}

--- a/firecrab-frontend/src/lib/terminal.ts
+++ b/firecrab-frontend/src/lib/terminal.ts
@@ -1,4 +1,5 @@
 import type { ITerminalInitOnlyOptions, ITerminalOptions, Terminal } from "@xterm/xterm";
+import { copyText } from "./textExport";
 
 type TerminalCtorOptions = ITerminalOptions & ITerminalInitOnlyOptions;
 
@@ -77,20 +78,108 @@ export function linesFromPointerDelta(
   return { lines, acc: acc - lines };
 }
 
+export const TERMINAL_PAN_THRESHOLD_PX = 10;
+export const TERMINAL_HOLD_MS = 500;
+
+export type TerminalGesture = "pending" | "pan" | "hold";
+
+/** Quick drag pans. A still press that lasts `holdMs` becomes hold (select/paste). */
+export function classifyTerminalGesture(
+  elapsedMs: number,
+  distancePx: number,
+  already: TerminalGesture,
+  panThresholdPx = TERMINAL_PAN_THRESHOLD_PX,
+  holdMs = TERMINAL_HOLD_MS,
+): TerminalGesture {
+  if (already === "pan" || already === "hold") return already;
+  if (distancePx >= panThresholdPx && elapsedMs < holdMs) return "pan";
+  if (elapsedMs >= holdMs) return "hold";
+  return "pending";
+}
+
+/** Inclusive linear range for `Terminal.select`. Rows are buffer rows. */
+export function linearSelect(
+  cols: number,
+  startCol: number,
+  startRow: number,
+  endCol: number,
+  endRow: number,
+): { column: number; row: number; length: number } {
+  const width = cols > 0 ? cols : 1;
+  const a = startRow * width + startCol;
+  const b = endRow * width + endCol;
+  const from = Math.min(a, b);
+  const to = Math.max(a, b);
+  return {
+    column: ((from % width) + width) % width,
+    row: Math.floor(from / width),
+    length: Math.max(1, to - from + 1),
+  };
+}
+
+function parkHelperTextarea(
+  container: HTMLElement,
+  clientX: number,
+  clientY: number,
+  text: string,
+): HTMLTextAreaElement | null {
+  const textarea = container.querySelector("textarea.xterm-helper-textarea");
+  if (!(textarea instanceof HTMLTextAreaElement)) return null;
+  const screen = container.querySelector(".xterm-screen");
+  const origin = screen instanceof HTMLElement ? screen : container;
+  const pos = origin.getBoundingClientRect();
+  textarea.style.width = "44px";
+  textarea.style.height = "44px";
+  textarea.style.left = `${clientX - pos.left - 22}px`;
+  textarea.style.top = `${clientY - pos.top - 22}px`;
+  textarea.style.opacity = "0.01";
+  textarea.style.zIndex = "1000";
+  textarea.readOnly = false;
+  textarea.value = text;
+  textarea.focus();
+  if (text) textarea.select();
+  return textarea;
+}
+
+function bufferCellAt(
+  term: Terminal,
+  element: HTMLElement,
+  clientX: number,
+  clientY: number,
+): { col: number; row: number } | null {
+  const screen = element.querySelector(".xterm-screen");
+  if (!(screen instanceof HTMLElement)) return null;
+  const rect = screen.getBoundingClientRect();
+  if (rect.width < 1 || rect.height < 1 || term.cols < 1 || term.rows < 1) return null;
+  const col = Math.max(
+    0,
+    Math.min(term.cols - 1, Math.floor((clientX - rect.left) / (rect.width / term.cols))),
+  );
+  const viewRow = Math.max(
+    0,
+    Math.min(term.rows - 1, Math.floor((clientY - rect.top) / (rect.height / term.rows))),
+  );
+  return { col, row: term.buffer.active.viewportY + viewRow };
+}
+
 /**
- * xterm 6 paints a fixed viewport and scrolls with a custom wheel handler —
- * the `.xterm-viewport` box is not a native scroller (`scrollHeight ===
- * clientHeight`), so a finger drag does nothing. Capture non-mouse pointers
- * (and mouse on `hover: none` devices) and map pans to `scrollLines`.
+ * xterm 6 has no native overflow, so a quick finger drag must call
+ * `scrollLines`. Do not steal the gesture on pointerdown: a still hold is
+ * paste (OS menu on the helper textarea) and hold-then-drag selects for copy.
  */
 export function enableTerminalTouchScroll(term: Terminal, container: HTMLElement): () => void {
   const element = term.element ?? container;
-  const PAN_THRESHOLD_PX = 8;
   let pointerId: number | null = null;
   let lastY = 0;
+  let startX = 0;
   let startY = 0;
+  let startAt = 0;
   let acc = 0;
-  let panning = false;
+  let mode: TerminalGesture = "pending";
+  let holdTimer: ReturnType<typeof setTimeout> | null = null;
+  let anchor: { col: number; row: number } | null = null;
+  let lastClientX = 0;
+  let lastClientY = 0;
 
   const cellHeight = (): number => {
     const screen = element.querySelector(".xterm-screen");
@@ -106,31 +195,85 @@ export function enableTerminalTouchScroll(term: Terminal, container: HTMLElement
   const hoverNone = (): boolean =>
     typeof window.matchMedia === "function" && window.matchMedia("(hover: none)").matches;
 
+  const clearHoldTimer = () => {
+    if (holdTimer !== null) {
+      clearTimeout(holdTimer);
+      holdTimer = null;
+    }
+  };
+
+  const applyHold = (clientX: number, clientY: number) => {
+    mode = "hold";
+    anchor = bufferCellAt(term, element, clientX, clientY);
+    if (anchor) {
+      term.select(anchor.col, anchor.row, 1);
+    }
+    parkHelperTextarea(element, clientX, clientY, term.getSelection());
+    element.dispatchEvent(
+      new MouseEvent("contextmenu", {
+        bubbles: true,
+        cancelable: true,
+        clientX,
+        clientY,
+        view: window,
+      }),
+    );
+  };
+
+  const applySelect = (clientX: number, clientY: number) => {
+    const end = bufferCellAt(term, element, clientX, clientY);
+    if (!anchor || !end) return;
+    const range = linearSelect(term.cols, anchor.col, anchor.row, end.col, end.row);
+    term.select(range.column, range.row, range.length);
+    parkHelperTextarea(element, clientX, clientY, term.getSelection());
+  };
+
   const onPointerDown = (event: PointerEvent) => {
     if (!shouldPanTerminalPointer(event, hoverNone())) return;
     pointerId = event.pointerId;
     lastY = event.clientY;
+    startX = event.clientX;
     startY = event.clientY;
+    lastClientX = event.clientX;
+    lastClientY = event.clientY;
+    startAt = event.timeStamp;
     acc = 0;
-    panning = false;
+    mode = "pending";
+    anchor = null;
     term.focus();
-    event.preventDefault();
-    try {
-      element.setPointerCapture(event.pointerId);
-    } catch {
-      /* capture is best-effort: the node may not be connected */
-    }
+    clearHoldTimer();
+    holdTimer = setTimeout(() => {
+      holdTimer = null;
+      if (pointerId !== event.pointerId || mode !== "pending") return;
+      applyHold(lastClientX, lastClientY);
+    }, TERMINAL_HOLD_MS);
   };
 
   const onPointerMove = (event: PointerEvent) => {
     if (pointerId !== event.pointerId) return;
+    lastClientX = event.clientX;
+    lastClientY = event.clientY;
+    const distance = Math.hypot(event.clientX - startX, event.clientY - startY);
+    const nextMode = classifyTerminalGesture(event.timeStamp - startAt, distance, mode);
+    if (nextMode === "pan" && mode !== "pan") {
+      clearHoldTimer();
+      term.clearSelection();
+      try {
+        element.setPointerCapture(event.pointerId);
+      } catch {
+        /* capture is best-effort */
+      }
+    }
+    mode = nextMode;
+    if (mode === "hold") {
+      applySelect(event.clientX, event.clientY);
+      event.preventDefault();
+      return;
+    }
+    if (mode !== "pan") return;
     const y = event.clientY;
     const dy = y - lastY;
     lastY = y;
-    if (!panning) {
-      if (Math.abs(y - startY) < PAN_THRESHOLD_PX) return;
-      panning = true;
-    }
     const next = linesFromPointerDelta(dy, cellHeight(), acc);
     acc = next.acc;
     if (next.lines !== 0) term.scrollLines(next.lines);
@@ -139,13 +282,24 @@ export function enableTerminalTouchScroll(term: Terminal, container: HTMLElement
 
   const onPointerUp = (event: PointerEvent) => {
     if (pointerId !== event.pointerId) return;
+    clearHoldTimer();
+    const ended = mode;
     pointerId = null;
-    panning = false;
+    mode = "pending";
     acc = 0;
     try {
       element.releasePointerCapture(event.pointerId);
     } catch {
       /* already released */
+    }
+    if (ended === "hold") {
+      const selected = term.getSelection();
+      if (selected) {
+        void copyText(selected);
+        parkHelperTextarea(element, event.clientX, event.clientY, selected);
+      } else {
+        parkHelperTextarea(element, event.clientX, event.clientY, "");
+      }
     }
   };
 
@@ -157,6 +311,7 @@ export function enableTerminalTouchScroll(term: Terminal, container: HTMLElement
   element.addEventListener("lostpointercapture", onPointerUp, opts);
 
   return () => {
+    clearHoldTimer();
     element.removeEventListener("pointerdown", onPointerDown, opts);
     element.removeEventListener("pointermove", onPointerMove, opts);
     element.removeEventListener("pointerup", onPointerUp, opts);

--- a/firecrab-frontend/src/lib/textExport.test.ts
+++ b/firecrab-frontend/src/lib/textExport.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  prepareClipboardFallbackTextarea,
+  shouldPreferAsyncClipboard,
+} from "./textExport";
+
+test("async clipboard write is only used in a secure context", () => {
+  assert.equal(shouldPreferAsyncClipboard(true, true), true);
+  assert.equal(shouldPreferAsyncClipboard(false, true), false);
+  assert.equal(shouldPreferAsyncClipboard(true, false), false);
+  assert.equal(shouldPreferAsyncClipboard(false, false), false);
+});
+
+test("fallback textarea stays in the viewport so iOS can copy", () => {
+  const style: Record<string, string> = {};
+  const area = {
+    style,
+    setAttribute() {},
+  } as unknown as HTMLTextAreaElement;
+
+  prepareClipboardFallbackTextarea(area);
+
+  assert.equal(style.position, "fixed");
+  assert.equal(style.left, "0");
+  assert.equal(style.top, "0");
+  assert.notEqual(style.left, "-9999px");
+});

--- a/firecrab-frontend/src/lib/textExport.ts
+++ b/firecrab-frontend/src/lib/textExport.ts
@@ -3,16 +3,50 @@
  * Shared by the VM detail modal, serial console, and (later) image install logs.
  */
 
+/**
+ * `navigator.clipboard.writeText` is async. On HTTP (LAN phone) and after an
+ * `await`, the user gesture is already gone, so a failed write-then-fallback
+ * never reaches `execCommand`. Only call the async API when it can succeed
+ * in this same turn.
+ */
+export function shouldPreferAsyncClipboard(
+  isSecureContext: boolean,
+  hasWriteText: boolean,
+): boolean {
+  return isSecureContext && hasWriteText;
+}
+
+/**
+ * iOS ignores `execCommand('copy')` when the source is off-screen (`left: -9999px`).
+ * Keep a 1×1 transparent node at the origin instead.
+ */
+export function prepareClipboardFallbackTextarea(area: HTMLTextAreaElement): void {
+  area.setAttribute("readonly", "");
+  area.setAttribute("aria-hidden", "true");
+  area.style.position = "fixed";
+  area.style.top = "0";
+  area.style.left = "0";
+  area.style.width = "1px";
+  area.style.height = "1px";
+  area.style.padding = "0";
+  area.style.border = "0";
+  area.style.outline = "none";
+  area.style.boxShadow = "none";
+  area.style.opacity = "0.01";
+  area.style.zIndex = "10000";
+}
+
 /** Copy `text` to the system clipboard. Returns false if the API is unavailable or rejects. */
 export async function copyText(text: string): Promise<boolean> {
   const value = text ?? "";
-  try {
-    if (navigator.clipboard?.writeText) {
+  const hasWriteText = typeof navigator.clipboard?.writeText === "function";
+  if (shouldPreferAsyncClipboard(window.isSecureContext, hasWriteText)) {
+    try {
       await navigator.clipboard.writeText(value);
       return true;
+    } catch {
+      /* fall through to execCommand — gesture may already be gone */
     }
-  } catch {
-    /* fall through to execCommand */
   }
   return copyTextFallback(value);
 }
@@ -22,18 +56,34 @@ function copyTextFallback(text: string): boolean {
   try {
     const area = document.createElement("textarea");
     area.value = text;
-    area.setAttribute("readonly", "");
-    area.style.position = "fixed";
-    area.style.left = "-9999px";
-    area.style.top = "0";
+    prepareClipboardFallbackTextarea(area);
     document.body.appendChild(area);
-    area.select();
+    selectFallbackTextarea(area, text);
     const ok = document.execCommand("copy");
     document.body.removeChild(area);
     return ok;
   } catch {
     return false;
   }
+}
+
+function selectFallbackTextarea(area: HTMLTextAreaElement, text: string): void {
+  const ios =
+    /ipad|iphone|ipod/i.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  if (ios) {
+    area.contentEditable = "true";
+    area.readOnly = false;
+    const range = document.createRange();
+    range.selectNodeContents(area);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    area.setSelectionRange(0, text.length);
+    return;
+  }
+  area.focus();
+  area.select();
 }
 
 /**

--- a/firecrab-frontend/tsconfig.app.json
+++ b/firecrab-frontend/tsconfig.app.json
@@ -23,5 +23,6 @@
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -81,9 +81,10 @@ npm run dev --prefix firecrab-frontend
 - Terminal chrome is light; the serial surface stays dark
 - Phone: inspect rail is capped and scrolls
 - SSH commands fill the remaining column and scroll
-- Serial: a finger or pen drag pans the buffer
+- Serial: a quick finger drag pans the buffer
+- A still hold opens the OS paste menu
+- Hold then drag selects text and copies it
 - A mouse drag on a desktop still selects text
-- Paste uses the clipboard, or a prompt on HTTP
 - Copy buttons skip `clipboard.writeText` on HTTP so `execCommand` still runs in the same tap
 - Inspect rail: four equal cards (general, specs, network, usage) then ports + storage; a bottom white bar toggles it
 - Terminal Network group: ipv4, ipv6 (`—` when the network is IPv4-only), mac, egress, network id

--- a/public-docs/dashboard.md
+++ b/public-docs/dashboard.md
@@ -79,6 +79,12 @@ npm run dev --prefix firecrab-frontend
   is often not the one that reaches the host from elsewhere
 - SHA256 is the guest `ssh_host_ed25519` key, not the PEM. First `ssh` prompt must match.
 - Terminal chrome is light; the serial surface stays dark
+- Phone: inspect rail is capped and scrolls
+- SSH commands fill the remaining column and scroll
+- Serial: a finger or pen drag pans the buffer
+- A mouse drag on a desktop still selects text
+- Paste uses the clipboard, or a prompt on HTTP
+- Copy buttons skip `clipboard.writeText` on HTTP so `execCommand` still runs in the same tap
 - Inspect rail: four equal cards (general, specs, network, usage) then ports + storage; a bottom white bar toggles it
 - Terminal Network group: ipv4, ipv6 (`—` when the network is IPv4-only), mac, egress, network id
 - List poll: 3 seconds


### PR DESCRIPTION
Closes #218

## Bug Fixes

- Phone console layout no longer clips SSH commands behind a full-height inspect rail
- Serial: a quick finger drag pans the buffer
- A still hold opens the OS paste menu; hold then drag selects and copies
- Copy buttons work on HTTP LAN: skip `clipboard.writeText` and use an on-screen `execCommand` fallback
- Copy key keeps the tap gesture by prefetching the PEM
- Failed copies show Failed instead of staying on Copy

## Tests

- Clipboard policy: async write only in a secure context; fallback textarea stays in the viewport
- Pointer pan vs hold: a quick drag pans; a still press stays hold for select/copy
- Linear cell range for `Terminal.select`

## Docs

- Dashboard notes for phone inspect cap, serial pan, hold paste, and hold-drag copy