### PR TITLE
feat(cli): add host api resources and service management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,8 @@ dependencies = [
  "clap",
  "firecrab-api-types",
  "firecrab-helper-protocol",
+ "futures-util",
+ "nix",
  "reqwest",
  "serde",
  "serde_json",
@@ -452,6 +454,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "uuid",
 ]
 
@@ -778,7 +781,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1446,7 +1449,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1940,8 +1943,12 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2092,6 +2099,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
 ]
@@ -2333,6 +2342,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/firecrab-api-types/src/lib.rs
+++ b/firecrab-api-types/src/lib.rs
@@ -111,7 +111,7 @@ impl VmState {
 }
 
 /// Body for `POST /api/vms`.
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct CreateVmRequest {
     /// 1–64 chars, alphanumeric plus `.`/`_`/`-`.
@@ -667,7 +667,7 @@ impl fmt::Display for Ipv6EgressMode {
 }
 
 /// Request body for `POST /api/micro-networks`.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateMicroNetworkRequest {
     /// 1–64 chars, alphanumeric plus `.`/`_`/`-` (same convention as VM names).
@@ -1333,6 +1333,14 @@ mod tests {
         assert_eq!(request.egress_policy, EgressPolicy::Internet);
         assert!(request.shell_ids.is_empty());
         assert!(request.env.is_empty());
+
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert_eq!(serialized["diskGb"], 2);
+        assert_eq!(serialized["egressPolicy"], "internet");
+        assert_eq!(
+            serialized["microNetworkId"],
+            "00000000-0000-0000-0000-000000000001"
+        );
     }
 
     #[test]
@@ -1776,6 +1784,10 @@ mod tests {
         assert_eq!(request.name, "prod");
         assert_eq!(request.subnet_cidr, "172.31.0.0/24");
         assert_eq!(request.uplink, None);
+
+        let serialized = serde_json::to_value(&request).unwrap();
+        assert_eq!(serialized["subnetCidr"], "172.31.0.0/24");
+        assert_eq!(serialized["internetEnabled"], true);
     }
 
     #[test]

--- a/firecrab-cli/Cargo.toml
+++ b/firecrab-cli/Cargo.toml
@@ -13,15 +13,16 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 firecrab-api-types = { path = "../firecrab-api-types" }
 firecrab-helper-protocol = { path = "../firecrab-helper-protocol" }
+futures-util = "0.3"
+nix = { version = "0.30", features = ["term", "user"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-thiserror = { workspace = true }
-# `framing` is async-only, so the apply path wraps it in a current-thread
-# runtime. doctor/info/status stay fully synchronous.
-tokio = { version = "1", features = ["rt", "net", "io-util", "time"] }
-uuid = { workspace = true, features = ["v4"] }
-
-[dev-dependencies]
 tempfile = "3.27.0"
+thiserror = { workspace = true }
+# Helper framing and the VM console are async-only, so their paths use
+# current-thread runtimes. doctor/info/status stay fully synchronous.
+tokio = { version = "1", features = ["rt", "net", "io-util", "io-std", "time", "macros"] }
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/firecrab-cli/src/api_client.rs
+++ b/firecrab-cli/src/api_client.rs
@@ -1,6 +1,13 @@
 use std::time::Duration;
 
 use firecrab_api_types::HostStatusResponse;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Default timeout for API reads and mutations.
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
+/// Short timeout used only by the host status probe.
+const HOST_STATUS_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Matches firecrab-api's own default (`bind_addr_or_default` in
 /// firecrab-api/src/server.rs) — the API listens on 127.0.0.1:5523 unless
@@ -26,6 +33,8 @@ impl std::fmt::Display for ApiError {
     }
 }
 
+impl std::error::Error for ApiError {}
+
 /// `--api` flag > `FIRECRAB_API` env > `DEFAULT_API_BASE`. Trailing slash
 /// stripped so callers can always do `format!("{base}/api/host")`.
 pub fn resolve_api_base(flag: Option<&str>) -> String {
@@ -43,54 +52,244 @@ pub fn resolve_api_base(flag: Option<&str>) -> String {
 /// Thin blocking HTTP client for firecrab-api, used by `status`/other
 /// subcommands that need live host data.
 pub struct ApiClient {
+    /// Resolved API origin without a trailing slash.
     base: String,
+    /// Shared blocking client with the normal API request timeout.
     client: reqwest::blocking::Client,
 }
 
 impl ApiClient {
     /// `base` is used as-is (no re-validation) — pass it through
-    /// [`resolve_api_base`] first. A 3s request timeout keeps `status`
-    /// responsive when the API is down rather than hanging.
+    /// [`resolve_api_base`] first. The 15s default is longer than the API's
+    /// own 10s request deadline so mutation requests can receive the API's
+    /// response instead of timing out first. [`Self::get_host_status`] keeps
+    /// its shorter 3s timeout so `status` stays responsive when the API is
+    /// down.
     pub fn new(base: String) -> Self {
         let client = reqwest::blocking::Client::builder()
-            .timeout(Duration::from_secs(3))
+            .timeout(DEFAULT_REQUEST_TIMEOUT)
             .build()
             .expect("reqwest client build");
         Self { base, client }
     }
 
+    /// Resolved API origin without a trailing slash.
+    pub fn base_url(&self) -> &str {
+        &self.base
+    }
+
     /// `GET {base}/api/host`, deserialized as `HostStatusResponse`.
     pub fn get_host_status(&self) -> Result<HostStatusResponse, ApiError> {
-        let url = format!("{}/api/host", self.base);
         let resp = self
             .client
-            .get(&url)
+            .get(self.url("/api/host"))
+            .timeout(HOST_STATUS_TIMEOUT)
             .send()
             .map_err(|e| ApiError::Unreachable(e.to_string()))?;
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().unwrap_or_default();
-            return Err(ApiError::Http {
-                status: status.as_u16(),
-                body,
-            });
-        }
-        resp.json::<HostStatusResponse>()
+        Self::decode_json(resp)
+    }
+
+    /// Sends a JSON `GET` request to an API path such as `/api/vms` and
+    /// deserializes any successful 2xx response body.
+    pub fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T, ApiError> {
+        let resp = self
+            .client
+            .get(self.url(path))
+            .send()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Self::decode_json(resp)
+    }
+
+    /// Sends a JSON `GET` request with URL-encoded query parameters and
+    /// deserializes any successful 2xx response body.
+    pub fn get_query<Q, T>(&self, path: &str, query: &Q) -> Result<T, ApiError>
+    where
+        Q: Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        let resp = self
+            .client
+            .get(self.url(path))
+            .query(query)
+            .send()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Self::decode_json(resp)
+    }
+
+    /// Sends `body` as JSON to an API path and deserializes any successful
+    /// 2xx response body.
+    pub fn post<B, T>(&self, path: &str, body: &B) -> Result<T, ApiError>
+    where
+        B: Serialize + ?Sized,
+        T: DeserializeOwned,
+    {
+        let resp = self
+            .client
+            .post(self.url(path))
+            .json(body)
+            .send()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Self::decode_json(resp)
+    }
+
+    /// Sends a body-less `POST` request to an API path and deserializes any
+    /// successful 2xx response body.
+    pub fn post_empty<T: DeserializeOwned>(&self, path: &str) -> Result<T, ApiError> {
+        let resp = self
+            .client
+            .post(self.url(path))
+            .send()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Self::decode_json(resp)
+    }
+
+    /// Sends a `DELETE` request to an API path. Any 2xx response, including
+    /// the API's usual `204 No Content`, is successful.
+    pub fn delete(&self, path: &str) -> Result<(), ApiError> {
+        let resp = self
+            .client
+            .delete(self.url(path))
+            .send()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Self::ensure_success(resp).map(|_| ())
+    }
+
+    /// Joins the resolved origin and an absolute API path.
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base)
+    }
+
+    /// Checks the status and decodes a successful JSON response.
+    fn decode_json<T: DeserializeOwned>(resp: reqwest::blocking::Response) -> Result<T, ApiError> {
+        Self::ensure_success(resp)?
+            .json::<T>()
             .map_err(|e| ApiError::Unreachable(format!("bad response body: {e}")))
+    }
+
+    /// Returns successful responses unchanged and captures error bodies.
+    fn ensure_success(
+        resp: reqwest::blocking::Response,
+    ) -> Result<reqwest::blocking::Response, ApiError> {
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(resp);
+        }
+
+        let body = resp
+            .text()
+            .map_err(|e| ApiError::Unreachable(e.to_string()))?;
+        Err(ApiError::Http {
+            status: status.as_u16(),
+            body,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
     use std::sync::Mutex;
+    use std::sync::mpsc::{self, Receiver};
+    use std::thread::{self, JoinHandle};
+
+    use serde::{Deserialize, Serialize};
 
     use super::*;
+
+    #[derive(Debug)]
+    struct CapturedRequest {
+        method: String,
+        path: String,
+        body: Vec<u8>,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct FixtureResponse {
+        value: String,
+    }
+
+    #[derive(Debug, Serialize)]
+    struct FixtureRequest<'a> {
+        name: &'a str,
+        count: u8,
+    }
 
     /// Serializes the two tests below that read/write the real
     /// `FIRECRAB_API` process env var — `std::env::set_var` is process-wide,
     /// so without this lock they'd race under `cargo test`'s parallel
     /// runner (one could observe the other's value mid-test).
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn serve_once(
+        status: &str,
+        content_type: Option<&str>,
+        body: &str,
+    ) -> (String, Receiver<CapturedRequest>, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let response_body = body.as_bytes().to_vec();
+        let status = status.to_owned();
+        let content_type = content_type.map(str::to_owned);
+        let (tx, rx) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let request = read_request(&mut stream);
+            tx.send(request).unwrap();
+
+            let mut headers = format!(
+                "HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n",
+                response_body.len()
+            );
+            if let Some(content_type) = content_type {
+                headers.push_str(&format!("Content-Type: {content_type}\r\n"));
+            }
+            headers.push_str("\r\n");
+            stream.write_all(headers.as_bytes()).unwrap();
+            stream.write_all(&response_body).unwrap();
+        });
+        (format!("http://{address}"), rx, handle)
+    }
+
+    fn read_request(stream: &mut TcpStream) -> CapturedRequest {
+        let mut bytes = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).unwrap();
+            assert!(read > 0, "connection closed before HTTP headers");
+            bytes.extend_from_slice(&chunk[..read]);
+            if let Some(position) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+                break position + 4;
+            }
+        };
+
+        let (method, path, content_length) = {
+            let headers = std::str::from_utf8(&bytes[..header_end]).unwrap();
+            let mut request_line = headers.lines().next().unwrap().split_whitespace();
+            let method = request_line.next().unwrap().to_owned();
+            let path = request_line.next().unwrap().to_owned();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap_or(0);
+            (method, path, content_length)
+        };
+        while bytes.len() < header_end + content_length {
+            let read = stream.read(&mut chunk).unwrap();
+            assert!(read > 0, "connection closed before HTTP body");
+            bytes.extend_from_slice(&chunk[..read]);
+        }
+
+        CapturedRequest {
+            method,
+            path,
+            body: bytes[header_end..header_end + content_length].to_vec(),
+        }
+    }
 
     #[test]
     fn resolve_api_base_prefers_flag() {
@@ -122,10 +321,153 @@ mod tests {
     #[test]
     fn unreachable_client_returns_unreachable_error() {
         // Port 1 is a reserved, never-listening port — connection refused
-        // fast, well inside the 3s timeout, so this test stays quick.
+        // fast, well inside either request timeout, so this test stays quick.
         let client = ApiClient::new("http://127.0.0.1:1".to_owned());
         let err = client.get_host_status().unwrap_err();
         assert!(matches!(err, ApiError::Unreachable(_)));
+    }
+
+    #[test]
+    fn get_sends_path_and_deserializes_json() {
+        let (base, requests, server) =
+            serve_once("200 OK", Some("application/json"), r#"{"value":"listed"}"#);
+        let client = ApiClient::new(base);
+
+        let response: FixtureResponse = client.get("/api/vms?state=running").unwrap();
+
+        assert_eq!(
+            response,
+            FixtureResponse {
+                value: "listed".to_owned()
+            }
+        );
+        let request = requests.recv().unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.path, "/api/vms?state=running");
+        assert!(request.body.is_empty());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn get_query_url_encodes_the_reference() {
+        let (base, requests, server) = serve_once(
+            "200 OK",
+            Some("application/json"),
+            r#"{"value":"inspected"}"#,
+        );
+        let client = ApiClient::new(base);
+
+        let response: FixtureResponse = client
+            .get_query(
+                "/api/oci/inspect",
+                &[("reference", "ghcr.io/org/app:v1@sha256:abc")],
+            )
+            .unwrap();
+
+        assert_eq!(response.value, "inspected");
+        let request = requests.recv().unwrap();
+        assert_eq!(request.method, "GET");
+        assert_eq!(
+            request.path,
+            "/api/oci/inspect?reference=ghcr.io%2Forg%2Fapp%3Av1%40sha256%3Aabc"
+        );
+        assert!(request.body.is_empty());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn post_sends_path_and_json_body_and_accepts_created() {
+        let (base, requests, server) = serve_once(
+            "201 Created",
+            Some("application/json"),
+            r#"{"value":"created"}"#,
+        );
+        let client = ApiClient::new(base);
+        let body = FixtureRequest {
+            name: "example",
+            count: 2,
+        };
+
+        let response: FixtureResponse = client.post("/api/vms", &body).unwrap();
+
+        assert_eq!(response.value, "created");
+        let request = requests.recv().unwrap();
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/api/vms");
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&request.body).unwrap(),
+            serde_json::json!({"name": "example", "count": 2})
+        );
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn post_empty_sends_no_body_and_deserializes_json() {
+        let (base, requests, server) =
+            serve_once("200 OK", Some("application/json"), r#"{"value":"started"}"#);
+        let client = ApiClient::new(base);
+
+        let response: FixtureResponse = client.post_empty("/api/vms/123/start").unwrap();
+
+        assert_eq!(response.value, "started");
+        let request = requests.recv().unwrap();
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/api/vms/123/start");
+        assert!(request.body.is_empty());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn delete_accepts_no_content_and_sends_expected_request() {
+        let (base, requests, server) = serve_once("204 No Content", None, "");
+        let client = ApiClient::new(base);
+
+        client.delete("/api/micro-networks/123").unwrap();
+
+        let request = requests.recv().unwrap();
+        assert_eq!(request.method, "DELETE");
+        assert_eq!(request.path, "/api/micro-networks/123");
+        assert!(request.body.is_empty());
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn non_success_response_preserves_body_verbatim() {
+        let body = "  validation failed\n{not-json}\n";
+        let (base, _requests, server) = serve_once("422 Unprocessable Entity", None, body);
+        let client = ApiClient::new(base);
+
+        let err = client.get::<FixtureResponse>("/api/vms").unwrap_err();
+
+        match err {
+            ApiError::Http {
+                status,
+                body: actual,
+            } => {
+                assert_eq!(status, 422);
+                assert_eq!(actual, body);
+            }
+            ApiError::Unreachable(message) => panic!("unexpected transport error: {message}"),
+        }
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn invalid_success_json_is_an_unreachable_error() {
+        let (base, _requests, server) = serve_once("200 OK", Some("application/json"), "not-json");
+        let client = ApiClient::new(base);
+
+        let err = client.get::<FixtureResponse>("/api/vms").unwrap_err();
+
+        match err {
+            ApiError::Unreachable(message) => {
+                assert!(message.starts_with("bad response body:"));
+            }
+            ApiError::Http { status, body } => {
+                panic!("unexpected HTTP error {status}: {body}")
+            }
+        }
+        server.join().unwrap();
     }
 
     #[test]

--- a/firecrab-cli/src/host_api_tests.rs
+++ b/firecrab-cli/src/host_api_tests.rs
@@ -1,0 +1,318 @@
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+use clap::Parser;
+use serde_json::{Value, json};
+
+use super::{Cli, run};
+
+const VM_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const NETWORK_ID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+struct CapturedRequest {
+    method: String,
+    path: String,
+    content_type: Option<String>,
+    body: Vec<u8>,
+}
+
+fn run_once(args: &[&str], status: &str, body: &str) -> (i32, CapturedRequest) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let base = format!("http://{}", listener.local_addr().unwrap());
+    let status = status.to_owned();
+    let response = body.as_bytes().to_vec();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let request = read_request(&mut stream);
+        write!(
+            stream,
+            "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            response.len()
+        )
+        .unwrap();
+        stream.write_all(&response).unwrap();
+        request
+    });
+
+    let mut argv = vec!["firecrab", "--api", base.as_str()];
+    argv.extend_from_slice(args);
+    let code = run(Cli::try_parse_from(argv).unwrap());
+    (code, server.join().unwrap())
+}
+
+fn read_request(stream: &mut TcpStream) -> CapturedRequest {
+    let mut bytes = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).unwrap();
+        assert!(read > 0, "connection closed before HTTP headers");
+        bytes.extend_from_slice(&chunk[..read]);
+        if let Some(position) = bytes.windows(4).position(|part| part == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+
+    let headers = std::str::from_utf8(&bytes[..header_end]).unwrap();
+    let mut request_line = headers.lines().next().unwrap().split_whitespace();
+    let method = request_line.next().unwrap().to_owned();
+    let path = request_line.next().unwrap().to_owned();
+    let header = |wanted: &str| {
+        headers.lines().find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case(wanted)
+                .then(|| value.trim().to_owned())
+        })
+    };
+    let content_type = header("content-type");
+    let content_length = header("content-length")
+        .map(|value| value.parse::<usize>().unwrap())
+        .unwrap_or(0);
+
+    while bytes.len() < header_end + content_length {
+        let read = stream.read(&mut chunk).unwrap();
+        assert!(read > 0, "connection closed before HTTP body");
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+
+    CapturedRequest {
+        method,
+        path,
+        content_type,
+        body: bytes[header_end..header_end + content_length].to_vec(),
+    }
+}
+
+fn network_response() -> Value {
+    json!({
+        "id": NETWORK_ID,
+        "name": "lab",
+        "subnetCidr": "172.31.0.0/24",
+        "gateway": "172.31.0.1",
+        "internetEnabled": true,
+        "uplink": null,
+        "ipv6Cidr": null,
+        "ipv6Gateway": null,
+        "ipv6AddressMode": null,
+        "ipv6Egress": null
+    })
+}
+
+fn vm_response() -> Value {
+    json!({
+        "id": VM_ID,
+        "name": "web-1",
+        "state": "created",
+        "template": "alpine-3.24.1",
+        "templateVersion": "3.24.1",
+        "cpu": 1,
+        "ram": 512,
+        "diskGb": 2,
+        "startupStep": null,
+        "startupTimeline": [],
+        "egressPolicy": "internet",
+        "ipv4": "172.31.0.10",
+        "ipv6": null,
+        "mac": "02:fc:00:00:00:01",
+        "hostname": "fc-aaaaaaaaaaaa",
+        "microNetworkId": NETWORK_ID,
+        "storageRoot": "default",
+        "cpuUsagePercent": null,
+        "memoryUsedMib": null,
+        "memoryTotalMib": null,
+        "memoryUsedPercent": null,
+        "usageHistory": [],
+        "shellRefs": [],
+        "portForwards": [],
+        "env": {}
+    })
+}
+
+fn oci_inspect_response() -> Value {
+    json!({
+        "registry": "docker.io",
+        "repository": "library/nginx",
+        "version": "1.27",
+        "immutable": false,
+        "digest": "sha256:abc",
+        "architecture": "amd64",
+        "singlePlatform": false,
+        "alias": "nginx-1.27"
+    })
+}
+
+fn oci_import_response(status: &str, log: &str) -> Value {
+    json!({
+        "alias": "nginx-1.27",
+        "status": status,
+        "log": log,
+        "startedAtMs": 1
+    })
+}
+
+#[test]
+fn image_list_uses_the_catalog_endpoint() {
+    let response = json!([{
+        "alias": "alpine-3.24.1",
+        "version": "3.24.1",
+        "kernelSha256": "kernel",
+        "rootfsSha256": "rootfs",
+        "minDiskGb": 2,
+        "rootfsSizeBytes": 1024,
+        "installed": true,
+        "packageStaged": false,
+        "description": "Alpine",
+        "hasGuestService": false
+    }])
+    .to_string();
+    let (code, request) = run_once(&["image", "list"], "200 OK", &response);
+
+    assert_eq!(code, 0);
+    assert_eq!(request.method, "GET");
+    assert_eq!(request.path, "/api/images");
+}
+
+#[test]
+fn oci_image_commands_match_inspect_import_and_status_endpoints() {
+    let inspect_body = oci_inspect_response().to_string();
+    let (code, inspect) = run_once(
+        &["image", "inspect", "nginx:1.27", "--json"],
+        "200 OK",
+        &inspect_body,
+    );
+    assert_eq!(code, 0);
+    assert_eq!(inspect.method, "GET");
+    assert_eq!(inspect.path, "/api/oci/inspect?reference=nginx%3A1.27");
+
+    let import_body = oci_import_response("running", "import started").to_string();
+    let (code, import) = run_once(
+        &["image", "import", "nginx:1.27"],
+        "202 Accepted",
+        &import_body,
+    );
+    assert_eq!(code, 0);
+    assert_eq!(
+        (import.method.as_str(), import.path.as_str()),
+        ("POST", "/api/oci/import")
+    );
+    assert_eq!(import.content_type.as_deref(), Some("application/json"));
+    assert_eq!(
+        serde_json::from_slice::<Value>(&import.body).unwrap(),
+        json!({"reference": "nginx:1.27"})
+    );
+
+    let failed_body = oci_import_response("failed", "registry rejected blob").to_string();
+    let (code, status) = run_once(
+        &["image", "import-status", "nginx-1.27", "--json"],
+        "200 OK",
+        &failed_body,
+    );
+    assert_eq!(code, 1);
+    assert_eq!(status.method, "GET");
+    assert_eq!(status.path, "/api/oci/import/nginx-1.27");
+}
+
+#[test]
+fn network_commands_match_the_micro_network_api() {
+    let list_body = json!([network_response()]).to_string();
+    let (code, list) = run_once(&["network", "list"], "200 OK", &list_body);
+    assert_eq!(code, 0);
+    assert_eq!(
+        (list.method.as_str(), list.path.as_str()),
+        ("GET", "/api/micro-networks")
+    );
+
+    let create_body = network_response().to_string();
+    let (code, create) = run_once(
+        &[
+            "network",
+            "create",
+            "--name",
+            "lab",
+            "--subnet-cidr",
+            "172.31.0.0/24",
+            "--json",
+        ],
+        "201 Created",
+        &create_body,
+    );
+    assert_eq!(code, 0);
+    assert_eq!(
+        (create.method.as_str(), create.path.as_str()),
+        ("POST", "/api/micro-networks")
+    );
+    assert_eq!(create.content_type.as_deref(), Some("application/json"));
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(body["name"], "lab");
+    assert_eq!(body["subnetCidr"], "172.31.0.0/24");
+    assert_eq!(body["internetEnabled"], true);
+
+    let (code, delete) = run_once(
+        &["network", "delete", NETWORK_ID, "--json"],
+        "204 No Content",
+        "",
+    );
+    assert_eq!(code, 0);
+    assert_eq!(
+        (delete.method.as_str(), delete.path.as_str()),
+        (
+            "DELETE",
+            format!("/api/micro-networks/{NETWORK_ID}").as_str()
+        )
+    );
+}
+
+#[test]
+fn vm_commands_match_the_lifecycle_api() {
+    let list_body = json!([vm_response()]).to_string();
+    let (code, list) = run_once(&["vm", "list", "--json"], "200 OK", &list_body);
+    assert_eq!(code, 0);
+    assert_eq!(
+        (list.method.as_str(), list.path.as_str()),
+        ("GET", "/api/vms")
+    );
+
+    let vm_body = vm_response().to_string();
+    let (code, create) = run_once(
+        &[
+            "vm",
+            "create",
+            "--name",
+            "web-1",
+            "--template",
+            "alpine-3.24.1",
+            "--network",
+            NETWORK_ID,
+        ],
+        "201 Created",
+        &vm_body,
+    );
+    assert_eq!(code, 0);
+    assert_eq!(
+        (create.method.as_str(), create.path.as_str()),
+        ("POST", "/api/vms")
+    );
+    assert_eq!(create.content_type.as_deref(), Some("application/json"));
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(body["name"], "web-1");
+    assert_eq!(body["microNetworkId"], NETWORK_ID);
+    assert_eq!(body["egressPolicy"], "internet");
+
+    for action in ["start", "stop"] {
+        let expected_path = format!("/api/vms/{VM_ID}/{action}");
+        let (code, request) = run_once(&["vm", action, VM_ID, "--json"], "200 OK", &vm_body);
+        assert_eq!(code, 0);
+        assert_eq!(
+            (request.method.as_str(), request.path.as_str()),
+            ("POST", expected_path.as_str())
+        );
+        assert!(request.body.is_empty());
+    }
+
+    let (code, delete) = run_once(&["vm", "delete", VM_ID], "204 No Content", "");
+    assert_eq!(code, 0);
+    assert_eq!(
+        (delete.method.as_str(), delete.path.as_str()),
+        ("DELETE", format!("/api/vms/{VM_ID}").as_str())
+    );
+}

--- a/firecrab-cli/src/image.rs
+++ b/firecrab-cli/src/image.rs
@@ -1,0 +1,340 @@
+use std::fmt::Write;
+
+use clap::Subcommand;
+use firecrab_api_types::{
+    ImageInstallResponse, ImageInstallStatus, ImageResponse, OciImportRequest, OciInspectResponse,
+};
+
+use crate::api_client::{ApiClient, ApiError};
+
+/// Template image operations exposed by `firecrab image`.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// List known template images and their local install state.
+    List {
+        /// Emit the API response as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Resolve an OCI reference without downloading its layers.
+    Inspect {
+        /// OCI reference accepted by `docker pull`, such as `nginx:1.27`.
+        reference: String,
+        /// Emit the inspection response as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Start a background OCI import.
+    Import {
+        /// OCI reference accepted by `docker pull`, such as `nginx:1.27`.
+        reference: String,
+        /// Emit the initial import snapshot as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the latest background OCI import snapshot.
+    ImportStatus {
+        /// Derived image alias returned by `image inspect` or `image import`.
+        alias: String,
+        /// Emit the import snapshot as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Errors produced while executing an image command.
+#[derive(Debug)]
+pub enum Error {
+    /// HTTP, transport, or response decoding failure.
+    Api(ApiError),
+    /// A background OCI import reached the failed state.
+    ImportFailed { alias: String, detail: String },
+}
+
+impl From<ApiError> for Error {
+    fn from(value: ApiError) -> Self {
+        Self::Api(value)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Api(error) => error.fmt(f),
+            Self::ImportFailed { alias, detail } => {
+                write!(f, "OCI import {alias} failed: {detail}")
+            }
+        }
+    }
+}
+
+/// Executes one image command through the host API.
+pub fn run(client: &ApiClient, command: Command) -> Result<(), Error> {
+    match command {
+        Command::List { json } => {
+            let images: Vec<ImageResponse> = client.get("/api/images")?;
+            if json {
+                print_json(&images);
+            } else {
+                print!("{}", format_list(&images));
+            }
+        }
+        Command::Inspect { reference, json } => {
+            let inspect: OciInspectResponse =
+                client.get_query("/api/oci/inspect", &[("reference", reference.as_str())])?;
+            if json {
+                print_json(&inspect);
+            } else {
+                print!("{}", format_inspect(&inspect));
+            }
+        }
+        Command::Import { reference, json } => {
+            let snapshot: ImageInstallResponse =
+                client.post("/api/oci/import", &OciImportRequest { reference })?;
+            print_import_snapshot(&snapshot, json);
+            ensure_import_succeeded_or_active(&snapshot)?;
+        }
+        Command::ImportStatus { alias, json } => {
+            let snapshot: ImageInstallResponse = client.get(&format!("/api/oci/import/{alias}"))?;
+            print_import_snapshot(&snapshot, json);
+            ensure_import_succeeded_or_active(&snapshot)?;
+        }
+    }
+    Ok(())
+}
+
+fn print_json(value: &(impl serde::Serialize + ?Sized)) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).expect("API response serializes")
+    );
+}
+
+fn format_list(images: &[ImageResponse]) -> String {
+    let mut output = String::from("ALIAS\tVERSION\tINSTALLED\tMIN_DISK_GIB\tPACKAGE\n");
+    for image in images {
+        let package = if image.package_staged {
+            "staged"
+        } else if image.package_url.is_some() {
+            "available"
+        } else {
+            "-"
+        };
+        output.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\n",
+            image.alias,
+            image.version,
+            if image.installed { "yes" } else { "no" },
+            image.min_disk_gb,
+            package
+        ));
+    }
+    output
+}
+
+fn format_inspect(inspect: &OciInspectResponse) -> String {
+    let mut output = String::new();
+    writeln!(output, "OCI IMAGE {}", inspect.alias).unwrap();
+    writeln!(output, "  registry:        {}", inspect.registry).unwrap();
+    writeln!(output, "  repository:      {}", inspect.repository).unwrap();
+    writeln!(output, "  version:         {}", inspect.version).unwrap();
+    writeln!(output, "  digest:          {}", inspect.digest).unwrap();
+    writeln!(output, "  architecture:    {}", inspect.architecture).unwrap();
+    writeln!(
+        output,
+        "  immutable:       {}",
+        if inspect.immutable { "yes" } else { "no" }
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  single platform: {}",
+        if inspect.single_platform { "yes" } else { "no" }
+    )
+    .unwrap();
+    output
+}
+
+fn print_import_snapshot(snapshot: &ImageInstallResponse, json: bool) {
+    if json {
+        print_json(snapshot);
+    } else {
+        print!("{}", format_import_snapshot(snapshot));
+    }
+}
+
+fn format_import_snapshot(snapshot: &ImageInstallResponse) -> String {
+    let mut output = format!(
+        "OCI import {}: {}\n",
+        snapshot.alias,
+        install_status(snapshot.status)
+    );
+    if !snapshot.log.trim().is_empty() {
+        output.push_str("  log:\n");
+        for line in snapshot.log.lines() {
+            writeln!(output, "    {line}").unwrap();
+        }
+    }
+    if snapshot.status == ImageInstallStatus::Running {
+        writeln!(
+            output,
+            "  poll: firecrab image import-status {}",
+            snapshot.alias
+        )
+        .unwrap();
+    }
+    output
+}
+
+fn install_status(status: ImageInstallStatus) -> &'static str {
+    match status {
+        ImageInstallStatus::Idle => "idle",
+        ImageInstallStatus::Running => "running",
+        ImageInstallStatus::Succeeded => "succeeded",
+        ImageInstallStatus::Failed => "failed",
+    }
+}
+
+fn ensure_import_succeeded_or_active(snapshot: &ImageInstallResponse) -> Result<(), Error> {
+    if snapshot.status != ImageInstallStatus::Failed {
+        return Ok(());
+    }
+    let detail = snapshot
+        .log
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("no failure detail returned")
+        .trim()
+        .to_owned();
+    Err(Error::ImportFailed {
+        alias: snapshot.alias.clone(),
+        detail,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: Command,
+    }
+
+    fn image(installed: bool, staged: bool) -> ImageResponse {
+        ImageResponse {
+            alias: "alpine-3.24.1".to_owned(),
+            version: "3.24.1".to_owned(),
+            kernel_sha256: String::new(),
+            rootfs_sha256: String::new(),
+            initrd_sha256: None,
+            min_disk_gb: 2,
+            rootfs_size_bytes: 0,
+            installed,
+            package_url: Some("https://example.test/alpine.tar.zst".to_owned()),
+            package_staged: staged,
+            package_origin: None,
+            description: "Alpine".to_owned(),
+            has_guest_service: false,
+        }
+    }
+
+    #[test]
+    fn empty_list_still_has_a_header() {
+        assert_eq!(
+            format_list(&[]),
+            "ALIAS\tVERSION\tINSTALLED\tMIN_DISK_GIB\tPACKAGE\n"
+        );
+    }
+
+    #[test]
+    fn list_formats_install_and_package_state() {
+        let output = format_list(&[image(true, false), image(false, true)]);
+        assert!(output.contains("alpine-3.24.1\t3.24.1\tyes\t2\tavailable"));
+        assert!(output.contains("alpine-3.24.1\t3.24.1\tno\t2\tstaged"));
+    }
+
+    #[test]
+    fn oci_commands_parse_reference_alias_and_json() {
+        let inspect = TestCli::try_parse_from(["test", "inspect", "nginx:1.27", "--json"]).unwrap();
+        assert!(matches!(
+            inspect.command,
+            Command::Inspect {
+                reference,
+                json: true
+            } if reference == "nginx:1.27"
+        ));
+
+        let import = TestCli::try_parse_from(["test", "import", "nginx:1.27"]).unwrap();
+        assert!(matches!(
+            import.command,
+            Command::Import {
+                reference,
+                json: false
+            } if reference == "nginx:1.27"
+        ));
+
+        let status = TestCli::try_parse_from(["test", "import-status", "nginx-1.27"]).unwrap();
+        assert!(matches!(
+            status.command,
+            Command::ImportStatus {
+                alias,
+                json: false
+            } if alias == "nginx-1.27"
+        ));
+    }
+
+    #[test]
+    fn inspect_human_includes_resolved_manifest_and_alias() {
+        let output = format_inspect(&OciInspectResponse {
+            registry: "docker.io".to_owned(),
+            repository: "library/nginx".to_owned(),
+            version: "1.27".to_owned(),
+            immutable: false,
+            digest: "sha256:abc".to_owned(),
+            architecture: "amd64".to_owned(),
+            single_platform: false,
+            alias: "nginx-1.27".to_owned(),
+        });
+        assert!(output.contains("OCI IMAGE nginx-1.27"));
+        assert!(output.contains("repository:      library/nginx"));
+        assert!(output.contains("digest:          sha256:abc"));
+        assert!(output.contains("architecture:    amd64"));
+    }
+
+    #[test]
+    fn running_import_names_the_poll_command() {
+        let output = format_import_snapshot(&import_snapshot(ImageInstallStatus::Running));
+        assert!(output.contains("OCI import nginx-1.27: running"));
+        assert!(output.contains("firecrab image import-status nginx-1.27"));
+    }
+
+    #[test]
+    fn failed_import_uses_the_last_non_empty_log_line() {
+        let error = ensure_import_succeeded_or_active(&ImageInstallResponse {
+            log: "pulling layers\n\nregistry rejected blob\n".to_owned(),
+            ..import_snapshot(ImageInstallStatus::Failed)
+        })
+        .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "OCI import nginx-1.27 failed: registry rejected blob"
+        );
+    }
+
+    fn import_snapshot(status: ImageInstallStatus) -> ImageInstallResponse {
+        ImageInstallResponse {
+            alias: "nginx-1.27".to_owned(),
+            status,
+            log: "import started".to_owned(),
+            started_at_ms: Some(1),
+            ended_at_ms: None,
+            downloaded_bytes: None,
+            total_bytes: None,
+        }
+    }
+}

--- a/firecrab-cli/src/main.rs
+++ b/firecrab-cli/src/main.rs
@@ -7,6 +7,7 @@ mod host_api_tests;
 mod image;
 mod info;
 mod network;
+mod service;
 mod shell;
 mod status;
 mod update;
@@ -74,6 +75,11 @@ enum Command {
         #[command(subcommand)]
         command: image::Command,
     },
+    /// Install, remove, or control the firecrab host services.
+    Service {
+        #[command(subcommand)]
+        command: service::Command,
+    },
 }
 
 fn main() {
@@ -105,6 +111,13 @@ fn run(cli: Cli) -> i32 {
             let client = build_api_client(api.as_deref());
             finish_api_command(image::run(&client, command))
         }
+        Command::Service { command } => match service::run(&shell::RealCommandRunner, command) {
+            Ok(()) => 0,
+            Err(error) => {
+                error.report();
+                1
+            }
+        },
     }
 }
 
@@ -464,4 +477,73 @@ mod tests {
         assert_eq!(code, 1);
     }
 
+    #[test]
+    fn cli_parses_service_commands() {
+        let install = Cli::try_parse_from([
+            "firecrab",
+            "service",
+            "install",
+            "--version",
+            "v0.3.0",
+            "--libc",
+            "musl",
+            "--bin-dir",
+            "target/release",
+            "--dashboard-dir",
+            "firecrab-frontend/dist",
+            "--no-deps",
+            "--no-frontend",
+            "--check",
+        ])
+        .unwrap();
+        match install.command {
+            Command::Service {
+                command: service::Command::Install(opts),
+            } => {
+                assert_eq!(opts.version.as_deref(), Some("v0.3.0"));
+                assert_eq!(opts.libc.as_deref(), Some("musl"));
+                assert_eq!(
+                    opts.bin_dir.as_deref(),
+                    Some(std::path::Path::new("target/release"))
+                );
+                assert_eq!(
+                    opts.dashboard_dir.as_deref(),
+                    Some(std::path::Path::new("firecrab-frontend/dist"))
+                );
+                assert!(opts.no_deps && opts.no_frontend && opts.check);
+            }
+            _ => panic!("expected service install"),
+        }
+
+        let uninstall =
+            Cli::try_parse_from(["firecrab", "service", "uninstall", "--purge"]).unwrap();
+        assert!(matches!(
+            uninstall.command,
+            Command::Service {
+                command: service::Command::Uninstall { purge: true }
+            }
+        ));
+
+        let reinstall =
+            Cli::try_parse_from(["firecrab", "service", "reinstall", "--purge"]).unwrap();
+        assert!(matches!(
+            reinstall.command,
+            Command::Service {
+                command: service::Command::Reinstall { purge: true, .. }
+            }
+        ));
+
+        for verb in ["start", "stop", "restart", "enable", "disable"] {
+            assert!(
+                Cli::try_parse_from(["firecrab", "service", verb]).is_ok(),
+                "failed to parse service {verb}"
+            );
+        }
+        assert!(
+            Cli::try_parse_from(["firecrab", "service", "install", "--dashboard-dir", "x"])
+                .is_err(),
+            "--dashboard-dir requires --bin-dir"
+        );
+        assert!(Cli::try_parse_from(["firecrab", "service", "bogus"]).is_err());
+    }
 }

--- a/firecrab-cli/src/main.rs
+++ b/firecrab-cli/src/main.rs
@@ -2,15 +2,24 @@ use clap::{Parser, Subcommand};
 
 mod api_client;
 mod doctor;
+#[cfg(test)]
+mod host_api_tests;
+mod image;
 mod info;
+mod network;
 mod shell;
 mod status;
 mod update;
+mod vm;
+mod vm_console;
 
 /// `clap`-derived top-level CLI, replacing `scripts/firecrab-doctor.sh`.
 #[derive(Parser)]
 #[command(name = "firecrab", version, about = "firecrab host CLI")]
 struct Cli {
+    /// Override the API base URL (else FIRECRAB_API, else http://127.0.0.1:5523).
+    #[arg(long, global = true, value_name = "URL")]
+    api: Option<String>,
     #[command(subcommand)]
     command: Command,
 }
@@ -31,18 +40,12 @@ enum Command {
         /// Emit the [`info::InfoReport`] as JSON instead of the human format.
         #[arg(long)]
         json: bool,
-        /// Override the API base URL (else FIRECRAB_API, else http://127.0.0.1:5523).
-        #[arg(long)]
-        api: Option<String>,
     },
     /// Show systemd unit status and the API host status.
     Status {
         /// Emit the [`status::StatusReport`] as JSON instead of the human format.
         #[arg(long)]
         json: bool,
-        /// Override the API base URL (else FIRECRAB_API, else http://127.0.0.1:5523).
-        #[arg(long)]
-        api: Option<String>,
     },
     /// Check for a newer firecrab release, and optionally install it.
     Update {
@@ -56,16 +59,65 @@ enum Command {
         #[arg(long)]
         json: bool,
     },
+    /// Manage MicroVMs through the host API.
+    Vm {
+        #[command(subcommand)]
+        command: vm::Command,
+    },
+    /// Manage MicroNetworks through the host API.
+    Network {
+        #[command(subcommand)]
+        command: network::Command,
+    },
+    /// Inspect template images through the host API.
+    Image {
+        #[command(subcommand)]
+        command: image::Command,
+    },
 }
 
 fn main() {
-    let cli = Cli::parse();
-    match cli.command {
-        Command::Doctor { digest, json } => std::process::exit(run_doctor(digest, json)),
-        Command::Info { json, api } => run_info(json, api),
-        Command::Status { json, api } => run_status(json, api),
-        Command::Update { check, apply, json } => {
-            std::process::exit(run_update(check, apply, json))
+    std::process::exit(run(Cli::parse()));
+}
+
+fn run(cli: Cli) -> i32 {
+    let Cli { api, command } = cli;
+    match command {
+        Command::Doctor { digest, json } => run_doctor(digest, json),
+        Command::Info { json } => {
+            run_info(json, api);
+            0
+        }
+        Command::Status { json } => {
+            run_status(json, api);
+            0
+        }
+        Command::Update { check, apply, json } => run_update(check, apply, json),
+        Command::Vm { command } => {
+            let client = build_api_client(api.as_deref());
+            finish_api_command(vm::run(&client, command))
+        }
+        Command::Network { command } => {
+            let client = build_api_client(api.as_deref());
+            finish_api_command(network::run(&client, command))
+        }
+        Command::Image { command } => {
+            let client = build_api_client(api.as_deref());
+            finish_api_command(image::run(&client, command))
+        }
+    }
+}
+
+fn build_api_client(api: Option<&str>) -> api_client::ApiClient {
+    api_client::ApiClient::new(api_client::resolve_api_base(api))
+}
+
+fn finish_api_command<E: std::fmt::Display>(result: Result<(), E>) -> i32 {
+    match result {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("{error}");
+            1
         }
     }
 }
@@ -222,10 +274,10 @@ mod tests {
     #[test]
     fn cli_parses_info_api_flag() {
         let cli = Cli::try_parse_from(["firecrab", "info", "--api", "http://x:1"]).unwrap();
+        assert_eq!(cli.api.as_deref(), Some("http://x:1"));
         match cli.command {
-            Command::Info { json, api } => {
+            Command::Info { json } => {
                 assert!(!json);
-                assert_eq!(api.as_deref(), Some("http://x:1"));
             }
             _ => panic!("expected Info"),
         }
@@ -234,13 +286,8 @@ mod tests {
     #[test]
     fn cli_parses_status_subcommand() {
         let cli = Cli::try_parse_from(["firecrab", "status"]).unwrap();
-        assert!(matches!(
-            cli.command,
-            Command::Status {
-                json: false,
-                api: None
-            }
-        ));
+        assert!(matches!(cli.command, Command::Status { json: false }));
+        assert!(cli.api.is_none());
     }
 
     #[test]
@@ -301,4 +348,120 @@ mod tests {
         unsafe { std::env::remove_var("FIRECRAB_RELEASE_API") };
         assert!(code == 0 || code == 1, "unexpected exit code {code}");
     }
+
+    #[test]
+    fn cli_parses_vm_commands() {
+        let list = Cli::try_parse_from([
+            "firecrab",
+            "vm",
+            "list",
+            "--json",
+            "--api",
+            "http://host.test:5523",
+        ])
+        .unwrap();
+        assert_eq!(list.api.as_deref(), Some("http://host.test:5523"));
+        assert!(matches!(
+            list.command,
+            Command::Vm {
+                command: vm::Command::List { json: true }
+            }
+        ));
+
+        let create = Cli::try_parse_from([
+            "firecrab",
+            "--api",
+            "http://host.test:5523",
+            "vm",
+            "create",
+            "--name",
+            "demo",
+            "--template",
+            "alpine-3.24.1",
+            "--network",
+            "11111111-1111-4111-8111-111111111111",
+        ])
+        .unwrap();
+        assert_eq!(create.api.as_deref(), Some("http://host.test:5523"));
+        assert!(matches!(
+            create.command,
+            Command::Vm {
+                command: vm::Command::Create {
+                    cpu: 1,
+                    ram: 512,
+                    disk_gb: 2,
+                    ..
+                }
+            }
+        ));
+
+        for action in ["start", "stop", "delete"] {
+            assert!(
+                Cli::try_parse_from([
+                    "firecrab",
+                    "vm",
+                    action,
+                    "11111111-1111-4111-8111-111111111111"
+                ])
+                .is_ok(),
+                "failed to parse vm {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn cli_parses_network_commands() {
+        assert!(Cli::try_parse_from(["firecrab", "network", "list"]).is_ok());
+        assert!(
+            Cli::try_parse_from([
+                "firecrab",
+                "network",
+                "create",
+                "--name",
+                "lab",
+                "--subnet-cidr",
+                "172.31.0.0/24"
+            ])
+            .is_ok()
+        );
+        assert!(
+            Cli::try_parse_from([
+                "firecrab",
+                "network",
+                "delete",
+                "11111111-1111-4111-8111-111111111111"
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn cli_parses_image_list() {
+        assert!(matches!(
+            Cli::try_parse_from(["firecrab", "image", "list", "--json"])
+                .unwrap()
+                .command,
+            Command::Image {
+                command: image::Command::List { json: true }
+            }
+        ));
+    }
+
+    #[test]
+    fn cli_rejects_missing_create_arguments_and_bad_uuid() {
+        assert!(Cli::try_parse_from(["firecrab", "vm", "create"]).is_err());
+        assert!(Cli::try_parse_from(["firecrab", "network", "create"]).is_err());
+        assert!(Cli::try_parse_from(["firecrab", "vm", "start", "not-a-uuid"]).is_err());
+    }
+
+    #[test]
+    fn api_command_failure_returns_non_zero() {
+        let code =
+            run(
+                Cli::try_parse_from(["firecrab", "--api", "http://127.0.0.1:1", "image", "list"])
+                    .unwrap(),
+            );
+        assert_eq!(code, 1);
+    }
+
 }

--- a/firecrab-cli/src/network.rs
+++ b/firecrab-cli/src/network.rs
@@ -1,0 +1,156 @@
+use clap::Subcommand;
+use firecrab_api_types::{CreateMicroNetworkRequest, MicroNetworkResponse};
+use uuid::Uuid;
+
+use crate::api_client::{ApiClient, ApiError};
+
+/// MicroNetwork operations exposed by `firecrab network`.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// List every MicroNetwork on the host.
+    List {
+        /// Emit the API response as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Create a MicroNetwork.
+    Create {
+        /// Network name.
+        #[arg(long)]
+        name: String,
+        /// Reserved IPv4 CIDR block, for example 172.31.0.0/24.
+        #[arg(long, value_name = "CIDR")]
+        subnet_cidr: String,
+        /// Emit the created network as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete an empty MicroNetwork.
+    Delete {
+        /// MicroNetwork UUID.
+        id: Uuid,
+        /// Emit a JSON deletion receipt.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Executes one MicroNetwork command through the host API.
+pub fn run(client: &ApiClient, command: Command) -> Result<(), ApiError> {
+    match command {
+        Command::List { json } => {
+            let networks: Vec<MicroNetworkResponse> = client.get("/api/micro-networks")?;
+            if json {
+                print_json(&networks);
+            } else {
+                print!("{}", format_list(&networks));
+            }
+        }
+        Command::Create {
+            name,
+            subnet_cidr,
+            json,
+        } => {
+            let request = CreateMicroNetworkRequest {
+                name,
+                subnet_cidr,
+                internet_enabled: true,
+                uplink: None,
+                ipv6_cidr: None,
+                ipv6_address_mode: None,
+            };
+            let network: MicroNetworkResponse = client.post("/api/micro-networks", &request)?;
+            if json {
+                print_json(&network);
+            } else {
+                println!("{}", format_one("created", &network));
+            }
+        }
+        Command::Delete { id, json } => {
+            client.delete(&format!("/api/micro-networks/{id}"))?;
+            if json {
+                print_json(&serde_json::json!({ "deleted": id }));
+            } else {
+                println!("deleted network {id}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn print_json(value: &impl serde::Serialize) {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(value).expect("API response serializes")
+    );
+}
+
+fn format_list(networks: &[MicroNetworkResponse]) -> String {
+    let mut output = String::from("ID\tNAME\tSUBNET\tGATEWAY\tINTERNET\tUPLINK\n");
+    for network in networks {
+        output.push_str(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}\n",
+            network.id,
+            network.name,
+            network.subnet_cidr,
+            network.gateway,
+            if network.internet_enabled {
+                "yes"
+            } else {
+                "no"
+            },
+            network.uplink.as_deref().unwrap_or("auto")
+        ));
+    }
+    output
+}
+
+fn format_one(action: &str, network: &MicroNetworkResponse) -> String {
+    format!(
+        "{action} network {} ({}, {}, gateway {})",
+        network.id, network.name, network.subnet_cidr, network.gateway
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn network() -> MicroNetworkResponse {
+        MicroNetworkResponse {
+            id: Uuid::parse_str("11111111-1111-4111-8111-111111111111").unwrap(),
+            name: "lab".to_owned(),
+            subnet_cidr: "172.31.0.0/24".to_owned(),
+            gateway: "172.31.0.1".to_owned(),
+            internet_enabled: true,
+            uplink: None,
+            ipv6_cidr: None,
+            ipv6_gateway: None,
+            ipv6_address_mode: None,
+            ipv6_egress: None,
+        }
+    }
+
+    #[test]
+    fn empty_list_still_has_a_header() {
+        assert_eq!(
+            format_list(&[]),
+            "ID\tNAME\tSUBNET\tGATEWAY\tINTERNET\tUPLINK\n"
+        );
+    }
+
+    #[test]
+    fn list_formats_network_fields() {
+        let output = format_list(&[network()]);
+        assert!(output.contains("11111111-1111-4111-8111-111111111111\tlab"));
+        assert!(output.contains("172.31.0.0/24\t172.31.0.1\tyes\tauto"));
+    }
+
+    #[test]
+    fn create_summary_names_the_network() {
+        assert_eq!(
+            format_one("created", &network()),
+            "created network 11111111-1111-4111-8111-111111111111 (lab, 172.31.0.0/24, gateway 172.31.0.1)"
+        );
+    }
+}

--- a/firecrab-cli/src/service/deps.rs
+++ b/firecrab-cli/src/service/deps.rs
@@ -1,0 +1,397 @@
+//! install.sh `ensure` / `ensure_runtime_deps`: 두 데몬이 런타임에 shell out 하는
+//! 명령들과 설치 스크립트 자체가 필요로 하는 몇 가지를 채운다.
+
+use super::output;
+use super::pkg::{Packages, PkgManager, have};
+
+/// 무엇이 빠졌고 무엇을 경고했는지. `missing`이 비면 성공이다.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct DepsOutcome {
+    /// 설치하지 못한, 반드시 필요한 명령들.
+    pub missing: Vec<String>,
+    /// 없어도 진행 가능한 항목에 대한 경고.
+    pub warnings: Vec<String>,
+}
+
+/// install.sh `ensure`: 실제로 없는 것만 설치한다.
+fn ensure(
+    packages: &mut Packages<'_>,
+    outcome: &mut DepsOutcome,
+    command_name: &str,
+    generic: &str,
+    install_deps: bool,
+    check_only: bool,
+) -> bool {
+    if have(packages.runner(), command_name) {
+        return true;
+    }
+    let manager = packages.manager();
+    let names: Vec<&str> = manager
+        .map(|m| m.packages_for(generic))
+        .unwrap_or_else(|| vec![generic]);
+    if check_only {
+        output::warn(&format!(
+            "missing: {command_name} (would install: {})",
+            names.join(" ")
+        ));
+        outcome.missing.push(command_name.to_owned());
+        return false;
+    }
+    if !install_deps {
+        output::warn(&format!(
+            "missing: {command_name} (--no-deps, install '{}' yourself)",
+            names.join(" ")
+        ));
+        outcome.missing.push(command_name.to_owned());
+        return false;
+    }
+    if manager.is_none() {
+        output::warn(&format!(
+            "missing: {command_name} and no known package manager — install '{}' yourself",
+            names.join(" ")
+        ));
+        outcome.missing.push(command_name.to_owned());
+        return false;
+    }
+    output::step(&format!(
+        "installing {} (for {command_name})",
+        names.join(" ")
+    ));
+    if let Err(err) = packages.install("deps", &names) {
+        output::warn(&format!("failed to install {}: {err}", names.join(" ")));
+        outcome.missing.push(command_name.to_owned());
+        return false;
+    }
+    // install.sh re-checks `have` even after a successful `pkg_install`: a
+    // package can install with exit 0 and still not provide the binary
+    // (wrong or incomplete generic-name mapping), and that must count as
+    // missing, not satisfied.
+    if have(packages.runner(), command_name) {
+        true
+    } else {
+        outcome.missing.push(command_name.to_owned());
+        false
+    }
+}
+
+/// install.sh `ensure_runtime_deps` 전체.
+pub fn ensure_runtime_deps(
+    packages: &mut Packages<'_>,
+    install_deps: bool,
+    check_only: bool,
+    selinux_on: bool,
+) -> DepsOutcome {
+    let mut outcome = DepsOutcome::default();
+    for (command_name, generic) in [
+        ("ip", "iproute2"),
+        ("nft", "nftables"),
+        ("dnsmasq", "dnsmasq"),
+    ] {
+        ensure(
+            packages,
+            &mut outcome,
+            command_name,
+            generic,
+            install_deps,
+            check_only,
+        );
+    }
+
+    // dhcp_release releases DHCP leases on VM stop; VMs still run without it,
+    // leases just expire on their own. Fedora/RHEL ship dnsmasq without that
+    // binary — do not reinstall dnsmasq for it.
+    if !have(packages.runner(), "dhcp_release") {
+        if packages.manager() == Some(PkgManager::Dnf) {
+            outcome.warnings.push(
+                "dhcp_release is not available on this distribution; leases expire on their own"
+                    .to_owned(),
+            );
+        } else {
+            let mut probe = DepsOutcome::default();
+            if !ensure(
+                packages,
+                &mut probe,
+                "dhcp_release",
+                "dnsmasq-utils",
+                install_deps,
+                check_only,
+            ) {
+                outcome.warnings.push(
+                    "dhcp_release not found; install dnsmasq-utils to release leases on VM stop"
+                        .to_owned(),
+                );
+            }
+        }
+    }
+
+    // Without semanage the services stay in SELinux's init_t domain, where they
+    // cannot reach a registry or exec nft — an install that looks successful
+    // and works for nothing.
+    if selinux_on && !have(packages.runner(), "semanage") {
+        let mut probe = DepsOutcome::default();
+        if !ensure(
+            packages,
+            &mut probe,
+            "semanage",
+            "selinux-tools",
+            install_deps,
+            check_only,
+        ) {
+            outcome.warnings.push(
+                "SELinux is on but semanage is missing; the services will be confined to init_t"
+                    .to_owned(),
+            );
+        }
+    }
+
+    for (command_name, generic) in [
+        ("mkfs.ext4", "e2fsprogs"),
+        ("curl", "curl"),
+        ("find", "findutils"),
+        ("tar", "tar"),
+        ("zstd", "zstd"),
+        ("sha256sum", "coreutils"),
+    ] {
+        ensure(
+            packages,
+            &mut outcome,
+            command_name,
+            generic,
+            install_deps,
+            check_only,
+        );
+    }
+
+    for warning in &outcome.warnings {
+        output::warn(warning);
+    }
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::privileged::Privileged;
+    use crate::shell::FakeCommandRunner;
+
+    /// Registers `command -v <cmd>` as present for each listed command;
+    /// everything else probes as absent.
+    fn fake_with_present(present: &[&str]) -> FakeCommandRunner {
+        let mut fake = FakeCommandRunner::permissive();
+        for cmd in present {
+            fake.set(
+                "sh",
+                &["-c", &format!("command -v {cmd}")],
+                0,
+                "/usr/bin/x\n",
+                "",
+            );
+        }
+        for cmd in [
+            "ip",
+            "nft",
+            "dnsmasq",
+            "dhcp_release",
+            "mkfs.ext4",
+            "curl",
+            "find",
+            "tar",
+            "zstd",
+            "sha256sum",
+            "semanage",
+        ] {
+            if !present.contains(&cmd) {
+                fake.set("sh", &["-c", &format!("command -v {cmd}")], 1, "", "");
+            }
+        }
+        fake
+    }
+
+    const ALL: &[&str] = &[
+        "ip",
+        "nft",
+        "dnsmasq",
+        "dhcp_release",
+        "mkfs.ext4",
+        "curl",
+        "find",
+        "tar",
+        "zstd",
+        "sha256sum",
+        "semanage",
+    ];
+
+    #[test]
+    fn nothing_is_installed_when_everything_is_present() {
+        let fake = fake_with_present(ALL);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, true, false, false);
+        assert!(outcome.missing.is_empty());
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("apt-get install")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn missing_commands_are_installed_by_generic_name() {
+        let mut fake = fake_with_present(&[
+            "ip",
+            "dnsmasq",
+            "dhcp_release",
+            "mkfs.ext4",
+            "curl",
+            "find",
+            "tar",
+            "zstd",
+            "sha256sum",
+        ]);
+        // `nft` is absent on the first probe (before install), then present
+        // on the second (install.sh's post-install `have` re-check).
+        fake.set_seq(
+            "sh",
+            &["-c", "command -v nft"],
+            &[(1, "", ""), (0, "/usr/sbin/nft\n", "")],
+        );
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, true, false, false);
+        assert!(outcome.missing.is_empty(), "{:?}", outcome.missing);
+        assert!(
+            fake.calls()
+                .iter()
+                .any(|c| c.ends_with("apt-get install -y -qq nftables")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn a_package_that_installs_but_leaves_the_command_absent_is_reported_missing() {
+        // `nft` is absent on both probes: apt-get reports success but the
+        // package-name mapping was wrong (or incomplete), so the binary
+        // never actually appears. install.sh's re-check catches this.
+        let fake = fake_with_present(&[
+            "ip",
+            "dnsmasq",
+            "dhcp_release",
+            "mkfs.ext4",
+            "curl",
+            "find",
+            "tar",
+            "zstd",
+            "sha256sum",
+        ]);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, true, false, false);
+        assert!(
+            outcome.missing.contains(&"nft".to_owned()),
+            "{:?}",
+            outcome.missing
+        );
+        assert!(
+            fake.calls()
+                .iter()
+                .any(|c| c.ends_with("apt-get install -y -qq nftables")),
+            "install was still attempted: {:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn check_only_reports_without_installing() {
+        let fake = fake_with_present(&[]);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, true, true, false);
+        assert!(
+            outcome.missing.contains(&"nft".to_owned()),
+            "{:?}",
+            outcome.missing
+        );
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("install")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn no_deps_reports_missing_without_installing() {
+        let fake = fake_with_present(&[]);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, false, false, false);
+        assert!(outcome.missing.contains(&"ip".to_owned()));
+        assert!(!fake.calls().iter().any(|c| c.contains("install")));
+    }
+
+    #[test]
+    fn dhcp_release_is_a_warning_not_a_failure_and_never_reinstalls_dnsmasq_on_dnf() {
+        let fake = fake_with_present(&[
+            "ip",
+            "nft",
+            "dnsmasq",
+            "mkfs.ext4",
+            "curl",
+            "find",
+            "tar",
+            "zstd",
+            "sha256sum",
+        ]);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::Dnf), &privileged);
+        let outcome = ensure_runtime_deps(&mut packages, true, false, false);
+        assert!(outcome.missing.is_empty(), "{:?}", outcome.missing);
+        assert!(
+            outcome.warnings.iter().any(|w| w.contains("dhcp_release")),
+            "{:?}",
+            outcome.warnings
+        );
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("dnf install")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn semanage_is_only_pursued_when_selinux_is_on() {
+        let present = &[
+            "ip",
+            "nft",
+            "dnsmasq",
+            "dhcp_release",
+            "mkfs.ext4",
+            "curl",
+            "find",
+            "tar",
+            "zstd",
+            "sha256sum",
+        ];
+        let fake = fake_with_present(present);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::Dnf), &privileged);
+        ensure_runtime_deps(&mut packages, true, false, false);
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("policycoreutils")),
+            "{:?}",
+            fake.calls()
+        );
+
+        let fake = fake_with_present(present);
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::Dnf), &privileged);
+        ensure_runtime_deps(&mut packages, true, false, true);
+        assert!(
+            fake.calls()
+                .iter()
+                .any(|c| c.contains("policycoreutils-python-utils")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+}

--- a/firecrab-cli/src/service/env.rs
+++ b/firecrab-cli/src/service/env.rs
@@ -1,0 +1,161 @@
+//! install.sh 상단 변수 블록의 Rust 대응: 계정과 설치 경로.
+
+use std::path::{Path, PathBuf};
+
+/// 시작 순서. 정지는 역순.
+pub const UNITS: [&str; 2] = ["firecrab-net-helper.service", "firecrab-api.service"];
+
+/// 설치 계정과 경로 집합. `firecrab update`의 `resolve_layout`과 같은 규칙으로
+/// `PREFIX`/`FIRECRAB_LIBDIR`를 해석해 helper의 `host_layout`과 어긋나지 않는다.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceEnv {
+    /// 서비스 계정 이름 (`$FIRECRAB_USER`, 기본 `firecrab`).
+    pub user: String,
+    /// 서비스 그룹 이름 (`$FIRECRAB_GROUP`, 기본 `firecrab`).
+    pub group: String,
+    /// 설치 접두 경로 (`$PREFIX`, 기본 `/usr/local`).
+    pub prefix: PathBuf,
+    /// 실행 파일 디렉터리 (`$PREFIX/bin`).
+    pub bindir: PathBuf,
+    /// 라이브러리 디렉터리 (`$FIRECRAB_LIBDIR`, 기본 `$PREFIX/lib/firecrab`).
+    pub libdir: PathBuf,
+    /// 공유 데이터 디렉터리 (`$PREFIX/share/firecrab`).
+    pub sharedir: PathBuf,
+    /// VM 디스크·DB 등 상태 디렉터리 (`$DATADIR`, 기본 `/var/lib/firecrab`).
+    pub datadir: PathBuf,
+    /// 설정 디렉터리 (`$CONFDIR`, 기본 `/etc/firecrab`).
+    pub confdir: PathBuf,
+    /// systemd 유닛 디렉터리 (`$UNITDIR`, 기본 `/etc/systemd/system`).
+    pub unitdir: PathBuf,
+}
+
+fn env_or(var: &str, default: &str) -> String {
+    std::env::var(var)
+        .ok()
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| default.to_owned())
+}
+
+impl ServiceEnv {
+    /// install.sh와 같은 이름·기본값으로 프로세스 환경을 읽는다.
+    pub fn from_process_env() -> Self {
+        let layout = crate::update::resolve_layout();
+        let prefix = PathBuf::from(env_or("PREFIX", "/usr/local"));
+        Self {
+            user: env_or("FIRECRAB_USER", "firecrab"),
+            group: env_or("FIRECRAB_GROUP", "firecrab"),
+            bindir: layout.bindir,
+            libdir: layout.libdir,
+            sharedir: layout.sharedir,
+            prefix,
+            datadir: crate::update::datadir(),
+            confdir: PathBuf::from(env_or("CONFDIR", "/etc/firecrab")),
+            unitdir: PathBuf::from(env_or("UNITDIR", "/etc/systemd/system")),
+        }
+    }
+
+    /// 테스트·임시 디렉터리용: prefix 아래 표준 배치.
+    pub fn from_values(
+        user: &str,
+        group: &str,
+        prefix: &Path,
+        datadir: &Path,
+        confdir: &Path,
+        unitdir: &Path,
+    ) -> Self {
+        Self {
+            user: user.to_owned(),
+            group: group.to_owned(),
+            prefix: prefix.to_path_buf(),
+            bindir: prefix.join("bin"),
+            libdir: prefix.join("lib/firecrab"),
+            sharedir: prefix.join("share/firecrab"),
+            datadir: datadir.to_path_buf(),
+            confdir: confdir.to_path_buf(),
+            unitdir: unitdir.to_path_buf(),
+        }
+    }
+
+    /// `$UNITDIR/<unit>`.
+    pub fn unit_path(&self, unit: &str) -> PathBuf {
+        self.unitdir.join(unit)
+    }
+
+    /// `FIRECRAB_BIND_ADDR`, else the API's default bind.
+    pub fn api_bind() -> String {
+        env_or("FIRECRAB_BIND_ADDR", "127.0.0.1:5523")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::update::ENV_LOCK;
+
+    fn clear() {
+        for var in [
+            "FIRECRAB_USER",
+            "FIRECRAB_GROUP",
+            "PREFIX",
+            "FIRECRAB_LIBDIR",
+            "DATADIR",
+            "CONFDIR",
+            "UNITDIR",
+        ] {
+            // SAFETY: serialized by ENV_LOCK against every other env-touching test.
+            unsafe { std::env::remove_var(var) };
+        }
+    }
+
+    #[test]
+    fn defaults_match_install_sh() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear();
+        let env = ServiceEnv::from_process_env();
+        assert_eq!(env.user, "firecrab");
+        assert_eq!(env.group, "firecrab");
+        assert_eq!(env.prefix, Path::new("/usr/local"));
+        assert_eq!(env.bindir, Path::new("/usr/local/bin"));
+        assert_eq!(env.libdir, Path::new("/usr/local/lib/firecrab"));
+        assert_eq!(env.sharedir, Path::new("/usr/local/share/firecrab"));
+        assert_eq!(env.datadir, Path::new("/var/lib/firecrab"));
+        assert_eq!(env.confdir, Path::new("/etc/firecrab"));
+        assert_eq!(env.unitdir, Path::new("/etc/systemd/system"));
+        assert_eq!(
+            env.unit_path("firecrab-api.service"),
+            Path::new("/etc/systemd/system/firecrab-api.service")
+        );
+    }
+
+    #[test]
+    fn prefix_and_libdir_overrides_follow_update() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        clear();
+        // SAFETY: serialized by ENV_LOCK against every other env-touching test.
+        unsafe {
+            std::env::set_var("PREFIX", "/opt/fc");
+            std::env::set_var("FIRECRAB_LIBDIR", "/opt/lib/fc");
+            std::env::set_var("FIRECRAB_USER", "fcuser");
+        }
+        let env = ServiceEnv::from_process_env();
+        clear();
+        assert_eq!(env.bindir, Path::new("/opt/fc/bin"));
+        assert_eq!(env.sharedir, Path::new("/opt/fc/share/firecrab"));
+        assert_eq!(env.libdir, Path::new("/opt/lib/fc"));
+        assert_eq!(env.user, "fcuser");
+        assert_eq!(env.group, "firecrab");
+    }
+
+    #[test]
+    fn api_bind_defaults_to_loopback() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // SAFETY: serialized by ENV_LOCK against every other env-touching test.
+        unsafe { std::env::remove_var("FIRECRAB_BIND_ADDR") };
+        assert_eq!(ServiceEnv::api_bind(), "127.0.0.1:5523");
+        // SAFETY: serialized by ENV_LOCK — see the note above.
+        unsafe { std::env::set_var("FIRECRAB_BIND_ADDR", "0.0.0.0:8080") };
+        assert_eq!(ServiceEnv::api_bind(), "0.0.0.0:8080");
+        // SAFETY: serialized by ENV_LOCK — see the note above.
+        unsafe { std::env::remove_var("FIRECRAB_BIND_ADDR") };
+    }
+}

--- a/firecrab-cli/src/service/firecracker.rs
+++ b/firecrab-cli/src/service/firecracker.rs
@@ -1,0 +1,246 @@
+//! install.sh `ensure_firecracker`: firecracker는 배포판 패키지가 아니라
+//! 업스트림 스크립트로 설치한다. 체크아웃이 없으면 같은 스크립트를 내려받는다.
+
+use std::path::{Path, PathBuf};
+
+use super::Error;
+use super::env::ServiceEnv;
+use super::output;
+use super::pkg::have;
+use super::privileged::Privileged;
+use crate::update::bundle;
+
+const STEP: &str = "firecracker";
+
+/// install.sh 스크립트 상대 경로.
+const SCRIPT_PATH: &str = "scripts/install-firecracker.sh";
+
+/// `firecrab_repo_raw_url`: 태그의 raw GitHub 파일. `latest`(=None)는 `main`.
+pub fn repo_raw_url(repo: &str, version: Option<&str>, path: &str) -> String {
+    let tag = match version {
+        None => "main".to_owned(),
+        Some(v) if v.is_empty() || v == "latest" => "main".to_owned(),
+        Some(v) if v.starts_with('v') => v.to_owned(),
+        Some(v) => format!("v{v}"),
+    };
+    format!("https://raw.githubusercontent.com/{repo}/{tag}/{path}")
+}
+
+/// firecracker가 없으면 업스트림 스크립트로 설치한다.
+///
+/// `checkout`은 `--bin-dir` 설치에서 넘어오는 저장소 루트. 없으면 릴리스
+/// 태그(또는 main)의 raw 스크립트를 임시 파일로 내려받아 실행한다.
+pub fn ensure_firecracker(
+    privileged: &Privileged<'_>,
+    env: &ServiceEnv,
+    checkout: Option<&Path>,
+    version: Option<&str>,
+    install_deps: bool,
+    check_only: bool,
+) -> Result<(), Error> {
+    if have(privileged.runner(), "firecracker") {
+        output::log("firecracker present");
+        return Ok(());
+    }
+    if check_only {
+        output::warn("missing: firecracker (would install the upstream Firecracker binary)");
+        return Err(Error::step(STEP, "firecracker is required"));
+    }
+    if !install_deps {
+        return Err(Error::step_fix(
+            STEP,
+            "firecracker is missing (--no-deps)",
+            "install it, or re-run without --no-deps",
+        ));
+    }
+
+    output::step("installing firecracker");
+    let notice_dir = env.sharedir.join("firecracker");
+    let notice_dir = notice_dir.to_string_lossy().into_owned();
+
+    let checkout_script = checkout.map(|root| root.join(SCRIPT_PATH));
+    let (script, temp): (PathBuf, Option<tempfile::TempDir>) = match checkout_script {
+        Some(path) if path.is_file() => (path, None),
+        _ => {
+            let dir = tempfile::tempdir().map_err(|e| {
+                Error::step(STEP, format!("could not create a temporary directory: {e}"))
+            })?;
+            let dest = dir.path().join("install-firecracker.sh");
+            let url = repo_raw_url(&bundle::release_repo(), version, SCRIPT_PATH);
+            bundle::download_to(&url, &dest)?;
+            (dest, Some(dir))
+        }
+    };
+
+    let script_s = script.to_string_lossy().into_owned();
+    let result = privileged.run_env(
+        STEP,
+        &[("FIRECRACKER_NOTICE_DIR", &notice_dir)],
+        "bash",
+        &[&script_s],
+    );
+    drop(temp);
+    result?;
+
+    if have(privileged.runner(), "firecracker") {
+        Ok(())
+    } else {
+        Err(Error::step(
+            STEP,
+            "firecracker install ran but the binary is still not on PATH",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+
+    fn env_for(prefix: &Path) -> ServiceEnv {
+        ServiceEnv::from_values(
+            "firecrab",
+            "firecrab",
+            prefix,
+            Path::new("/var/lib/firecrab"),
+            Path::new("/etc/firecrab"),
+            Path::new("/etc/systemd/system"),
+        )
+    }
+
+    #[test]
+    fn raw_url_maps_latest_to_main_and_normalizes_tags() {
+        assert_eq!(
+            repo_raw_url("SteelCrab/firecrab", None, "scripts/install-firecracker.sh"),
+            "https://raw.githubusercontent.com/SteelCrab/firecrab/main/scripts/install-firecracker.sh"
+        );
+        assert_eq!(
+            repo_raw_url(
+                "SteelCrab/firecrab",
+                Some("0.3.0"),
+                "scripts/install-firecracker.sh"
+            ),
+            "https://raw.githubusercontent.com/SteelCrab/firecrab/v0.3.0/scripts/install-firecracker.sh"
+        );
+        assert_eq!(
+            repo_raw_url("SteelCrab/firecrab", Some("v0.3.0"), "x"),
+            "https://raw.githubusercontent.com/SteelCrab/firecrab/v0.3.0/x"
+        );
+    }
+
+    #[test]
+    fn present_firecracker_is_left_alone() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set(
+            "sh",
+            &["-c", "command -v firecracker"],
+            0,
+            "/usr/bin/firecracker\n",
+            "",
+        );
+        let privileged = Privileged::with_sudo(&fake, true);
+        ensure_firecracker(
+            &privileged,
+            &env_for(Path::new("/usr/local")),
+            None,
+            None,
+            true,
+            false,
+        )
+        .unwrap();
+        assert!(
+            !fake
+                .calls()
+                .iter()
+                .any(|c| c.contains("install-firecracker")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn checkout_script_is_run_with_the_notice_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let scripts = dir.path().join("scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+        std::fs::write(scripts.join("install-firecracker.sh"), "#!/bin/sh\n").unwrap();
+
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("sh", &["-c", "command -v firecracker"], 1, "", "");
+        let privileged = Privileged::with_sudo(&fake, true);
+        let env = env_for(Path::new("/usr/local"));
+        // The second `have` probe (after the install) must succeed or the call fails.
+        let result = ensure_firecracker(&privileged, &env, Some(dir.path()), None, true, false);
+        assert!(
+            result.is_err(),
+            "the probe after install still reports it missing"
+        );
+        let script = scripts.join("install-firecracker.sh");
+        assert!(
+            fake.calls().iter().any(|c| c
+                == &format!(
+                    "sudo env FIRECRACKER_NOTICE_DIR=/usr/local/share/firecrab/firecracker bash {}",
+                    script.display()
+                )),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn check_only_reports_without_installing() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("sh", &["-c", "command -v firecracker"], 1, "", "");
+        let privileged = Privileged::with_sudo(&fake, true);
+        let err = ensure_firecracker(
+            &privileged,
+            &env_for(Path::new("/usr/local")),
+            None,
+            None,
+            true,
+            true,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Step {
+                step: "firecracker",
+                ..
+            }
+        ));
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("bash")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn no_deps_refuses_to_install() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("sh", &["-c", "command -v firecracker"], 1, "", "");
+        let privileged = Privileged::with_sudo(&fake, true);
+        let err = ensure_firecracker(
+            &privileged,
+            &env_for(Path::new("/usr/local")),
+            None,
+            None,
+            false,
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            Error::Step {
+                step: "firecracker",
+                ..
+            }
+        ));
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("bash")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+}

--- a/firecrab-cli/src/service/layout.rs
+++ b/firecrab-cli/src/service/layout.rs
@@ -1,0 +1,559 @@
+//! install.sh `ensure_account` … `install_config`: 계정, 디렉터리, 컴플라이언스
+//! 자료, 바이너리·대시보드, 그리고 api.env.
+
+use std::path::Path;
+
+use super::Error;
+use super::env::ServiceEnv;
+use super::output;
+use super::payload::{BUNDLE_BINARIES, EXTRACT_HELPERS, Payload, resolve_binary};
+use super::pkg::have;
+use super::privileged::Privileged;
+
+/// install.sh가 처음 한 번 심는 `$CONFDIR/api.env`.
+pub const API_ENV_TEMPLATE: &str = "\
+# firecrab API settings. The unit already sets the image root, the dashboard
+# assets and the working directory; uncomment only what you want to change.
+#
+# FIRECRAB_BIND_ADDR=127.0.0.1:5523
+# A non-loopback address requires authentication AND TLS to be enabled.
+# FIRECRAB_ALLOWED_ORIGINS=
+# Empty is correct while the dashboard is served from this same origin.
+# FIRECRAB_FIRECRACKER_BIN=firecracker
+#
+# M2Image install (Images page / POST /api/images/{alias}/install).
+# Points at a directory-style base that serves `{alias}.tar.zst` packages
+# (see scripts/package-m2images.sh). Unset = use the public MicroRegistry.
+# Example local mirror:
+# FIRECRAB_IMAGE_BASE_URL=http://127.0.0.1:8765
+# Requires host tools: tar, zstd. Restart firecrab-api after changing this.
+";
+
+const STEP_ACCOUNT: &str = "account";
+const STEP_DIRS: &str = "directories";
+const STEP_COMPLIANCE: &str = "compliance";
+const STEP_BINARIES: &str = "binaries";
+const STEP_CONFIG: &str = "config";
+
+fn succeeded(privileged: &Privileged<'_>, cmd: &str, args: &[&str]) -> bool {
+    privileged
+        .runner()
+        .run(cmd, args)
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// install.sh `ensure_account`: 시스템 계정과 kvm 그룹 소속, /dev/kvm ACL.
+pub fn ensure_account(privileged: &Privileged<'_>, env: &ServiceEnv) -> Result<(), Error> {
+    if succeeded(privileged, "getent", &["group", &env.group]) {
+        output::log(&format!("group {} exists", env.group));
+    } else {
+        output::step(&format!("creating group {}", env.group));
+        privileged.run_ok(STEP_ACCOUNT, "groupadd", &["--system", &env.group])?;
+    }
+
+    if succeeded(privileged, "id", &[&env.user]) {
+        output::log(&format!("user {} exists", env.user));
+    } else {
+        output::step(&format!("creating user {}", env.user));
+        let home = env.datadir.to_string_lossy().into_owned();
+        privileged.run_ok(
+            STEP_ACCOUNT,
+            "useradd",
+            &[
+                "--system",
+                "--gid",
+                &env.group,
+                "--home-dir",
+                &home,
+                "--shell",
+                "/usr/sbin/nologin",
+                &env.user,
+            ],
+        )?;
+    }
+
+    // The API spawns firecracker, which opens /dev/kvm.
+    if succeeded(privileged, "getent", &["group", "kvm"]) {
+        let in_kvm = privileged
+            .runner()
+            .run("id", &["-nG", &env.user])
+            .map(|out| {
+                String::from_utf8_lossy(&out.stdout)
+                    .split_whitespace()
+                    .any(|g| g == "kvm")
+            })
+            .unwrap_or(false);
+        if !in_kvm {
+            output::step(&format!("adding {} to the kvm group", env.user));
+            privileged.run_ok(
+                STEP_ACCOUNT,
+                "usermod",
+                &["--append", "--groups", "kvm", &env.user],
+            )?;
+        }
+    }
+
+    // Group membership is necessary but not always sufficient: some hosts'
+    // /dev/kvm does not land in the kvm group the standard udev rule asks for.
+    // The ACL entry is narrow and idempotent.
+    if Path::new("/dev/kvm").exists() {
+        if have(privileged.runner(), "setfacl") {
+            let has_entry = privileged
+                .runner()
+                .run("getfacl", &["-p", "/dev/kvm"])
+                .map(|out| {
+                    String::from_utf8_lossy(&out.stdout)
+                        .lines()
+                        .any(|l| l.trim() == "group:kvm:rw-")
+                })
+                .unwrap_or(false);
+            if !has_entry {
+                output::step("granting the kvm group ACL access to /dev/kvm");
+                privileged.run_ok(STEP_ACCOUNT, "setfacl", &["-m", "g:kvm:rw", "/dev/kvm"])?;
+            }
+        } else {
+            output::warn(
+                "setfacl not found — skipping the /dev/kvm ACL fixup (install the 'acl' package if VMs fail with a KVM permission error)",
+            );
+        }
+    }
+    Ok(())
+}
+
+/// install.sh `ensure_directories`.
+pub fn ensure_directories(privileged: &Privileged<'_>, env: &ServiceEnv) -> Result<(), Error> {
+    privileged.install_dirs(
+        STEP_DIRS,
+        &[&env.libdir, &env.sharedir],
+        "root",
+        "root",
+        "0755",
+    )?;
+    let data = env.datadir.join("data");
+    let images = env.datadir.join("images");
+    let updates = env.datadir.join("updates");
+    privileged.install_dirs(
+        STEP_DIRS,
+        &[&env.datadir, &data, &images, &updates],
+        &env.user,
+        &env.group,
+        "0750",
+    )?;
+    privileged.install_dirs(STEP_DIRS, &[&env.confdir], "root", &env.group, "0750")?;
+    output::log(&format!(
+        "directories ready under {}, {}",
+        env.datadir.display(),
+        env.confdir.display()
+    ));
+    Ok(())
+}
+
+/// install.sh `install_compliance`.
+pub fn install_compliance(
+    privileged: &Privileged<'_>,
+    env: &ServiceEnv,
+    payload: &Payload,
+) -> Result<(), Error> {
+    let licenses = env.sharedir.join("licenses");
+    privileged.install_dirs(STEP_COMPLIANCE, &[&licenses], "root", "root", "0755")?;
+    privileged.install_file(
+        STEP_COMPLIANCE,
+        &payload.license,
+        &env.sharedir.join("LICENSE"),
+        "root",
+        "root",
+        "0644",
+    )?;
+    privileged.install_file(
+        STEP_COMPLIANCE,
+        &payload.gpl,
+        &licenses.join("GPL-2.0-only.txt"),
+        "root",
+        "root",
+        "0644",
+    )?;
+    match (&payload.third_party, &payload.inventory) {
+        (Some(notices), Some(inventory)) => {
+            privileged.install_file(
+                STEP_COMPLIANCE,
+                notices,
+                &env.sharedir.join("THIRD_PARTY_NOTICES.txt"),
+                "root",
+                "root",
+                "0644",
+            )?;
+            privileged.install_file(
+                STEP_COMPLIANCE,
+                inventory,
+                &env.sharedir.join("release-license-inventory.json"),
+                "root",
+                "root",
+                "0644",
+            )?;
+        }
+        _ => {
+            // A checkout may not have run the compliance-generation step;
+            // stale copies from a previous release install must not linger.
+            let notices = env.sharedir.join("THIRD_PARTY_NOTICES.txt");
+            let inventory = env.sharedir.join("release-license-inventory.json");
+            let (a, b) = (
+                notices.to_string_lossy().into_owned(),
+                inventory.to_string_lossy().into_owned(),
+            );
+            privileged.run_ok(STEP_COMPLIANCE, "rm", &["-f", &a, &b])?;
+        }
+    }
+    output::log(&format!(
+        "license and attribution material installed to {}",
+        env.sharedir.display()
+    ));
+    Ok(())
+}
+
+/// install.sh `install_binaries`.
+pub fn install_binaries(
+    privileged: &Privileged<'_>,
+    env: &ServiceEnv,
+    payload: &Payload,
+    with_frontend: bool,
+) -> Result<(), Error> {
+    for name in ["firecrab-api", "firecrab-net-helper"] {
+        let src = resolve_binary(name, Some(&payload.bin), &env.libdir).ok_or_else(|| {
+            Error::step_fix(
+                STEP_BINARIES,
+                format!(
+                    "no {name} in {} or {}",
+                    payload.bin.display(),
+                    env.libdir.display()
+                ),
+                "pass it via --bin-dir, or install a release",
+            )
+        })?;
+        let dest = env.libdir.join(name);
+        if src == dest {
+            output::log(&format!("keeping existing {}", dest.display()));
+        } else {
+            privileged.install_file(STEP_BINARIES, &src, &dest, "root", "root", "0755")?;
+        }
+    }
+
+    // The API turns a distro vmlinuz into the format Firecracker boots with
+    // these; installing them next to the binary means it never needs the checkout.
+    for helper in EXTRACT_HELPERS {
+        let src = payload.extract.join(helper);
+        if !src.is_file() {
+            return Err(Error::step(
+                STEP_BINARIES,
+                format!("missing {}", src.display()),
+            ));
+        }
+        privileged.install_file(
+            STEP_BINARIES,
+            &src,
+            &env.libdir.join(helper),
+            "root",
+            "root",
+            "0755",
+        )?;
+    }
+
+    let cli = BUNDLE_BINARIES[2];
+    let src = resolve_binary(cli, Some(&payload.bin), &env.bindir).ok_or_else(|| {
+        Error::step_fix(
+            STEP_BINARIES,
+            format!(
+                "no {cli} (CLI) in {} or {}",
+                payload.bin.display(),
+                env.bindir.display()
+            ),
+            "pass it via --bin-dir, or install a release",
+        )
+    })?;
+    let dest = env.bindir.join(cli);
+    if src == dest {
+        output::log(&format!("keeping existing {}", dest.display()));
+    } else {
+        privileged.install_dirs(STEP_BINARIES, &[&env.bindir], "root", "root", "0755")?;
+        privileged.install_file(STEP_BINARIES, &src, &dest, "root", "root", "0755")?;
+    }
+    output::log(&format!(
+        "binaries installed to {} (cli → {})",
+        env.libdir.display(),
+        dest.display()
+    ));
+
+    if !with_frontend {
+        return Ok(());
+    }
+    let target = env.sharedir.join("dashboard");
+    match &payload.dashboard {
+        Some(dir) if dir.join("index.html").is_file() => {
+            let (target_s, source_s) = (
+                target.to_string_lossy().into_owned(),
+                format!("{}/.", dir.display()),
+            );
+            privileged.run_ok(STEP_BINARIES, "rm", &["-rf", &target_s])?;
+            privileged.install_dirs(STEP_BINARIES, &[&target], "root", "root", "0755")?;
+            privileged.run_ok(
+                STEP_BINARIES,
+                "cp",
+                &["-r", &source_s, &format!("{target_s}/")],
+            )?;
+            privileged.run_ok(STEP_BINARIES, "chown", &["-R", "root:root", &target_s])?;
+            output::log(&format!("dashboard installed to {target_s}"));
+            Ok(())
+        }
+        _ if target.join("index.html").is_file() => {
+            output::log(&format!("keeping existing {}", target.display()));
+            Ok(())
+        }
+        _ => Err(Error::step_fix(
+            STEP_BINARIES,
+            "dashboard not found",
+            "pass --dashboard-dir, or use a release bundle",
+        )),
+    }
+}
+
+/// install.sh `install_config`: 한 번만 심어 운영자의 수정이 재실행에서 살아남는다.
+pub fn install_config(privileged: &Privileged<'_>, env: &ServiceEnv) -> Result<(), Error> {
+    let api_env = env.confdir.join("api.env");
+    if api_env.is_file() {
+        output::log(&format!("keeping existing {}", api_env.display()));
+        return Ok(());
+    }
+    privileged.write_file(STEP_CONFIG, &api_env, API_ENV_TEMPLATE.as_bytes(), "0640")?;
+    let path = api_env.to_string_lossy().into_owned();
+    privileged.run_ok(
+        STEP_CONFIG,
+        "chown",
+        &[&format!("root:{}", env.group), &path],
+    )?;
+    output::log(&format!("wrote {path}"));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+
+    fn env_for(root: &Path) -> ServiceEnv {
+        ServiceEnv::from_values(
+            "firecrab",
+            "firecrab",
+            &root.join("usr/local"),
+            &root.join("var/lib/firecrab"),
+            &root.join("etc/firecrab"),
+            &root.join("etc/systemd/system"),
+        )
+    }
+
+    #[test]
+    fn account_creation_is_skipped_when_the_user_and_group_exist() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("getent", &["group", "firecrab"], 0, "firecrab:x:900:\n", "");
+        fake.set("id", &["firecrab"], 0, "uid=900\n", "");
+        fake.set("getent", &["group", "kvm"], 0, "kvm:x:104:firecrab\n", "");
+        fake.set("id", &["-nG", "firecrab"], 0, "firecrab kvm\n", "");
+        let dir = tempfile::tempdir().unwrap();
+        ensure_account(&Privileged::with_sudo(&fake, true), &env_for(dir.path())).unwrap();
+        let calls = fake.calls();
+        assert!(!calls.iter().any(|c| c.contains("groupadd")), "{calls:?}");
+        assert!(!calls.iter().any(|c| c.contains("useradd")), "{calls:?}");
+        assert!(!calls.iter().any(|c| c.contains("usermod")), "{calls:?}");
+    }
+
+    #[test]
+    fn account_creation_adds_group_user_and_kvm_membership() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("getent", &["group", "firecrab"], 1, "", "");
+        fake.set("id", &["firecrab"], 1, "", "");
+        fake.set("getent", &["group", "kvm"], 0, "kvm:x:104:\n", "");
+        fake.set("id", &["-nG", "firecrab"], 0, "firecrab\n", "");
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_for(dir.path());
+        ensure_account(&Privileged::with_sudo(&fake, true), &env).unwrap();
+        let calls = fake.calls();
+        assert!(
+            calls.iter().any(|c| c == "sudo groupadd --system firecrab"),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(|c| c
+                == &format!(
+                    "sudo useradd --system --gid firecrab --home-dir {} --shell /usr/sbin/nologin firecrab",
+                    env.datadir.display()
+                )),
+            "{calls:?}"
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "sudo usermod --append --groups kvm firecrab"),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn directories_use_install_sh_owners_and_modes() {
+        let fake = FakeCommandRunner::permissive();
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_for(dir.path());
+        ensure_directories(&Privileged::with_sudo(&fake, true), &env).unwrap();
+        let calls = fake.calls();
+        assert!(
+            calls.iter().any(|c| c
+                == &format!(
+                    "sudo install -d -o root -g root -m 0755 {} {}",
+                    env.libdir.display(),
+                    env.sharedir.display()
+                )),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(
+                |c| c.starts_with("sudo install -d -o firecrab -g firecrab -m 0750")
+                    && c.contains(&env.datadir.join("images").display().to_string())
+                    && c.contains(&env.datadir.join("updates").display().to_string())
+            ),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(|c| c
+                == &format!(
+                    "sudo install -d -o root -g firecrab -m 0750 {}",
+                    env.confdir.display()
+                )),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn binaries_land_in_libdir_and_the_cli_in_bindir() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let env = env_for(root);
+        let bin = root.join("payload");
+        std::fs::create_dir_all(&bin).unwrap();
+        for name in [
+            "firecrab-api",
+            "firecrab-net-helper",
+            "firecrab",
+            "extract-vmlinux",
+            "extract-arm64-image",
+        ] {
+            std::fs::write(bin.join(name), b"x").unwrap();
+        }
+        let dash = root.join("dash");
+        std::fs::create_dir_all(&dash).unwrap();
+        std::fs::write(dash.join("index.html"), b"<html>").unwrap();
+        let payload = Payload {
+            bin: bin.clone(),
+            units: root.join("units"),
+            extract: bin.clone(),
+            dashboard: Some(dash.clone()),
+            license: root.join("LICENSE"),
+            gpl: root.join("GPL"),
+            third_party: None,
+            inventory: None,
+            checkout: None,
+            _temp: None,
+        };
+        let fake = FakeCommandRunner::permissive();
+        install_binaries(&Privileged::with_sudo(&fake, true), &env, &payload, true).unwrap();
+        let calls = fake.calls();
+        assert!(
+            calls.iter().any(|c| c
+                == &format!(
+                    "sudo install -o root -g root -m 0755 {} {}",
+                    bin.join("firecrab-api").display(),
+                    env.libdir.join("firecrab-api").display()
+                )),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(|c| c
+                == &format!(
+                    "sudo install -o root -g root -m 0755 {} {}",
+                    bin.join("firecrab").display(),
+                    env.bindir.join("firecrab").display()
+                )),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(|c| c.contains("extract-vmlinux")),
+            "{calls:?}"
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c.starts_with("sudo cp -r ") && c.contains("dashboard")),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn no_frontend_skips_the_dashboard() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let env = env_for(root);
+        let bin = root.join("payload");
+        std::fs::create_dir_all(&bin).unwrap();
+        for name in [
+            "firecrab-api",
+            "firecrab-net-helper",
+            "firecrab",
+            "extract-vmlinux",
+            "extract-arm64-image",
+        ] {
+            std::fs::write(bin.join(name), b"x").unwrap();
+        }
+        let payload = Payload {
+            bin: bin.clone(),
+            units: root.join("units"),
+            extract: bin.clone(),
+            dashboard: None,
+            license: root.join("LICENSE"),
+            gpl: root.join("GPL"),
+            third_party: None,
+            inventory: None,
+            checkout: None,
+            _temp: None,
+        };
+        let fake = FakeCommandRunner::permissive();
+        install_binaries(&Privileged::with_sudo(&fake, true), &env, &payload, false).unwrap();
+        assert!(
+            !fake.calls().iter().any(|c| c.contains("dashboard")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn config_is_seeded_once_and_then_left_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_for(dir.path());
+        std::fs::create_dir_all(&env.confdir).unwrap();
+        let fake = FakeCommandRunner::permissive();
+        let privileged = Privileged::with_sudo(&fake, true);
+        install_config(&privileged, &env).unwrap();
+        let api_env = env.confdir.join("api.env");
+        assert_eq!(
+            fake.stdin_of(&format!("sudo tee {}", api_env.display())),
+            Some(API_ENV_TEMPLATE.as_bytes().to_vec())
+        );
+
+        // The fake never actually writes, so simulate the file the tee created.
+        std::fs::write(&api_env, API_ENV_TEMPLATE).unwrap();
+        let fake2 = FakeCommandRunner::permissive();
+        install_config(&Privileged::with_sudo(&fake2, true), &env).unwrap();
+        assert!(
+            !fake2.calls().iter().any(|c| c.contains("tee")),
+            "{:?}",
+            fake2.calls()
+        );
+    }
+}

--- a/firecrab-cli/src/service/mod.rs
+++ b/firecrab-cli/src/service/mod.rs
@@ -1,0 +1,169 @@
+//! `firecrab service` — install.sh의 설치/삭제와 systemd 제어를 Rust로.
+//!
+//! install.sh 함수 하나가 이 모듈 트리의 함수 하나에 대응한다. 모든 호스트
+//! 변경은 [`privileged::Privileged`]를 거쳐 `sudo <cmd>`로 실행되고, 읽기
+//! 전용 검사는 sudo 없이 실행된다.
+//!
+//! Task 1은 명령 표면과 에러 타입만 세운다. `Error::Sudo`/`NotInstalled`와
+//! `Error::step_fix`는 이후 태스크의 실제 설치/삭제/systemd 제어 구현이
+//! 붙으면 쓰인다.
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+use crate::shell::CommandRunner;
+
+pub mod deps;
+pub mod env;
+pub mod firecracker;
+pub mod layout;
+pub mod output;
+pub mod payload;
+pub mod pkg;
+pub mod privileged;
+pub mod selinux;
+pub mod uninstall;
+pub mod units;
+
+/// `firecrab service <sub>`.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Install the host services (install.sh equivalent).
+    Install(InstallOpts),
+    /// Stop and remove units, binaries and the dashboard.
+    Uninstall {
+        /// Also delete $DATADIR and $CONFDIR (VM disks and the database!).
+        #[arg(long)]
+        purge: bool,
+    },
+    /// Uninstall (keeping data unless --purge) and install again.
+    Reinstall {
+        /// Also delete $DATADIR and $CONFDIR before installing.
+        #[arg(long)]
+        purge: bool,
+        #[command(flatten)]
+        opts: InstallOpts,
+    },
+    /// Start firecrab-net-helper then firecrab-api.
+    Start,
+    /// Stop firecrab-api then firecrab-net-helper.
+    Stop,
+    /// Stop then start both units.
+    Restart,
+    /// Enable both units at boot.
+    Enable,
+    /// Disable both units at boot.
+    Disable,
+}
+
+/// Options shared by `install` and `reinstall`.
+#[derive(Debug, Clone, Default, Args)]
+pub struct InstallOpts {
+    /// Release tag to install (default: latest).
+    #[arg(long, value_name = "TAG")]
+    pub version: Option<String>,
+    /// Force the bundle libc: gnu, glibc or musl.
+    #[arg(long, value_name = "LIBC")]
+    pub libc: Option<String>,
+    /// Install binaries from this directory instead of a release (needs a checkout).
+    #[arg(long, value_name = "DIR")]
+    pub bin_dir: Option<PathBuf>,
+    /// Dashboard build to install alongside --bin-dir.
+    #[arg(long, value_name = "DIR", requires = "bin_dir")]
+    pub dashboard_dir: Option<PathBuf>,
+    /// Do not install packages or firecracker; report what is missing.
+    #[arg(long)]
+    pub no_deps: bool,
+    /// Skip the dashboard.
+    #[arg(long)]
+    pub no_frontend: bool,
+    /// Report every step without changing the host.
+    #[arg(long)]
+    pub check: bool,
+}
+
+/// Everything `firecrab service` can fail at.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// One pipeline step failed; `fix` is the operator hint install.sh prints.
+    #[error("{step}: {detail}")]
+    Step {
+        /// Pipeline step name (`deps`, `payload`, `units`, ...).
+        step: &'static str,
+        /// What went wrong.
+        detail: String,
+        /// How to fix it, if known.
+        fix: Option<String>,
+    },
+    /// sudo is missing, needs a password without a tty, or refused.
+    #[error("sudo: {0}")]
+    Sudo(String),
+    /// A unit file is not in $UNITDIR.
+    #[error("firecrab is not installed — run `firecrab service install`")]
+    NotInstalled,
+    /// Release download / checksum failure (reuses `firecrab update`'s errors).
+    #[error(transparent)]
+    Bundle(#[from] crate::update::UpdateError),
+}
+
+impl Error {
+    /// Shorthand for [`Error::Step`] without a fix hint.
+    pub fn step(step: &'static str, detail: impl Into<String>) -> Self {
+        Self::Step {
+            step,
+            detail: detail.into(),
+            fix: None,
+        }
+    }
+
+    /// Shorthand for [`Error::Step`] with a fix hint.
+    pub fn step_fix(step: &'static str, detail: impl Into<String>, fix: impl Into<String>) -> Self {
+        Self::Step {
+            step,
+            detail: detail.into(),
+            fix: Some(fix.into()),
+        }
+    }
+
+    /// Renders the `xx step: detail` + `→ fix` lines the way install.sh's `die` does.
+    pub fn report(&self) {
+        output::fail(&self.to_string());
+        if let Self::Step { fix: Some(fix), .. } = self {
+            eprintln!("  → {fix}");
+        }
+    }
+}
+
+/// Executes one `firecrab service` command.
+pub fn run(runner: &dyn CommandRunner, command: Command) -> Result<(), Error> {
+    let env = env::ServiceEnv::from_process_env();
+    let privileged = privileged::Privileged::detect(runner);
+    match command {
+        Command::Start | Command::Stop | Command::Restart | Command::Enable | Command::Disable => {
+            units::require_installed(&env)?;
+            privileged.ensure_ticket()?;
+            let bind = env::ServiceEnv::api_bind();
+            let probe = move || units::http_probe(&bind);
+            match command {
+                Command::Start => units::start(&privileged, &probe),
+                Command::Stop => units::stop(&privileged),
+                Command::Restart => {
+                    units::stop(&privileged)?;
+                    units::start(&privileged, &probe)
+                }
+                Command::Enable => units::enable(&privileged),
+                Command::Disable => units::disable(&privileged),
+                _ => unreachable!("guarded by the outer match"),
+            }
+        }
+        Command::Uninstall { purge } => {
+            privileged.ensure_ticket()?;
+            uninstall::uninstall(&privileged, &env, purge)
+        }
+        Command::Install(_) | Command::Reinstall { .. } => {
+            Err(Error::step("service", "not implemented yet"))
+        }
+    }
+}

--- a/firecrab-cli/src/service/output.rs
+++ b/firecrab-cli/src/service/output.rs
@@ -1,0 +1,25 @@
+//! install.sh와 같은 접두를 쓰는 진행 메시지 출력.
+//!
+//! Task 1에서는 `fail`만 [`super::Error::report`]를 통해 쓰인다. 나머지는
+//! 이후 태스크(설치/삭제/systemd 제어 구현)에서 소비된다.
+#![allow(dead_code)]
+
+/// `==> msg` — 완료된 단계 (stdout).
+pub fn log(msg: &str) {
+    println!("\x1b[1;32m==>\x1b[0m {msg}");
+}
+
+/// `--  msg` — 시작하는 작업 (stdout).
+pub fn step(msg: &str) {
+    println!("\x1b[1;36m--\x1b[0m  {msg}");
+}
+
+/// `!!  msg` — 계속 진행하는 경고 (stderr).
+pub fn warn(msg: &str) {
+    eprintln!("\x1b[1;33m!!\x1b[0m  {msg}");
+}
+
+/// `xx  msg` — 실패 (stderr). 종료는 호출자가 결정한다.
+pub fn fail(msg: &str) {
+    eprintln!("\x1b[1;31mxx\x1b[0m  {msg}");
+}

--- a/firecrab-cli/src/service/payload.rs
+++ b/firecrab-cli/src/service/payload.rs
@@ -1,0 +1,461 @@
+//! install.sh `resolve_payload` / `download_host_bundle`: 설치할 파일 묶음을
+//! `--bin-dir` 체크아웃 또는 다운로드한 릴리스 번들 중 하나로 확정한다.
+
+use std::path::{Path, PathBuf};
+
+use crate::shell::CommandRunner;
+use crate::update::{bundle, check};
+
+use super::Error;
+
+const STEP: &str = "payload";
+
+/// 번들과 `--bin-dir` 양쪽에서 반드시 있어야 하는 바이너리.
+pub const BUNDLE_BINARIES: [&str; 3] = ["firecrab-api", "firecrab-net-helper", "firecrab"];
+
+/// API가 런타임에 커널을 변환할 때 쓰는 셸 스크립트.
+pub const EXTRACT_HELPERS: [&str; 2] = ["extract-vmlinux", "extract-arm64-image"];
+
+/// `firecrab_elf_arch`: 64비트 리틀엔디언 ELF의 `e_machine`을 릴리스 arch 이름으로.
+pub fn elf_arch(path: &Path) -> Option<&'static str> {
+    let bytes = std::fs::read(path).ok()?;
+    if bytes.len() < 20 || &bytes[0..4] != b"\x7fELF" {
+        return None;
+    }
+    if bytes[4] != 2 || bytes[5] != 1 {
+        return None;
+    }
+    match u16::from_le_bytes([bytes[18], bytes[19]]) {
+        62 => Some("x86_64"),
+        183 => Some("aarch64"),
+        _ => None,
+    }
+}
+
+/// `firecrab_resolve_binary`: `--bin-dir`에 있으면 그것, 없으면 이미 설치된 것.
+///
+/// `scripts/firecrab-release.sh`는 `-x`(실행 비트)로 검사하지만, 여기서는
+/// `is_file()`로 충분하다: 설치는 `install -o root -g root -m 0755`로 복사돼
+/// 실행 비트를 무조건 다시 세팅하므로, 원본의 실행 비트 유무는 이후 설치
+/// 성공 여부에 영향을 주지 않는다.
+pub fn resolve_binary(name: &str, src_dir: Option<&Path>, dest_dir: &Path) -> Option<PathBuf> {
+    if let Some(src) = src_dir {
+        let candidate = src.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    let installed = dest_dir.join(name);
+    installed.is_file().then_some(installed)
+}
+
+/// `start`에서 위로 올라가며 firecrab 체크아웃 루트를 찾는다
+/// (install.sh `is_checkout`과 같은 판정).
+pub fn find_checkout(start: &Path) -> Option<PathBuf> {
+    let mut dir = Some(start);
+    while let Some(current) = dir {
+        if current.join("Cargo.toml").is_file()
+            && current
+                .join("packaging/systemd/firecrab-api.service")
+                .is_file()
+        {
+            return Some(current.to_path_buf());
+        }
+        dir = current.parent();
+    }
+    None
+}
+
+/// 추출된 릴리스 번들이 install.sh가 요구하는 멤버를 모두 갖췄는지 확인한다.
+///
+/// `install.sh`는 `[ -x "$PAYLOAD_ROOT/$name" ]`로 검사하지만, 여기서도
+/// [`resolve_binary`]와 같은 이유로 `is_file()`이면 충분하다 — 이후 설치
+/// 단계가 `install -m 0755`로 실행 비트를 다시 세팅한다.
+pub fn verify_bundle_members(root: &Path, arch: &str) -> Result<(), Error> {
+    for name in BUNDLE_BINARIES {
+        let path = root.join(name);
+        if !path.is_file() {
+            return Err(Error::step(
+                STEP,
+                format!("release bundle is missing {name}"),
+            ));
+        }
+        match elf_arch(&path) {
+            Some(found) if found == arch => {}
+            _ => {
+                return Err(Error::step(
+                    STEP,
+                    format!("release bundle: {name} is not a {arch} binary"),
+                ));
+            }
+        }
+    }
+    for name in [
+        "LICENSE",
+        "THIRD_PARTY_NOTICES.txt",
+        "release-license-inventory.json",
+        "licenses/GPL-2.0-only.txt",
+    ] {
+        if !root.join(name).is_file() {
+            return Err(Error::step(
+                STEP,
+                format!("release bundle is missing compliance artifact {name}"),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// 명시적으로 주어진 버전을 정규화한다. `None`은 "아직 확정된 태그가 없다 —
+/// GitHub의 `releases/latest`를 조회해서 알아내야 한다"는 뜻으로, 미지정
+/// (`None`), 빈 문자열, `"latest"` 모두 이 경우로 합쳐진다. 그 외에는
+/// `scripts/firecrab-release.sh`의 `firecrab_normalize_tag`와 같은 규칙으로
+/// `v` 접두를 보정한 `Some(tag)`를 돌려준다.
+///
+/// 순수 함수로 분리해 둔 이유는 네트워크 없이 태그 정규화 규칙만 테스트하기
+/// 위해서다 — 실제 "latest" 조회는 [`Payload::from_release`]에서
+/// `check::fetch_latest_tag`로 한다.
+fn normalize_tag(version: Option<&str>) -> Option<String> {
+    match version {
+        None => None,
+        Some(v) if v.is_empty() || v == "latest" => None,
+        Some(v) if v.starts_with('v') => Some(v.to_owned()),
+        Some(v) => Some(format!("v{v}")),
+    }
+}
+
+/// 설치할 파일들의 출처.
+#[derive(Debug)]
+pub struct Payload {
+    /// 바이너리가 있는 디렉터리.
+    pub bin: PathBuf,
+    /// `*.service` 템플릿 디렉터리.
+    pub units: PathBuf,
+    /// `extract-vmlinux` / `extract-arm64-image`가 있는 디렉터리.
+    pub extract: PathBuf,
+    /// 대시보드 빌드 (없으면 `--no-frontend`이거나 기존 설치 유지).
+    pub dashboard: Option<PathBuf>,
+    /// FireCrab LICENSE.
+    pub license: PathBuf,
+    /// GPL-2.0 전문.
+    pub gpl: PathBuf,
+    /// 서드파티 고지 (체크아웃에서는 없을 수 있음).
+    pub third_party: Option<PathBuf>,
+    /// 라이선스 인벤토리 (체크아웃에서는 없을 수 있음).
+    pub inventory: Option<PathBuf>,
+    /// 체크아웃 루트 (firecracker 스크립트 탐색에 쓰임).
+    pub checkout: Option<PathBuf>,
+    /// 다운로드 번들의 수명을 payload에 묶는다.
+    pub(crate) _temp: Option<tempfile::TempDir>,
+}
+
+impl Payload {
+    /// install.sh `resolve_payload`의 `dir` 분기.
+    pub fn from_bin_dir(
+        bin_dir: &Path,
+        dashboard_dir: Option<&Path>,
+        checkout: &Path,
+    ) -> Result<Self, Error> {
+        if !bin_dir.is_dir() {
+            return Err(Error::step(
+                STEP,
+                format!("--bin-dir is not a directory: {}", bin_dir.display()),
+            ));
+        }
+        for name in BUNDLE_BINARIES {
+            if !bin_dir.join(name).is_file() {
+                return Err(Error::step_fix(
+                    STEP,
+                    format!("no {name} in {}", bin_dir.display()),
+                    "cargo build --release -p firecrab-api -p firecrab-net-helper -p firecrab-cli",
+                ));
+            }
+        }
+        let license = checkout.join("LICENSE");
+        let gpl = checkout.join("licenses/GPL-2.0-only.txt");
+        for path in [&license, &gpl] {
+            if !path.is_file() {
+                return Err(Error::step(
+                    STEP,
+                    format!("missing {} in the checkout", path.display()),
+                ));
+            }
+        }
+        let compliance = checkout.join("dist/compliance");
+        let (third_party, inventory) = {
+            let notices = compliance.join("THIRD_PARTY_NOTICES.txt");
+            let inv = compliance.join("release-license-inventory.json");
+            if notices.is_file() && inv.is_file() {
+                (Some(notices), Some(inv))
+            } else {
+                (None, None)
+            }
+        };
+        let dashboard = match dashboard_dir {
+            Some(dir) => Some(dir.to_path_buf()),
+            None => {
+                let default = checkout.join("firecrab-frontend/dist");
+                default.join("index.html").is_file().then_some(default)
+            }
+        };
+        Ok(Self {
+            bin: bin_dir.to_path_buf(),
+            units: checkout.join("packaging/systemd"),
+            extract: checkout.join("scripts/firecracker-menual"),
+            dashboard,
+            license,
+            gpl,
+            third_party,
+            inventory,
+            checkout: Some(checkout.to_path_buf()),
+            _temp: None,
+        })
+    }
+
+    /// install.sh `download_host_bundle`: 번들과 `SHA256SUMS`를 받아 검증하고 푼다.
+    pub fn from_release(
+        runner: &dyn CommandRunner,
+        version: Option<&str>,
+        libc: Option<&str>,
+    ) -> Result<Self, Error> {
+        let arch = bundle::host_arch()?;
+        let libc = bundle::host_libc(libc)?;
+        let tarball = bundle::host_tarball(arch, libc);
+        // GitHub only serves the "latest" alias at `releases/latest/download/…`,
+        // never `releases/download/latest/…` (see `bundle::asset_url`'s doc
+        // comment). So an unspecified/"latest" version must be resolved to a
+        // real tag first, the same way `firecrab update` does via
+        // `check::fetch_latest_tag`.
+        let tag = match normalize_tag(version) {
+            Some(tag) => tag,
+            None => check::fetch_latest_tag(&check::release_api_url(&bundle::release_repo()))?,
+        };
+        let base = bundle::release_base();
+
+        let temp = tempfile::tempdir().map_err(|e| {
+            Error::step(STEP, format!("could not create a temporary directory: {e}"))
+        })?;
+        let archive = temp.path().join(&tarball);
+        let sums = temp.path().join("SHA256SUMS");
+
+        super::output::step(&format!("downloading {tarball}"));
+        bundle::download_to(&bundle::asset_url(&base, &tag, &tarball), &archive)?;
+        bundle::download_to(&bundle::asset_url(&base, &tag, "SHA256SUMS"), &sums)?;
+
+        let sums_text = std::fs::read_to_string(&sums).unwrap_or_default();
+        let expected = bundle::expected_sha256(&sums_text, &tarball)
+            .ok_or_else(|| Error::step(STEP, format!("{tarball} is not listed in SHA256SUMS")))?;
+        let actual = bundle::file_sha256(&archive)?;
+        if actual != expected {
+            return Err(Error::step(
+                STEP,
+                format!("checksum mismatch for {tarball}: expected {expected}, got {actual}"),
+            ));
+        }
+
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&root)
+            .map_err(|e| Error::step(STEP, format!("could not create {}: {e}", root.display())))?;
+        let (archive_s, root_s) = (
+            archive.to_string_lossy().into_owned(),
+            root.to_string_lossy().into_owned(),
+        );
+        let out = runner
+            .run("tar", &["-xzf", &archive_s, "-C", &root_s])
+            .map_err(|e| Error::step(STEP, format!("tar: {e}")))?;
+        if !out.status.success() {
+            return Err(Error::step(
+                STEP,
+                format!(
+                    "tar failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+            ));
+        }
+
+        verify_bundle_members(&root, arch)?;
+        super::output::log(&format!("host bundle {arch}/{libc}"));
+        Ok(Self {
+            bin: root.clone(),
+            units: root.join("systemd"),
+            extract: root.clone(),
+            dashboard: Some(root.join("dashboard")),
+            license: root.join("LICENSE"),
+            gpl: root.join("licenses/GPL-2.0-only.txt"),
+            third_party: Some(root.join("THIRD_PARTY_NOTICES.txt")),
+            inventory: Some(root.join("release-license-inventory.json")),
+            checkout: None,
+            _temp: Some(temp),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Minimal 64-bit little-endian ELF header with the given e_machine.
+    fn write_elf(path: &Path, machine: u16) {
+        let mut header = vec![0u8; 64];
+        header[0..4].copy_from_slice(&[0x7f, b'E', b'L', b'F']);
+        header[4] = 2; // ELFCLASS64
+        header[5] = 1; // ELFDATA2LSB
+        header[18..20].copy_from_slice(&machine.to_le_bytes());
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(&header).unwrap();
+    }
+
+    #[test]
+    fn normalize_tag_resolves_absent_and_latest_to_none_and_prefixes_bare_versions() {
+        assert_eq!(normalize_tag(None), None);
+        assert_eq!(normalize_tag(Some("latest")), None);
+        assert_eq!(normalize_tag(Some("")), None);
+        assert_eq!(normalize_tag(Some("0.3.0")), Some("v0.3.0".to_owned()));
+        assert_eq!(normalize_tag(Some("v0.3.0")), Some("v0.3.0".to_owned()));
+    }
+
+    #[test]
+    fn elf_arch_reads_the_machine_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let x86 = dir.path().join("x86");
+        let arm = dir.path().join("arm");
+        let junk = dir.path().join("junk");
+        write_elf(&x86, 62);
+        write_elf(&arm, 183);
+        std::fs::write(&junk, b"not an elf").unwrap();
+        assert_eq!(elf_arch(&x86), Some("x86_64"));
+        assert_eq!(elf_arch(&arm), Some("aarch64"));
+        assert_eq!(elf_arch(&junk), None);
+        assert_eq!(elf_arch(&dir.path().join("absent")), None);
+    }
+
+    #[test]
+    fn resolve_binary_prefers_the_source_directory_then_the_installed_copy() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        let dest = dir.path().join("dest");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::write(dest.join("firecrab-api"), b"old").unwrap();
+        assert_eq!(
+            resolve_binary("firecrab-api", Some(&src), &dest),
+            Some(dest.join("firecrab-api"))
+        );
+        std::fs::write(src.join("firecrab-api"), b"new").unwrap();
+        assert_eq!(
+            resolve_binary("firecrab-api", Some(&src), &dest),
+            Some(src.join("firecrab-api"))
+        );
+        assert_eq!(resolve_binary("absent", Some(&src), &dest), None);
+    }
+
+    #[test]
+    fn find_checkout_walks_up_to_the_workspace_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::write(root.join("Cargo.toml"), b"[workspace]\n").unwrap();
+        std::fs::create_dir_all(root.join("packaging/systemd")).unwrap();
+        std::fs::write(
+            root.join("packaging/systemd/firecrab-api.service"),
+            b"[Unit]\n",
+        )
+        .unwrap();
+        let nested = root.join("a/b");
+        std::fs::create_dir_all(&nested).unwrap();
+        assert_eq!(find_checkout(&nested).as_deref(), Some(root));
+        let elsewhere = tempfile::tempdir().unwrap();
+        assert_eq!(find_checkout(elsewhere.path()), None);
+    }
+
+    #[test]
+    fn from_bin_dir_requires_the_binaries_and_units() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("packaging/systemd")).unwrap();
+        std::fs::create_dir_all(root.join("scripts/firecracker-menual")).unwrap();
+        std::fs::create_dir_all(root.join("licenses")).unwrap();
+        std::fs::write(root.join("LICENSE"), b"x").unwrap();
+        std::fs::write(root.join("licenses/GPL-2.0-only.txt"), b"x").unwrap();
+        let bin = root.join("target/release");
+        std::fs::create_dir_all(&bin).unwrap();
+
+        let err = Payload::from_bin_dir(&bin, None, root).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::Step {
+                    step: "payload",
+                    ..
+                }
+            ),
+            "{err:?}"
+        );
+
+        for name in BUNDLE_BINARIES {
+            std::fs::write(bin.join(name), b"x").unwrap();
+        }
+        let dash = root.join("firecrab-frontend/dist");
+        std::fs::create_dir_all(&dash).unwrap();
+        std::fs::write(dash.join("index.html"), b"<html>").unwrap();
+
+        let payload = Payload::from_bin_dir(&bin, None, root).unwrap();
+        assert_eq!(payload.bin, bin);
+        assert_eq!(payload.units, root.join("packaging/systemd"));
+        assert_eq!(payload.extract, root.join("scripts/firecracker-menual"));
+        assert_eq!(payload.dashboard.as_deref(), Some(dash.as_path()));
+        assert_eq!(payload.checkout.as_deref(), Some(root));
+    }
+
+    #[test]
+    fn from_bin_dir_accepts_an_explicit_dashboard_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("packaging/systemd")).unwrap();
+        std::fs::create_dir_all(root.join("scripts/firecracker-menual")).unwrap();
+        std::fs::create_dir_all(root.join("licenses")).unwrap();
+        std::fs::write(root.join("LICENSE"), b"x").unwrap();
+        std::fs::write(root.join("licenses/GPL-2.0-only.txt"), b"x").unwrap();
+        let bin = root.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        for name in BUNDLE_BINARIES {
+            std::fs::write(bin.join(name), b"x").unwrap();
+        }
+        let dash = root.join("custom-dash");
+        std::fs::create_dir_all(&dash).unwrap();
+        std::fs::write(dash.join("index.html"), b"<html>").unwrap();
+
+        let payload = Payload::from_bin_dir(&bin, Some(&dash), root).unwrap();
+        assert_eq!(payload.dashboard.as_deref(), Some(dash.as_path()));
+    }
+
+    #[test]
+    fn verify_bundle_members_rejects_a_missing_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("licenses")).unwrap();
+        std::fs::write(root.join("LICENSE"), b"x").unwrap();
+        std::fs::write(root.join("licenses/GPL-2.0-only.txt"), b"x").unwrap();
+        write_elf(&root.join("firecrab-api"), 62);
+        let err = verify_bundle_members(root, "x86_64").unwrap_err();
+        assert!(format!("{err}").contains("firecrab-net-helper"), "{err}");
+    }
+
+    #[test]
+    fn verify_bundle_members_rejects_a_foreign_architecture() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("licenses")).unwrap();
+        std::fs::create_dir_all(root.join("systemd")).unwrap();
+        std::fs::create_dir_all(root.join("dashboard")).unwrap();
+        std::fs::write(root.join("LICENSE"), b"x").unwrap();
+        std::fs::write(root.join("THIRD_PARTY_NOTICES.txt"), b"x").unwrap();
+        std::fs::write(root.join("release-license-inventory.json"), b"{}").unwrap();
+        std::fs::write(root.join("licenses/GPL-2.0-only.txt"), b"x").unwrap();
+        for name in BUNDLE_BINARIES {
+            write_elf(&root.join(name), 183); // aarch64
+        }
+        let err = verify_bundle_members(root, "x86_64").unwrap_err();
+        assert!(format!("{err}").contains("x86_64"), "{err}");
+    }
+}

--- a/firecrab-cli/src/service/pkg.rs
+++ b/firecrab-cli/src/service/pkg.rs
@@ -1,0 +1,319 @@
+//! install.sh의 `detect_pkg` / `pkg_name` / `pkg_refresh` / `pkg_install`.
+
+use crate::shell::CommandRunner;
+
+use super::Error;
+use super::privileged::Privileged;
+
+/// install.sh `have`: `command -v <cmd>`.
+///
+/// `sh -c` 경유인 이유는 `command`가 셸 빌트인이라 `std::process::Command`로
+/// 직접 부를 수 없기 때문이다.
+pub fn have(runner: &dyn CommandRunner, cmd: &str) -> bool {
+    let probe = format!("command -v {cmd}");
+    runner
+        .run("sh", &["-c", &probe])
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// The package managers install.sh knows, in its probe order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PkgManager {
+    /// Debian, Ubuntu.
+    AptGet,
+    /// Fedora, RHEL.
+    Dnf,
+    /// openSUSE.
+    Zypper,
+    /// Arch.
+    Pacman,
+    /// Alpine.
+    Apk,
+}
+
+impl PkgManager {
+    /// The first manager on `$PATH`, probed in install.sh's order.
+    pub fn detect(runner: &dyn CommandRunner) -> Option<Self> {
+        [
+            Self::AptGet,
+            Self::Dnf,
+            Self::Zypper,
+            Self::Pacman,
+            Self::Apk,
+        ]
+        .into_iter()
+        .find(|candidate| have(runner, candidate.as_str()))
+    }
+
+    /// The binary name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::AptGet => "apt-get",
+            Self::Dnf => "dnf",
+            Self::Zypper => "zypper",
+            Self::Pacman => "pacman",
+            Self::Apk => "apk",
+        }
+    }
+
+    /// install.sh `pkg_name`: the distro package(s) providing a generic name.
+    /// One generic name can map to two packages, so this returns a list.
+    pub fn packages_for<'a>(&self, generic: &'a str) -> Vec<&'a str> {
+        match (self, generic) {
+            (Self::Dnf, "iproute2") => vec!["iproute"],
+            // dhcp_release ships separately on Debian/Alpine; RHEL has no such package.
+            (Self::Dnf, "dnsmasq-utils") => vec!["dnsmasq"],
+            (Self::Apk, "e2fsprogs") => vec!["e2fsprogs-extra"],
+            (Self::AptGet, "xz") => vec!["xz-utils"],
+            // semanage lives in a python tooling package on the SELinux distros.
+            (Self::Dnf | Self::AptGet | Self::Zypper, "selinux-tools") => {
+                vec!["policycoreutils-python-utils"]
+            }
+            (_, "selinux-tools") => vec!["policycoreutils"],
+            (_, "iproute2") => vec!["iproute2"],
+            (_, "dnsmasq-utils") => vec!["dnsmasq-utils"],
+            (_, "e2fsprogs") => vec!["e2fsprogs"],
+            (_, "xz") => vec!["xz"],
+            (_, "nftables") => vec!["nftables"],
+            (_, "dnsmasq") => vec!["dnsmasq"],
+            (_, "curl") => vec!["curl"],
+            (_, "findutils") => vec!["findutils"],
+            (_, "tar") => vec!["tar"],
+            (_, "zstd") => vec!["zstd"],
+            (_, "coreutils") => vec!["coreutils"],
+            // Unknown generics pass through as-is.
+            (_, other) => vec![other],
+        }
+    }
+}
+
+/// Installs packages, refreshing the index at most once per run.
+pub struct Packages<'a> {
+    manager: Option<PkgManager>,
+    privileged: &'a Privileged<'a>,
+    refreshed: bool,
+}
+
+impl<'a> Packages<'a> {
+    /// Binds a detected manager (or none) to a privileged runner.
+    pub fn new(manager: Option<PkgManager>, privileged: &'a Privileged<'a>) -> Self {
+        Self {
+            manager,
+            privileged,
+            refreshed: false,
+        }
+    }
+
+    /// The detected manager, if any.
+    pub fn manager(&self) -> Option<PkgManager> {
+        self.manager
+    }
+
+    /// The underlying command runner, for read-only probes.
+    pub fn runner(&self) -> &'a dyn CommandRunner {
+        self.privileged.runner()
+    }
+
+    /// install.sh `pkg_refresh`: once per process, and only where it matters.
+    fn refresh(&mut self, step: &'static str) -> Result<(), Error> {
+        if self.refreshed {
+            return Ok(());
+        }
+        self.refreshed = true;
+        match self.manager {
+            Some(PkgManager::AptGet) => {
+                self.privileged.run_env(
+                    step,
+                    &[("DEBIAN_FRONTEND", "noninteractive")],
+                    "apt-get",
+                    &["update", "-qq"],
+                )?;
+            }
+            Some(PkgManager::Apk) => {
+                self.privileged.run_ok(step, "apk", &["update", "-q"])?;
+            }
+            // dnf/zypper/pacman refresh as part of install.
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn install_once(&self, step: &'static str, packages: &[&str]) -> Result<(), Error> {
+        let manager = self.manager.ok_or_else(|| {
+            Error::step(
+                step,
+                format!("no known package manager for: {}", packages.join(" ")),
+            )
+        })?;
+        match manager {
+            PkgManager::AptGet => {
+                let mut args = vec!["install", "-y", "-qq"];
+                args.extend_from_slice(packages);
+                self.privileged.run_env(
+                    step,
+                    &[("DEBIAN_FRONTEND", "noninteractive")],
+                    "apt-get",
+                    &args,
+                )?;
+            }
+            PkgManager::Dnf => {
+                let mut args = vec!["install", "-y", "-q"];
+                args.extend_from_slice(packages);
+                self.privileged.run_ok(step, "dnf", &args)?;
+            }
+            PkgManager::Zypper => {
+                let mut args = vec!["--non-interactive", "install", "-y"];
+                args.extend_from_slice(packages);
+                self.privileged.run_ok(step, "zypper", &args)?;
+            }
+            PkgManager::Pacman => {
+                let mut args = vec!["-Sy", "--noconfirm", "--needed"];
+                args.extend_from_slice(packages);
+                self.privileged.run_ok(step, "pacman", &args)?;
+            }
+            PkgManager::Apk => {
+                let mut args = vec!["add", "--no-cache"];
+                args.extend_from_slice(packages);
+                self.privileged.run_ok(step, "apk", &args)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// install.sh `pkg_install`: refresh once, then one retry — Fedora's
+    /// metalink/mirror writes fail transiently.
+    ///
+    /// install.sh sleeps 2s between the failed attempt and the retry
+    /// (install.sh:280); deliberately omitted here so tests stay fast.
+    pub fn install(&mut self, step: &'static str, packages: &[&str]) -> Result<(), Error> {
+        if self.manager.is_none() {
+            return Err(Error::step(
+                step,
+                format!("no known package manager for: {}", packages.join(" ")),
+            ));
+        }
+        self.refresh(step)?;
+        match self.install_once(step, packages) {
+            Ok(()) => Ok(()),
+            Err(_) => {
+                super::output::warn("package install failed; retrying once");
+                self.install_once(step, packages)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::privileged::Privileged;
+    use crate::shell::FakeCommandRunner;
+
+    #[test]
+    fn detect_prefers_the_first_manager_on_path() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set("sh", &["-c", "command -v dnf"], 0, "/usr/bin/dnf\n", "");
+        // apt-get is probed first and is not registered → NotFound → absent.
+        assert_eq!(PkgManager::detect(&fake), Some(PkgManager::Dnf));
+    }
+
+    #[test]
+    fn detect_returns_none_without_any_manager() {
+        assert_eq!(PkgManager::detect(&FakeCommandRunner::new()), None);
+    }
+
+    #[test]
+    fn package_names_follow_install_sh_mapping() {
+        assert_eq!(PkgManager::Dnf.packages_for("iproute2"), vec!["iproute"]);
+        assert_eq!(
+            PkgManager::AptGet.packages_for("iproute2"),
+            vec!["iproute2"]
+        );
+        assert_eq!(
+            PkgManager::Dnf.packages_for("dnsmasq-utils"),
+            vec!["dnsmasq"]
+        );
+        assert_eq!(
+            PkgManager::Apk.packages_for("dnsmasq-utils"),
+            vec!["dnsmasq-utils"]
+        );
+        assert_eq!(
+            PkgManager::Apk.packages_for("e2fsprogs"),
+            vec!["e2fsprogs-extra"]
+        );
+        assert_eq!(
+            PkgManager::Pacman.packages_for("e2fsprogs"),
+            vec!["e2fsprogs"]
+        );
+        assert_eq!(PkgManager::AptGet.packages_for("xz"), vec!["xz-utils"]);
+        assert_eq!(PkgManager::Zypper.packages_for("xz"), vec!["xz"]);
+        assert_eq!(
+            PkgManager::Dnf.packages_for("selinux-tools"),
+            vec!["policycoreutils-python-utils"]
+        );
+        assert_eq!(
+            PkgManager::Pacman.packages_for("selinux-tools"),
+            vec!["policycoreutils"]
+        );
+        assert_eq!(PkgManager::AptGet.packages_for("curl"), vec!["curl"]);
+    }
+
+    #[test]
+    fn install_refreshes_the_index_at_most_once() {
+        let fake = FakeCommandRunner::permissive();
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::AptGet), &privileged);
+        packages.install("deps", &["nftables"]).unwrap();
+        packages.install("deps", &["dnsmasq"]).unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec![
+                "sudo env DEBIAN_FRONTEND=noninteractive apt-get update -qq",
+                "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nftables",
+                "sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq dnsmasq",
+            ]
+        );
+    }
+
+    #[test]
+    fn install_retries_once_before_failing() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "sudo",
+            &["dnf", "install", "-y", "-q", "nftables"],
+            1,
+            "",
+            "mirror error\n",
+        );
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(Some(PkgManager::Dnf), &privileged);
+        let err = packages.install("deps", &["nftables"]).unwrap_err();
+        assert!(matches!(err, Error::Step { step: "deps", .. }), "{err:?}");
+        assert_eq!(
+            fake.calls()
+                .iter()
+                .filter(|c| c.contains("dnf install"))
+                .count(),
+            2,
+            "one retry, then give up"
+        );
+    }
+
+    #[test]
+    fn install_without_a_manager_is_an_error() {
+        let fake = FakeCommandRunner::permissive();
+        let privileged = Privileged::with_sudo(&fake, true);
+        let mut packages = Packages::new(None, &privileged);
+        assert!(packages.install("deps", &["nftables"]).is_err());
+    }
+
+    #[test]
+    fn have_probes_with_command_v() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set("sh", &["-c", "command -v nft"], 0, "/usr/sbin/nft\n", "");
+        fake.set("sh", &["-c", "command -v missing"], 1, "", "");
+        assert!(have(&fake, "nft"));
+        assert!(!have(&fake, "missing"));
+    }
+}

--- a/firecrab-cli/src/service/privileged.rs
+++ b/firecrab-cli/src/service/privileged.rs
@@ -1,0 +1,347 @@
+//! install.sh의 `$SUDO` 접두: root면 빈 문자열, 아니면 `sudo`.
+//!
+//! 전체 프로세스를 root로 올리지 않고 변경 명령마다 `sudo`를 붙이는 이유는
+//! install.sh와 같다 — `$HOME`, SSH 키, 다운로드 캐시가 호출자의 것으로 남는다.
+
+use std::io;
+use std::path::Path;
+use std::process::Output;
+
+use crate::shell::CommandRunner;
+
+use super::Error;
+
+/// Runs host-mutating commands with a `sudo` prefix when not already root.
+pub struct Privileged<'a> {
+    runner: &'a dyn CommandRunner,
+    use_sudo: bool,
+}
+
+impl<'a> Privileged<'a> {
+    /// `sudo` unless the effective uid is 0.
+    pub fn detect(runner: &'a dyn CommandRunner) -> Self {
+        Self::with_sudo(runner, !nix::unistd::geteuid().is_root())
+    }
+
+    /// Explicit form for tests.
+    pub fn with_sudo(runner: &'a dyn CommandRunner, use_sudo: bool) -> Self {
+        Self { runner, use_sudo }
+    }
+
+    /// The underlying runner, for read-only probes that must not go through sudo.
+    pub fn runner(&self) -> &'a dyn CommandRunner {
+        self.runner
+    }
+
+    /// Whether commands are prefixed with `sudo`.
+    pub fn uses_sudo(&self) -> bool {
+        self.use_sudo
+    }
+
+    fn argv<'b>(&self, cmd: &'b str, args: &[&'b str]) -> (&'b str, Vec<&'b str>) {
+        if self.use_sudo {
+            let mut full = Vec::with_capacity(args.len() + 1);
+            full.push(cmd);
+            full.extend_from_slice(args);
+            ("sudo", full)
+        } else {
+            (cmd, args.to_vec())
+        }
+    }
+
+    /// install.sh `require_sudo_ticket`: `sudo -n true`, else one interactive `sudo -v`.
+    ///
+    /// Whether a controlling terminal is available for that interactive
+    /// prompt is decided by the caller via `has_tty` (see [`Self::ensure_ticket`]
+    /// for the real check), so this can be exercised deterministically in tests.
+    pub fn ensure_ticket_with(&self, has_tty: bool) -> Result<(), Error> {
+        if !self.use_sudo {
+            return Ok(());
+        }
+        match self.runner.run("sudo", &["-n", "true"]) {
+            Ok(out) if out.status.success() => return Ok(()),
+            Ok(_) => {}
+            Err(_) => {
+                return Err(Error::Sudo(
+                    "sudo is required for privileged steps; install it first".into(),
+                ));
+            }
+        }
+        if !has_tty {
+            return Err(Error::Sudo(
+                "needs a password and this session has no terminal".into(),
+            ));
+        }
+        super::output::step("sudo password required");
+        // `sudo -v` talks to the controlling tty itself; stdout/stderr capture does not interfere.
+        match std::process::Command::new("sudo").arg("-v").status() {
+            Ok(status) if status.success() => Ok(()),
+            _ => Err(Error::Sudo("authentication failed".into())),
+        }
+    }
+
+    /// [`Self::ensure_ticket_with`], deciding tty availability from `/dev/tty`.
+    pub fn ensure_ticket(&self) -> Result<(), Error> {
+        self.ensure_ticket_with(Path::new("/dev/tty").exists())
+    }
+
+    /// `[sudo] cmd args…`, raw `Output`.
+    pub fn run(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
+        let (cmd, args) = self.argv(cmd, args);
+        self.runner.run(cmd, &args)
+    }
+
+    /// [`Self::run`] that turns a spawn failure or a nonzero exit into [`Error::Step`].
+    pub fn run_ok(&self, step: &'static str, cmd: &str, args: &[&str]) -> Result<Output, Error> {
+        let line = format!("{cmd} {}", args.join(" "));
+        let out = self
+            .run(cmd, args)
+            .map_err(|e| Error::step(step, format!("{line}: {e}")))?;
+        if out.status.success() {
+            Ok(out)
+        } else {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_owned();
+            Err(Error::step(
+                step,
+                format!("{line} failed ({}): {stderr}", out.status),
+            ))
+        }
+    }
+
+    /// `[sudo] env K=V… cmd args…`.
+    pub fn run_env(
+        &self,
+        step: &'static str,
+        envs: &[(&str, &str)],
+        cmd: &str,
+        args: &[&str],
+    ) -> Result<Output, Error> {
+        let assignments: Vec<String> = envs.iter().map(|(k, v)| format!("{k}={v}")).collect();
+        let mut full: Vec<&str> = assignments.iter().map(String::as_str).collect();
+        full.push(cmd);
+        full.extend_from_slice(args);
+        self.run_ok(step, "env", &full)
+    }
+
+    /// `[sudo] tee path` with `contents` on stdin, then `[sudo] chmod mode path`.
+    pub fn write_file(
+        &self,
+        step: &'static str,
+        path: &Path,
+        contents: &[u8],
+        mode: &str,
+    ) -> Result<(), Error> {
+        let path_s = path.to_string_lossy();
+        let (cmd, args) = self.argv("tee", &[&path_s]);
+        let out = self
+            .runner
+            .run_with_stdin(cmd, &args, contents)
+            .map_err(|e| Error::step(step, format!("tee {path_s}: {e}")))?;
+        if !out.status.success() {
+            return Err(Error::step(
+                step,
+                format!(
+                    "tee {path_s} failed: {}",
+                    String::from_utf8_lossy(&out.stderr).trim()
+                ),
+            ));
+        }
+        self.run_ok(step, "chmod", &[mode, &path_s]).map(|_| ())
+    }
+
+    /// `[sudo] install -o owner -g group -m mode src dest`.
+    pub fn install_file(
+        &self,
+        step: &'static str,
+        src: &Path,
+        dest: &Path,
+        owner: &str,
+        group: &str,
+        mode: &str,
+    ) -> Result<(), Error> {
+        let (src, dest) = (src.to_string_lossy(), dest.to_string_lossy());
+        self.run_ok(
+            step,
+            "install",
+            &["-o", owner, "-g", group, "-m", mode, &src, &dest],
+        )
+        .map(|_| ())
+    }
+
+    /// `[sudo] install -d -o owner -g group -m mode dirs…`.
+    pub fn install_dirs(
+        &self,
+        step: &'static str,
+        dirs: &[&Path],
+        owner: &str,
+        group: &str,
+        mode: &str,
+    ) -> Result<(), Error> {
+        let dirs: Vec<String> = dirs
+            .iter()
+            .map(|d| d.to_string_lossy().into_owned())
+            .collect();
+        let mut args = vec!["-d", "-o", owner, "-g", group, "-m", mode];
+        args.extend(dirs.iter().map(String::as_str));
+        self.run_ok(step, "install", &args).map(|_| ())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+
+    #[test]
+    fn sudo_prefix_only_when_not_root() {
+        let fake = FakeCommandRunner::permissive();
+        Privileged::with_sudo(&fake, true)
+            .run("systemctl", &["daemon-reload"])
+            .unwrap();
+        Privileged::with_sudo(&fake, false)
+            .run("systemctl", &["daemon-reload"])
+            .unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec!["sudo systemctl daemon-reload", "systemctl daemon-reload"]
+        );
+    }
+
+    #[test]
+    fn run_ok_maps_nonzero_exit_to_step_error() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set("sudo", &["useradd", "x"], 9, "", "useradd: UID in use\n");
+        let err = Privileged::with_sudo(&fake, true)
+            .run_ok("account", "useradd", &["x"])
+            .unwrap_err();
+        match err {
+            Error::Step { step, detail, .. } => {
+                assert_eq!(step, "account");
+                assert!(
+                    detail.contains("useradd") && detail.contains("UID in use"),
+                    "{detail}"
+                );
+            }
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_ok_maps_spawn_failure_to_step_error() {
+        let fake = FakeCommandRunner::new(); // strict: nothing registered → NotFound
+        let err = Privileged::with_sudo(&fake, false)
+            .run_ok("units", "systemctl", &["x"])
+            .unwrap_err();
+        assert!(matches!(err, Error::Step { step: "units", .. }));
+    }
+
+    #[test]
+    fn write_file_uses_tee_then_chmod() {
+        let fake = FakeCommandRunner::permissive();
+        let p = Privileged::with_sudo(&fake, true);
+        p.write_file(
+            "units",
+            Path::new("/etc/systemd/system/a.service"),
+            b"[Unit]\n",
+            "0644",
+        )
+        .unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec![
+                "sudo tee /etc/systemd/system/a.service",
+                "sudo chmod 0644 /etc/systemd/system/a.service",
+            ]
+        );
+        assert_eq!(
+            fake.stdin_of("sudo tee /etc/systemd/system/a.service"),
+            Some(b"[Unit]\n".to_vec())
+        );
+    }
+
+    #[test]
+    fn install_helpers_build_install_argv() {
+        let fake = FakeCommandRunner::permissive();
+        let p = Privileged::with_sudo(&fake, false);
+        p.install_file(
+            "binaries",
+            Path::new("/tmp/a"),
+            Path::new("/usr/local/lib/firecrab/a"),
+            "root",
+            "root",
+            "0755",
+        )
+        .unwrap();
+        p.install_dirs(
+            "directories",
+            &[
+                Path::new("/var/lib/firecrab"),
+                Path::new("/var/lib/firecrab/data"),
+            ],
+            "firecrab",
+            "firecrab",
+            "0750",
+        )
+        .unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec![
+                "install -o root -g root -m 0755 /tmp/a /usr/local/lib/firecrab/a",
+                "install -d -o firecrab -g firecrab -m 0750 /var/lib/firecrab /var/lib/firecrab/data",
+            ]
+        );
+    }
+
+    #[test]
+    fn run_env_prefixes_env_assignments() {
+        let fake = FakeCommandRunner::permissive();
+        Privileged::with_sudo(&fake, true)
+            .run_env(
+                "firecracker",
+                &[(
+                    "FIRECRACKER_NOTICE_DIR",
+                    "/usr/local/share/firecrab/firecracker",
+                )],
+                "bash",
+                &["/tmp/i.sh"],
+            )
+            .unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec![
+                "sudo env FIRECRACKER_NOTICE_DIR=/usr/local/share/firecrab/firecracker bash /tmp/i.sh"
+            ]
+        );
+    }
+
+    #[test]
+    fn ensure_ticket_is_a_noop_as_root_and_probes_sudo_otherwise() {
+        let fake = FakeCommandRunner::permissive();
+        Privileged::with_sudo(&fake, false)
+            .ensure_ticket_with(true)
+            .unwrap();
+        assert!(fake.calls().is_empty());
+        Privileged::with_sudo(&fake, true)
+            .ensure_ticket_with(true)
+            .unwrap();
+        assert_eq!(fake.calls(), vec!["sudo -n true"]);
+    }
+
+    #[test]
+    fn ensure_ticket_fails_without_a_tty_when_sudo_needs_a_password() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "sudo",
+            &["-n", "true"],
+            1,
+            "",
+            "sudo: a password is required\n",
+        );
+        // `sudo -v` is not registered → NotFound → treated as unusable.
+        let err = Privileged::with_sudo(&fake, true)
+            .ensure_ticket_with(false)
+            .unwrap_err();
+        assert!(matches!(err, Error::Sudo(_)));
+    }
+}

--- a/firecrab-cli/src/service/selinux.rs
+++ b/firecrab-cli/src/service/selinux.rs
@@ -1,0 +1,292 @@
+//! install.sh `selinux_active` / `label_selinux_binaries`.
+//!
+//! `$PREFIX/lib/firecrab`는 기본 정책에서 `lib_t`이고, 서비스를 `init_t`에서
+//! 꺼내주는 규칙은 `bin_t` 실행 파일에만 적용된다. 라벨이 없으면 API가
+//! `init_t`에 남아 레지스트리로의 아웃바운드 HTTPS가 전부 거부된다.
+
+use crate::shell::CommandRunner;
+
+use super::env::ServiceEnv;
+use super::output;
+use super::pkg::have;
+use super::privileged::Privileged;
+
+/// SELinux가 로드되어 있는가. Permissive도 참 — 라벨이 틀리면 enforcing으로
+/// 되돌리는 순간 설치가 깨진다.
+pub fn selinux_active(runner: &dyn CommandRunner) -> bool {
+    if !have(runner, "getenforce") {
+        return false;
+    }
+    runner
+        .run("getenforce", &[])
+        .map(|out| {
+            let mode = String::from_utf8_lossy(&out.stdout).trim().to_owned();
+            mode == "Enforcing" || mode == "Permissive"
+        })
+        .unwrap_or(false)
+}
+
+fn pattern(env: &ServiceEnv) -> String {
+    format!("{}(/.*)?", env.libdir.display())
+}
+
+/// `$LIBDIR`에 `bin_t` 파일 컨텍스트를 기록하고 적용한다. 실패는 경고로 끝난다.
+pub fn label_binaries(privileged: &Privileged<'_>, env: &ServiceEnv) {
+    if !selinux_active(privileged.runner()) {
+        return;
+    }
+    let pattern = pattern(env);
+    if !have(privileged.runner(), "semanage") {
+        output::warn(&format!(
+            "semanage missing; cannot label {} bin_t — the services will stay in init_t and every registry read will fail (see `firecrab doctor`)",
+            env.libdir.display()
+        ));
+        return;
+    }
+    // `-a` fails when the rule already exists, which every re-run hits.
+    let added = privileged
+        .run("semanage", &["fcontext", "-a", "-t", "bin_t", &pattern])
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !added {
+        let modified = privileged
+            .run("semanage", &["fcontext", "-m", "-t", "bin_t", &pattern])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !modified {
+            output::warn(&format!(
+                "could not record an SELinux file context for {}",
+                env.libdir.display()
+            ));
+            return;
+        }
+    }
+    if have(privileged.runner(), "restorecon") {
+        let libdir = env.libdir.to_string_lossy().into_owned();
+        if privileged
+            .run("restorecon", &["-R", &libdir])
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            output::warn(&format!("restorecon failed for {libdir}"));
+        }
+    }
+    output::log(&format!("SELinux: {} labelled bin_t", env.libdir.display()));
+}
+
+/// 삭제 시 파일 컨텍스트 규칙을 걷어낸다. 규칙이 디렉터리보다 오래 살아남으면
+/// 다음에 그 경로에 설치되는 것이 조용히 재라벨된다.
+pub fn unlabel_binaries(privileged: &Privileged<'_>, env: &ServiceEnv) {
+    if !have(privileged.runner(), "semanage") {
+        return;
+    }
+    let _ = privileged.run("semanage", &["fcontext", "-d", &pattern(env)]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+
+    fn env_for(prefix: &Path) -> ServiceEnv {
+        ServiceEnv::from_values(
+            "firecrab",
+            "firecrab",
+            prefix,
+            Path::new("/var/lib/firecrab"),
+            Path::new("/etc/firecrab"),
+            Path::new("/etc/systemd/system"),
+        )
+    }
+
+    #[test]
+    fn selinux_active_follows_getenforce() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake.set("getenforce", &[], 0, "Enforcing\n", "");
+        assert!(selinux_active(&fake));
+
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake.set("getenforce", &[], 0, "Permissive\n", "");
+        assert!(
+            selinux_active(&fake),
+            "permissive counts: labels still have to be right"
+        );
+
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake.set("getenforce", &[], 0, "Disabled\n", "");
+        assert!(!selinux_active(&fake));
+
+        // getenforce absent entirely
+        assert!(!selinux_active(&FakeCommandRunner::new()));
+    }
+
+    #[test]
+    fn label_records_the_context_and_restores_it() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake.set("getenforce", &[], 0, "Enforcing\n", "");
+        fake.set(
+            "sh",
+            &["-c", "command -v semanage"],
+            0,
+            "/usr/sbin/semanage\n",
+            "",
+        );
+        fake.set(
+            "sh",
+            &["-c", "command -v restorecon"],
+            0,
+            "/usr/sbin/restorecon\n",
+            "",
+        );
+        let env = env_for(Path::new("/usr/local"));
+        label_binaries(&Privileged::with_sudo(&fake, true), &env);
+        let calls = fake.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "sudo semanage fcontext -a -t bin_t /usr/local/lib/firecrab(/.*)?"),
+            "{calls:?}"
+        );
+        assert!(
+            calls
+                .iter()
+                .any(|c| c == "sudo restorecon -R /usr/local/lib/firecrab"),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn label_falls_back_to_modify_when_the_rule_exists() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake.set("getenforce", &[], 0, "Enforcing\n", "");
+        fake.set(
+            "sh",
+            &["-c", "command -v semanage"],
+            0,
+            "/usr/sbin/semanage\n",
+            "",
+        );
+        fake.set("sh", &["-c", "command -v restorecon"], 1, "", "");
+        fake.set(
+            "sudo",
+            &[
+                "semanage",
+                "fcontext",
+                "-a",
+                "-t",
+                "bin_t",
+                "/usr/local/lib/firecrab(/.*)?",
+            ],
+            1,
+            "",
+            "already defined\n",
+        );
+        label_binaries(
+            &Privileged::with_sudo(&fake, true),
+            &env_for(Path::new("/usr/local")),
+        );
+        assert!(
+            fake.calls()
+                .iter()
+                .any(|c| c.contains("semanage fcontext -m -t bin_t")),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn label_without_semanage_only_warns() {
+        let mut fake2 = FakeCommandRunner::permissive();
+        fake2.set(
+            "sh",
+            &["-c", "command -v getenforce"],
+            0,
+            "/usr/sbin/getenforce\n",
+            "",
+        );
+        fake2.set("getenforce", &[], 0, "Enforcing\n", "");
+        fake2.set("sh", &["-c", "command -v semanage"], 1, "", "");
+        label_binaries(
+            &Privileged::with_sudo(&fake2, true),
+            &env_for(Path::new("/usr/local")),
+        );
+        // Positive: proves the run actually reached the `have(semanage)` check
+        // (past the SELinux-active guard) rather than bailing out earlier for
+        // an unrelated reason.
+        assert!(
+            fake2
+                .calls()
+                .iter()
+                .any(|c| c == "sh -c command -v semanage"),
+            "{:?}",
+            fake2.calls()
+        );
+        assert!(
+            !fake2
+                .calls()
+                .iter()
+                .any(|c| c.contains("semanage fcontext")),
+            "{:?}",
+            fake2.calls()
+        );
+    }
+
+    #[test]
+    fn unlabel_deletes_the_rule_when_semanage_exists() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set(
+            "sh",
+            &["-c", "command -v semanage"],
+            0,
+            "/usr/sbin/semanage\n",
+            "",
+        );
+        unlabel_binaries(
+            &Privileged::with_sudo(&fake, true),
+            &env_for(Path::new("/usr/local")),
+        );
+        assert!(
+            fake.calls()
+                .iter()
+                .any(|c| c == "sudo semanage fcontext -d /usr/local/lib/firecrab(/.*)?"),
+            "{:?}",
+            fake.calls()
+        );
+    }
+}

--- a/firecrab-cli/src/service/uninstall.rs
+++ b/firecrab-cli/src/service/uninstall.rs
@@ -1,0 +1,253 @@
+//! install.sh `do_uninstall`: 이 설치가 만든 것만 지운다. 데이터는 `--purge`에서만.
+
+use super::Error;
+use super::env::{ServiceEnv, UNITS};
+use super::output;
+use super::privileged::Privileged;
+use super::selinux;
+
+const STEP: &str = "uninstall";
+
+/// 유닛·바이너리·대시보드를 제거하고, `purge`면 데이터와 설정까지 지운다.
+///
+/// 계정은 남긴다 — 데이터 디렉터리가 그 계정 소유이고, 지우면 남은 파일이
+/// 고아가 된다.
+pub fn uninstall(privileged: &Privileged<'_>, env: &ServiceEnv, purge: bool) -> Result<(), Error> {
+    for unit in UNITS {
+        // 이미 없거나 비활성이면 실패가 정상이므로 결과를 보지 않는다.
+        let _ = privileged.run("systemctl", &["disable", "--now", unit]);
+        let path = env.unit_path(unit).to_string_lossy().into_owned();
+        privileged.run_ok(STEP, "rm", &["-f", &path])?;
+    }
+    privileged.run_ok(STEP, "systemctl", &["daemon-reload"])?;
+    output::log("units removed");
+
+    // SIGTERM은 helper의 소켓 루프만 멈춘다 — helper가 만든 브리지, TAP,
+    // nftables 테이블은 재부팅 전까지 남는다. 바이너리가 아직 디스크에 있는
+    // 동안 자체 teardown을 돌린다.
+    let helper = env.libdir.join("firecrab-net-helper");
+    if helper.is_file() {
+        let helper_s = helper.to_string_lossy().into_owned();
+        let ok = privileged
+            .run(&helper_s, &["--teardown"])
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !ok {
+            output::warn(
+                "network teardown failed — bridges/nftables tables may remain until reboot",
+            );
+        }
+    }
+
+    let api = env
+        .libdir
+        .join("firecrab-api")
+        .to_string_lossy()
+        .into_owned();
+    let helper_s = helper.to_string_lossy().into_owned();
+    let cli = env.bindir.join("firecrab").to_string_lossy().into_owned();
+    privileged.run_ok(STEP, "rm", &["-f", &api, &helper_s, &cli])?;
+
+    let dashboard = env
+        .sharedir
+        .join("dashboard")
+        .to_string_lossy()
+        .into_owned();
+    let licenses = env.sharedir.join("licenses").to_string_lossy().into_owned();
+    privileged.run_ok(STEP, "rm", &["-rf", &dashboard, &licenses])?;
+
+    let license = env.sharedir.join("LICENSE").to_string_lossy().into_owned();
+    let notices = env
+        .sharedir
+        .join("THIRD_PARTY_NOTICES.txt")
+        .to_string_lossy()
+        .into_owned();
+    let inventory = env
+        .sharedir
+        .join("release-license-inventory.json")
+        .to_string_lossy()
+        .into_owned();
+    privileged.run_ok(STEP, "rm", &["-f", &license, &notices, &inventory])?;
+
+    // Firecracker는 따로 설치되므로 일부러 남긴다 — 그 바이너리 옆의 업스트림
+    // 고지도 함께 남는다.
+    let libdir = env.libdir.to_string_lossy().into_owned();
+    let sharedir = env.sharedir.to_string_lossy().into_owned();
+    let _ = privileged.run("rmdir", &["--ignore-fail-on-non-empty", &libdir, &sharedir]);
+
+    selinux::unlabel_binaries(privileged, env);
+    output::log("binaries and dashboard removed");
+
+    if purge {
+        output::warn(&format!(
+            "purging {} and {} (all VM disks and the database)",
+            env.datadir.display(),
+            env.confdir.display()
+        ));
+        let (data, conf) = (
+            env.datadir.to_string_lossy().into_owned(),
+            env.confdir.to_string_lossy().into_owned(),
+        );
+        privileged.run_ok(STEP, "rm", &["-rf", &data, &conf])?;
+    } else {
+        output::log(&format!(
+            "kept {} and {} — pass --purge to delete them too",
+            env.datadir.display(),
+            env.confdir.display()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+
+    fn env_for(root: &Path) -> ServiceEnv {
+        ServiceEnv::from_values(
+            "firecrab",
+            "firecrab",
+            &root.join("usr/local"),
+            &root.join("var/lib/firecrab"),
+            &root.join("etc/firecrab"),
+            &root.join("etc/systemd/system"),
+        )
+    }
+
+    fn seeded_env(root: &Path) -> ServiceEnv {
+        let env = env_for(root);
+        std::fs::create_dir_all(&env.libdir).unwrap();
+        std::fs::create_dir_all(&env.unitdir).unwrap();
+        std::fs::write(env.libdir.join("firecrab-net-helper"), b"x").unwrap();
+        for unit in UNITS {
+            std::fs::write(env.unit_path(unit), b"[Unit]\n").unwrap();
+        }
+        env
+    }
+
+    #[test]
+    fn units_are_disabled_removed_and_reloaded_before_anything_else() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let fake = FakeCommandRunner::permissive();
+        uninstall(&Privileged::with_sudo(&fake, true), &env, false).unwrap();
+        let calls = fake.calls();
+        let reload = calls
+            .iter()
+            .position(|c| c == "sudo systemctl daemon-reload")
+            .unwrap();
+        for unit in UNITS {
+            let disable = calls
+                .iter()
+                .position(|c| c == &format!("sudo systemctl disable --now {unit}"))
+                .unwrap();
+            let remove = calls
+                .iter()
+                .position(|c| c == &format!("sudo rm -f {}", env.unit_path(unit).display()))
+                .unwrap();
+            assert!(disable < remove && remove < reload, "{calls:?}");
+        }
+    }
+
+    #[test]
+    fn network_teardown_runs_while_the_helper_binary_is_still_on_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let fake = FakeCommandRunner::permissive();
+        uninstall(&Privileged::with_sudo(&fake, true), &env, false).unwrap();
+        let calls = fake.calls();
+        let teardown = calls
+            .iter()
+            .position(|c| {
+                c == &format!(
+                    "sudo {} --teardown",
+                    env.libdir.join("firecrab-net-helper").display()
+                )
+            })
+            .expect("teardown call");
+        // `rposition`, not `position`: the unit-file removal loop earlier in
+        // the run also matches "starts with sudo rm -f and contains
+        // firecrab-net-helper" (it deletes firecrab-net-helper.service). The
+        // binary removal this test cares about is the later, combined call.
+        let removal = calls
+            .iter()
+            .rposition(|c| c.starts_with("sudo rm -f ") && c.contains("firecrab-net-helper"))
+            .unwrap();
+        assert!(teardown < removal, "{calls:?}");
+    }
+
+    #[test]
+    fn a_failing_teardown_is_only_a_warning() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let mut fake = FakeCommandRunner::permissive();
+        let helper = env.libdir.join("firecrab-net-helper").display().to_string();
+        fake.set("sudo", &[&helper, "--teardown"], 1, "", "rtnetlink error\n");
+        uninstall(&Privileged::with_sudo(&fake, true), &env, false).unwrap();
+    }
+
+    #[test]
+    fn data_and_config_survive_without_purge() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let fake = FakeCommandRunner::permissive();
+        uninstall(&Privileged::with_sudo(&fake, true), &env, false).unwrap();
+        let calls = fake.calls();
+        assert!(
+            !calls
+                .iter()
+                .any(|c| c.contains(&env.datadir.display().to_string())
+                    && c.starts_with("sudo rm -rf")),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn purge_removes_data_and_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let fake = FakeCommandRunner::permissive();
+        uninstall(&Privileged::with_sudo(&fake, true), &env, true).unwrap();
+        assert!(
+            fake.calls().iter().any(|c| c
+                == &format!(
+                    "sudo rm -rf {} {}",
+                    env.datadir.display(),
+                    env.confdir.display()
+                )),
+            "{:?}",
+            fake.calls()
+        );
+    }
+
+    #[test]
+    fn binaries_dashboard_and_licenses_are_removed() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = seeded_env(dir.path());
+        let fake = FakeCommandRunner::permissive();
+        uninstall(&Privileged::with_sudo(&fake, true), &env, false).unwrap();
+        let calls = fake.calls().join("\n");
+        assert!(
+            calls.contains(&env.libdir.join("firecrab-api").display().to_string()),
+            "{calls}"
+        );
+        assert!(
+            calls.contains(&env.bindir.join("firecrab").display().to_string()),
+            "{calls}"
+        );
+        assert!(
+            calls.contains(&env.sharedir.join("dashboard").display().to_string()),
+            "{calls}"
+        );
+        assert!(
+            calls.contains(&env.sharedir.join("licenses").display().to_string()),
+            "{calls}"
+        );
+        assert!(
+            calls.contains("rmdir --ignore-fail-on-non-empty"),
+            "{calls}"
+        );
+    }
+}

--- a/firecrab-cli/src/service/units.rs
+++ b/firecrab-cli/src/service/units.rs
@@ -1,0 +1,460 @@
+//! install.sh `install_units` / `start_units` / `wait_for_api`, 그리고
+//! `firecrab service start|stop|restart|enable|disable`의 systemd 호출.
+
+use std::time::Duration;
+
+use crate::shell::CommandRunner;
+
+use super::Error;
+use super::env::{ServiceEnv, UNITS};
+use super::output;
+use super::payload::Payload;
+use super::privileged::Privileged;
+
+const STEP_UNITS: &str = "units";
+const STEP_START: &str = "start";
+const STEP_STOP: &str = "stop";
+
+/// API가 실제로 응답할 때까지 기다리는 최대 횟수/간격.
+const API_ATTEMPTS: u32 = 60;
+const API_INTERVAL: Duration = Duration::from_secs(1);
+
+/// 유닛을 재시작한 직후, 상태를 확인하기 전에 기다리는 시간
+/// (install.sh `start_units`의 `sleep 1`과 같다 — Type=simple 유닛은 fork된
+/// 즉시 `is-active`가 참이 되므로, 곧바로 죽는 유닛을 놓치지 않으려면 잠깐
+/// 기다려야 한다).
+const SETTLE: Duration = Duration::from_secs(1);
+
+/// install.sh `install_units`의 sed 치환.
+pub fn render_unit(template: &str, env: &ServiceEnv, uid: &str) -> String {
+    template
+        .replace("@LIBDIR@", &env.libdir.to_string_lossy())
+        .replace("@SHAREDIR@", &env.sharedir.to_string_lossy())
+        .replace("@DATADIR@", &env.datadir.to_string_lossy())
+        .replace("@CONFDIR@", &env.confdir.to_string_lossy())
+        .replace("@PREFIX@", &env.prefix.to_string_lossy())
+        .replace("@FIRECRAB_USER@", &env.user)
+        .replace("@FIRECRAB_GROUP@", &env.group)
+        .replace("@FIRECRAB_UID@", uid)
+}
+
+/// 템플릿을 이 호스트의 경로·계정으로 렌더해 `$UNITDIR`에 쓰고 daemon-reload.
+pub fn install_units(
+    privileged: &Privileged<'_>,
+    env: &ServiceEnv,
+    payload: &Payload,
+) -> Result<(), Error> {
+    let uid_out = privileged
+        .runner()
+        .run("id", &["-u", &env.user])
+        .map_err(|e| Error::step(STEP_UNITS, format!("id -u {}: {e}", env.user)))?;
+    if !uid_out.status.success() {
+        return Err(Error::step(
+            STEP_UNITS,
+            format!("id -u {} failed", env.user),
+        ));
+    }
+    let uid = String::from_utf8_lossy(&uid_out.stdout).trim().to_owned();
+
+    for unit in UNITS {
+        let source = payload.units.join(unit);
+        let template = std::fs::read_to_string(&source).map_err(|e| {
+            Error::step(
+                STEP_UNITS,
+                format!("could not read {}: {e}", source.display()),
+            )
+        })?;
+        let rendered = render_unit(&template, env, &uid);
+        privileged.write_file(
+            STEP_UNITS,
+            &env.unit_path(unit),
+            rendered.as_bytes(),
+            "0644",
+        )?;
+    }
+    privileged.run_ok(STEP_UNITS, "systemctl", &["daemon-reload"])?;
+    output::log(&format!("units installed to {}", env.unitdir.display()));
+    Ok(())
+}
+
+/// 두 유닛 파일이 모두 `$UNITDIR`에 있어야 서비스 제어가 의미를 갖는다.
+pub fn require_installed(env: &ServiceEnv) -> Result<(), Error> {
+    if UNITS.iter().all(|unit| env.unit_path(unit).is_file()) {
+        Ok(())
+    } else {
+        Err(Error::NotInstalled)
+    }
+}
+
+/// `systemctl is-active <unit>`, systemctl 자체가 없으면 `"unknown"`.
+///
+/// `status` 서브커맨드의 `systemd_is_active`와 같은 규칙이다 — 여기서 그
+/// 구현에 위임한다.
+pub fn is_active(runner: &dyn CommandRunner, unit: &str) -> String {
+    crate::status::systemd_is_active(runner, unit)
+}
+
+/// 부팅 시 활성화.
+pub fn enable(privileged: &Privileged<'_>) -> Result<(), Error> {
+    let mut args = vec!["enable"];
+    args.extend(UNITS);
+    privileged
+        .run_ok(STEP_UNITS, "systemctl", &args)
+        .map(|_| ())
+}
+
+/// 부팅 시 비활성화.
+pub fn disable(privileged: &Privileged<'_>) -> Result<(), Error> {
+    let mut args = vec!["disable"];
+    args.extend(UNITS);
+    privileged
+        .run_ok(STEP_UNITS, "systemctl", &args)
+        .map(|_| ())
+}
+
+/// `probe`가 참을 돌려줄 때까지 `attempts`번 재시도한다.
+pub fn wait_for(probe: &dyn Fn() -> bool, attempts: u32, interval: Duration) -> bool {
+    for attempt in 0..attempts {
+        if probe() {
+            return true;
+        }
+        if attempt + 1 < attempts {
+            std::thread::sleep(interval);
+        }
+    }
+    false
+}
+
+/// install.sh `wait_for_api`의 HTTP probe.
+///
+/// `is-active`는 Type=simple 유닛에서 프로세스가 fork 되는 순간 참이 된다 —
+/// 실제로 서빙하는 시점이 아니다. API는 리스너를 열기 전에 설치된 모든 템플릿
+/// 아티팩트를 해시하므로, 큰 rootfs가 있으면 fork 이후로도 한참 걸린다.
+pub fn http_probe(bind: &str) -> bool {
+    let url = format!("http://{bind}/");
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .ok()
+        .and_then(|client| client.get(&url).send().ok())
+        .map(|response| response.status().is_success())
+        .unwrap_or(false)
+}
+
+/// [`confirm_active`]의 본체 — `settle`과 `(attempts, interval)`을 주입해
+/// 실서비스 경로의 대기 시간을 테스트에서는 0에 가깝게 줄일 수 있게 한다.
+fn confirm_active_with(
+    privileged: &Privileged<'_>,
+    probe: &dyn Fn() -> bool,
+    settle: Duration,
+    attempts: u32,
+    interval: Duration,
+) -> Result<(), Error> {
+    std::thread::sleep(settle);
+    let mut failed = Vec::new();
+    for unit in UNITS {
+        if is_active(privileged.runner(), unit) == "active" {
+            output::log(&format!("{unit} is running"));
+        } else {
+            output::warn(&format!(
+                "{unit} failed to start — journalctl -u {unit} -n 30"
+            ));
+            failed.push(unit);
+        }
+    }
+    if !failed.is_empty() {
+        return Err(Error::step_fix(
+            STEP_START,
+            format!("did not come up: {}", failed.join(", ")),
+            format!("journalctl -u {} -n 30", failed[0]),
+        ));
+    }
+    let bind = ServiceEnv::api_bind();
+    if wait_for(probe, attempts, interval) {
+        Ok(())
+    } else {
+        Err(Error::step_fix(
+            STEP_START,
+            format!("firecrab-api did not answer http://{bind}/ within {API_ATTEMPTS}s"),
+            "journalctl -u firecrab-api -n 30",
+        ))
+    }
+}
+
+fn confirm_active(privileged: &Privileged<'_>, probe: &dyn Fn() -> bool) -> Result<(), Error> {
+    confirm_active_with(privileged, probe, SETTLE, API_ATTEMPTS, API_INTERVAL)
+}
+
+/// 부팅 순서대로 시작한 뒤 실제로 떴는지 확인한다.
+pub fn start(privileged: &Privileged<'_>, probe: &dyn Fn() -> bool) -> Result<(), Error> {
+    let mut args = vec!["start"];
+    args.extend(UNITS);
+    privileged.run_ok(STEP_START, "systemctl", &args)?;
+    confirm_active(privileged, probe)
+}
+
+/// install.sh `start_units`: enable + restart + 확인.
+pub fn enable_and_start(
+    privileged: &Privileged<'_>,
+    probe: &dyn Fn() -> bool,
+) -> Result<(), Error> {
+    enable(privileged)?;
+    let mut args = vec!["restart"];
+    args.extend(UNITS);
+    privileged.run_ok(STEP_START, "systemctl", &args)?;
+    confirm_active(privileged, probe)
+}
+
+/// 역순으로 정지한다 — API가 helper보다 먼저 내려가야 한다.
+pub fn stop(privileged: &Privileged<'_>) -> Result<(), Error> {
+    let mut args = vec!["stop"];
+    args.extend(UNITS.iter().rev().copied());
+    privileged.run_ok(STEP_STOP, "systemctl", &args)?;
+    for unit in UNITS {
+        let state = is_active(privileged.runner(), unit);
+        if state == "active" {
+            return Err(Error::step(STEP_STOP, format!("{unit} is still active")));
+        }
+        output::log(&format!(
+            "{unit} is {}",
+            if state.is_empty() { "stopped" } else { &state }
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::FakeCommandRunner;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn env_for(root: &Path) -> ServiceEnv {
+        ServiceEnv::from_values(
+            "firecrab",
+            "firecrab",
+            &root.join("usr/local"),
+            &root.join("var/lib/firecrab"),
+            &root.join("etc/firecrab"),
+            &root.join("etc/systemd/system"),
+        )
+    }
+
+    const TEMPLATE: &str = "\
+User=@FIRECRAB_USER@
+Group=@FIRECRAB_GROUP@
+WorkingDirectory=@DATADIR@
+Environment=FIRECRAB_STATIC_ROOT=@SHAREDIR@/dashboard
+Environment=PREFIX=@PREFIX@
+Environment=FIRECRAB_LIBDIR=@LIBDIR@
+EnvironmentFile=-@CONFDIR@/api.env
+ExecStart=@LIBDIR@/firecrab-api
+Environment=FIRECRAB_NET_HELPER_ALLOWED_UID=@FIRECRAB_UID@
+";
+
+    #[test]
+    fn render_unit_replaces_every_placeholder() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_for(dir.path());
+        let rendered = render_unit(TEMPLATE, &env, "900");
+        assert!(
+            !rendered.contains('@'),
+            "unsubstituted placeholder left:\n{rendered}"
+        );
+        assert!(rendered.contains(&format!("WorkingDirectory={}", env.datadir.display())));
+        assert!(rendered.contains(&format!("ExecStart={}/firecrab-api", env.libdir.display())));
+        assert!(rendered.contains("FIRECRAB_NET_HELPER_ALLOWED_UID=900"));
+        assert!(rendered.contains("User=firecrab"));
+    }
+
+    #[test]
+    fn install_units_writes_both_units_and_reloads() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let env = env_for(root);
+        let units_dir = root.join("payload-units");
+        std::fs::create_dir_all(&units_dir).unwrap();
+        for unit in UNITS {
+            std::fs::write(units_dir.join(unit), TEMPLATE).unwrap();
+        }
+        let payload = Payload {
+            bin: root.to_path_buf(),
+            units: units_dir,
+            extract: root.to_path_buf(),
+            dashboard: None,
+            license: root.join("LICENSE"),
+            gpl: root.join("GPL"),
+            third_party: None,
+            inventory: None,
+            checkout: None,
+            _temp: None,
+        };
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set("id", &["-u", "firecrab"], 0, "900\n", "");
+        install_units(&Privileged::with_sudo(&fake, true), &env, &payload).unwrap();
+        let calls = fake.calls();
+        for unit in UNITS {
+            let path = env.unit_path(unit);
+            assert!(
+                calls
+                    .iter()
+                    .any(|c| c == &format!("sudo tee {}", path.display())),
+                "{calls:?}"
+            );
+            let written = fake
+                .stdin_of(&format!("sudo tee {}", path.display()))
+                .unwrap();
+            assert!(!String::from_utf8_lossy(&written).contains('@'));
+        }
+        assert!(
+            calls.iter().any(|c| c == "sudo systemctl daemon-reload"),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn require_installed_checks_both_unit_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_for(dir.path());
+        std::fs::create_dir_all(&env.unitdir).unwrap();
+        assert!(matches!(require_installed(&env), Err(Error::NotInstalled)));
+        for unit in UNITS {
+            std::fs::write(env.unit_path(unit), b"[Unit]\n").unwrap();
+        }
+        assert!(require_installed(&env).is_ok());
+    }
+
+    #[test]
+    fn start_uses_boot_order_and_stop_reverses_it() {
+        let mut fake = FakeCommandRunner::permissive();
+        // First is-active probe (inside `start`'s confirm) sees both units up;
+        // the second (inside `stop`'s post-check) sees them down again.
+        for unit in UNITS {
+            fake.set_seq(
+                "systemctl",
+                &["is-active", unit],
+                &[(0, "active\n", ""), (3, "inactive\n", "")],
+            );
+        }
+        let privileged = Privileged::with_sudo(&fake, true);
+        start_with_settle(&privileged, &|| true, Duration::ZERO).unwrap();
+        stop(&privileged).unwrap();
+        let calls = fake.calls();
+        assert!(
+            calls
+                .iter()
+                .any(|c| c
+                    == "sudo systemctl start firecrab-net-helper.service firecrab-api.service"),
+            "{calls:?}"
+        );
+        assert!(
+            calls.iter().any(
+                |c| c == "sudo systemctl stop firecrab-api.service firecrab-net-helper.service"
+            ),
+            "{calls:?}"
+        );
+    }
+
+    #[test]
+    fn start_fails_when_a_unit_is_not_active() {
+        let mut fake = FakeCommandRunner::permissive();
+        fake.set(
+            "systemctl",
+            &["is-active", "firecrab-api.service"],
+            1,
+            "failed\n",
+            "",
+        );
+        fake.set(
+            "systemctl",
+            &["is-active", "firecrab-net-helper.service"],
+            0,
+            "active\n",
+            "",
+        );
+        let err = start_with_settle(
+            &Privileged::with_sudo(&fake, true),
+            &|| true,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+        match err {
+            Error::Step {
+                step: "start",
+                detail,
+                ..
+            } => assert!(detail.contains("firecrab-api.service"), "{detail}"),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn start_fails_when_the_api_never_answers() {
+        let mut fake = FakeCommandRunner::permissive();
+        for unit in UNITS {
+            fake.set("systemctl", &["is-active", unit], 0, "active\n", "");
+        }
+        let err = start_with_settle(
+            &Privileged::with_sudo(&fake, true),
+            &|| false,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+        assert!(matches!(err, Error::Step { step: "start", .. }), "{err:?}");
+    }
+
+    #[test]
+    fn enable_and_disable_pass_both_units() {
+        let fake = FakeCommandRunner::permissive();
+        let privileged = Privileged::with_sudo(&fake, true);
+        enable(&privileged).unwrap();
+        disable(&privileged).unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec![
+                "sudo systemctl enable firecrab-net-helper.service firecrab-api.service",
+                "sudo systemctl disable firecrab-net-helper.service firecrab-api.service",
+            ]
+        );
+    }
+
+    #[test]
+    fn is_active_collapses_a_missing_systemctl_to_unknown() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set(
+            "systemctl",
+            &["is-active", "firecrab-api.service"],
+            0,
+            "active\n",
+            "",
+        );
+        assert_eq!(is_active(&fake, "firecrab-api.service"), "active");
+        assert_eq!(is_active(&fake, "firecrab-net-helper.service"), "unknown");
+    }
+
+    #[test]
+    fn wait_for_retries_until_the_probe_succeeds() {
+        let calls = AtomicU32::new(0);
+        let probe = || calls.fetch_add(1, Ordering::SeqCst) >= 2;
+        assert!(wait_for(&probe, 5, Duration::from_millis(1)));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+        let never = || false;
+        assert!(!wait_for(&never, 3, Duration::from_millis(1)));
+    }
+
+    /// [`start`] with an injectable settle duration and polling budget, for
+    /// tests only — the real entry point always uses [`SETTLE`] and the real
+    /// [`API_ATTEMPTS`]/[`API_INTERVAL`].
+    fn start_with_settle(
+        privileged: &Privileged<'_>,
+        probe: &dyn Fn() -> bool,
+        settle: Duration,
+    ) -> Result<(), Error> {
+        let mut args = vec!["start"];
+        args.extend(UNITS);
+        privileged.run_ok(STEP_START, "systemctl", &args)?;
+        confirm_active_with(privileged, probe, settle, 3, Duration::from_millis(1))
+    }
+}

--- a/firecrab-cli/src/shell.rs
+++ b/firecrab-cli/src/shell.rs
@@ -8,6 +8,13 @@ pub trait CommandRunner {
     /// command could not even be spawned (e.g. not on `$PATH`), a
     /// nonzero exit is still `Ok`.
     fn run(&self, cmd: &str, args: &[&str]) -> io::Result<Output>;
+
+    /// Like [`CommandRunner::run`], but writes `input` to the child's stdin
+    /// first (`sudo tee <path>` is how the service installer writes root-owned files).
+    // Not called from non-test code until the `firecrab service` installer (a later
+    // task) writes unit files through it.
+    #[allow(dead_code)]
+    fn run_with_stdin(&self, cmd: &str, args: &[&str], input: &[u8]) -> io::Result<Output>;
 }
 
 /// Shells out via `std::process::Command`. Used by every subcommand at
@@ -18,18 +25,70 @@ impl CommandRunner for RealCommandRunner {
     fn run(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
         std::process::Command::new(cmd).args(args).output()
     }
+
+    fn run_with_stdin(&self, cmd: &str, args: &[&str], input: &[u8]) -> io::Result<Output> {
+        use std::io::Write;
+        use std::process::Stdio;
+        let mut child = std::process::Command::new(cmd)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+        // Write stdin from a separate thread: `input` can exceed the pipe
+        // buffer, and a child that writes to stdout/stderr before reading all
+        // of stdin would otherwise deadlock the parent (blocked on
+        // `write_all`) against the child (blocked on a full stdout pipe).
+        // `wait_with_output` below drains stdout/stderr concurrently with
+        // this write.
+        if let Some(mut stdin) = child.stdin.take() {
+            let input = input.to_vec();
+            std::thread::spawn(move || {
+                let _ = stdin.write_all(&input);
+            });
+        }
+        child.wait_with_output()
+    }
 }
 
 #[cfg(test)]
 #[derive(Default)]
 pub(crate) struct FakeCommandRunner {
-    responses: std::collections::HashMap<String, (i32, String, String)>,
+    // A key can carry more than one response: successive calls consume the
+    // sequence in order, then repeat the last entry. `set` stores a
+    // one-element sequence, so it behaves exactly as before.
+    responses: std::collections::HashMap<String, Vec<(i32, String, String)>>,
+    // How many responses have already been consumed for each key, so a
+    // repeated call advances through a sequence registered via `set_seq`.
+    cursors: std::cell::RefCell<std::collections::HashMap<String, usize>>,
+    permissive: bool,
+    calls: std::cell::RefCell<Vec<String>>,
+    stdin: std::cell::RefCell<std::collections::HashMap<String, Vec<u8>>>,
 }
 
 #[cfg(test)]
 impl FakeCommandRunner {
     pub(crate) fn new() -> Self {
         Self::default()
+    }
+
+    /// Unregistered invocations succeed with empty output — for flows that
+    /// issue dozens of `sudo install`/`systemctl` calls whose exact output is irrelevant.
+    pub(crate) fn permissive() -> Self {
+        Self {
+            permissive: true,
+            ..Self::default()
+        }
+    }
+
+    /// Every invocation so far, as `"cmd arg1 arg2"`, in call order.
+    pub(crate) fn calls(&self) -> Vec<String> {
+        self.calls.borrow().clone()
+    }
+
+    /// Bytes written to the stdin of the given `"cmd args"` line, if any.
+    pub(crate) fn stdin_of(&self, cmd_line: &str) -> Option<Vec<u8>> {
+        self.stdin.borrow().get(cmd_line).cloned()
     }
 
     fn key(cmd: &str, args: &[&str]) -> String {
@@ -41,9 +100,10 @@ impl FakeCommandRunner {
         k
     }
 
-    /// Registers the output `run(cmd, args)` should return. Unregistered
-    /// invocations return an `ErrorKind::NotFound` error, matching what a
-    /// missing binary on `$PATH` looks like to `std::process::Command`.
+    /// Registers the output `run(cmd, args)` should return, every time it is
+    /// called. Unregistered invocations return an `ErrorKind::NotFound`
+    /// error, matching what a missing binary on `$PATH` looks like to
+    /// `std::process::Command`.
     pub(crate) fn set(
         &mut self,
         cmd: &str,
@@ -54,27 +114,66 @@ impl FakeCommandRunner {
     ) {
         self.responses.insert(
             Self::key(cmd, args),
-            (exit_code, stdout.to_owned(), stderr.to_owned()),
+            vec![(exit_code, stdout.to_owned(), stderr.to_owned())],
         );
     }
-}
 
-#[cfg(test)]
-impl CommandRunner for FakeCommandRunner {
-    fn run(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
+    /// Registers a sequence of outputs for `run(cmd, args)`: the first call
+    /// gets `responses[0]`, the second `responses[1]`, and so on; once the
+    /// sequence is exhausted, every further call repeats the last entry.
+    /// Use this to prove a caller re-probes after a state-changing command
+    /// (e.g. `have` returning absent, then present after an install).
+    pub(crate) fn set_seq(&mut self, cmd: &str, args: &[&str], responses: &[(i32, &str, &str)]) {
+        self.responses.insert(
+            Self::key(cmd, args),
+            responses
+                .iter()
+                .map(|(code, stdout, stderr)| (*code, (*stdout).to_owned(), (*stderr).to_owned()))
+                .collect(),
+        );
+    }
+
+    fn respond(&self, key: String) -> io::Result<Output> {
         use std::os::unix::process::ExitStatusExt;
-        let key = Self::key(cmd, args);
+        self.calls.borrow_mut().push(key.clone());
         match self.responses.get(&key) {
-            Some((code, stdout, stderr)) => Ok(Output {
-                status: std::process::ExitStatus::from_raw(code << 8),
-                stdout: stdout.clone().into_bytes(),
-                stderr: stderr.clone().into_bytes(),
+            Some(sequence) => {
+                let mut cursors = self.cursors.borrow_mut();
+                let cursor = cursors.entry(key).or_insert(0);
+                let index = (*cursor).min(sequence.len() - 1);
+                if *cursor < sequence.len() - 1 {
+                    *cursor += 1;
+                }
+                let (code, stdout, stderr) = &sequence[index];
+                Ok(Output {
+                    status: std::process::ExitStatus::from_raw(code << 8),
+                    stdout: stdout.clone().into_bytes(),
+                    stderr: stderr.clone().into_bytes(),
+                })
+            }
+            None if self.permissive => Ok(Output {
+                status: std::process::ExitStatus::from_raw(0),
+                stdout: Vec::new(),
+                stderr: Vec::new(),
             }),
             None => Err(io::Error::new(
                 io::ErrorKind::NotFound,
                 format!("no fake response for: {key}"),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+impl CommandRunner for FakeCommandRunner {
+    fn run(&self, cmd: &str, args: &[&str]) -> io::Result<Output> {
+        self.respond(Self::key(cmd, args))
+    }
+
+    fn run_with_stdin(&self, cmd: &str, args: &[&str], input: &[u8]) -> io::Result<Output> {
+        let key = Self::key(cmd, args);
+        self.stdin.borrow_mut().insert(key.clone(), input.to_vec());
+        self.respond(key)
     }
 }
 
@@ -108,5 +207,60 @@ mod tests {
         let out = fake.run("ufw", &["status"]).unwrap();
         assert!(!out.status.success());
         assert_eq!(String::from_utf8_lossy(&out.stderr), "Permission denied\n");
+    }
+
+    #[test]
+    fn fake_runner_records_calls_in_order_and_stdin() {
+        let fake = FakeCommandRunner::permissive();
+        fake.run("sudo", &["systemctl", "daemon-reload"]).unwrap();
+        fake.run_with_stdin("sudo", &["tee", "/etc/x"], b"hello")
+            .unwrap();
+        assert_eq!(
+            fake.calls(),
+            vec!["sudo systemctl daemon-reload", "sudo tee /etc/x"]
+        );
+        assert_eq!(fake.stdin_of("sudo tee /etc/x"), Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn permissive_fake_returns_success_for_unregistered_commands() {
+        let fake = FakeCommandRunner::permissive();
+        assert!(fake.run("anything", &[]).unwrap().status.success());
+    }
+
+    #[test]
+    fn strict_fake_still_errors_on_unregistered_commands() {
+        let fake = FakeCommandRunner::new();
+        assert_eq!(
+            fake.run("anything", &[]).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn set_seq_advances_through_responses_then_repeats_the_last() {
+        let mut fake = FakeCommandRunner::new();
+        fake.set_seq(
+            "sh",
+            &["-c", "command -v nft"],
+            &[(1, "", ""), (0, "/usr/sbin/nft\n", "")],
+        );
+        let first = fake.run("sh", &["-c", "command -v nft"]).unwrap();
+        assert!(!first.status.success());
+        let second = fake.run("sh", &["-c", "command -v nft"]).unwrap();
+        assert!(second.status.success());
+        let third = fake.run("sh", &["-c", "command -v nft"]).unwrap();
+        assert!(
+            third.status.success(),
+            "repeats the last entry once exhausted"
+        );
+    }
+
+    #[test]
+    fn real_runner_pipes_stdin() {
+        let out = RealCommandRunner
+            .run_with_stdin("cat", &[], b"piped")
+            .unwrap();
+        assert_eq!(String::from_utf8_lossy(&out.stdout), "piped");
     }
 }

--- a/firecrab-cli/src/status.rs
+++ b/firecrab-cli/src/status.rs
@@ -19,7 +19,10 @@ pub struct StatusReport {
 
 /// Wraps `systemctl is-active`; any runner error (missing binary, non-UTF8
 /// output) collapses to `"unknown"` rather than failing the whole report.
-fn systemd_is_active(runner: &dyn CommandRunner, unit: &str) -> String {
+///
+/// `pub(crate)` so `service::units::is_active` can delegate to the same rule
+/// instead of duplicating it.
+pub(crate) fn systemd_is_active(runner: &dyn CommandRunner, unit: &str) -> String {
     match runner.run("systemctl", &["is-active", unit]) {
         Ok(out) => String::from_utf8_lossy(&out.stdout).trim().to_owned(),
         Err(_) => "unknown".to_owned(),

--- a/firecrab-cli/src/vm.rs
+++ b/firecrab-cli/src/vm.rs
@@ -1,0 +1,552 @@
+use std::collections::BTreeMap;
+use std::fmt::Write;
+
+use clap::ValueEnum;
+use firecrab_api_types::{CreateVmRequest, EgressPolicy, VmResponse, VmState};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::api_client::{ApiClient, ApiError};
+use crate::vm_console;
+
+/// MicroVM operations backed by firecrab-api.
+#[derive(Debug, clap::Subcommand)]
+pub enum Command {
+    /// List every MicroVM on the host.
+    List {
+        /// Emit the API response as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Create a MicroVM from an installed image.
+    Create {
+        /// User-facing MicroVM name.
+        #[arg(long)]
+        name: String,
+        /// Installed image alias, such as `alpine-3.24.1`.
+        #[arg(long)]
+        template: String,
+        /// Number of virtual CPUs.
+        #[arg(long, default_value_t = 1)]
+        cpu: u8,
+        /// Memory in MiB.
+        #[arg(long, default_value_t = 512)]
+        ram: u32,
+        /// Disk capacity in GiB.
+        #[arg(long, default_value_t = 2)]
+        disk_gb: u16,
+        /// MicroNetwork UUID for the VM's ENI-like attachment.
+        #[arg(long)]
+        network: Uuid,
+        /// Outbound network posture.
+        #[arg(long, value_enum, default_value = "internet")]
+        egress: EgressArg,
+        /// Storage root id; omitted uses the API's default root.
+        #[arg(long)]
+        storage_root: Option<String>,
+        /// Emit the created VM as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Start an inactive MicroVM.
+    Start {
+        /// MicroVM UUID.
+        id: Uuid,
+        /// Emit the resulting VM as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Stop a running MicroVM.
+    Stop {
+        /// MicroVM UUID.
+        id: Uuid,
+        /// Emit the resulting VM as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete an inactive MicroVM and its disk.
+    Delete {
+        /// MicroVM UUID.
+        id: Uuid,
+        /// Emit a deletion acknowledgement as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Attach to a running MicroVM's serial console.
+    #[command(visible_alias = "terminal")]
+    Console {
+        /// MicroVM UUID or name.
+        target: String,
+    },
+}
+
+/// Errors produced while executing a VM command.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// REST API operation failure.
+    #[error(transparent)]
+    Api(#[from] ApiError),
+    /// Interactive serial-console failure.
+    #[error(transparent)]
+    Console(#[from] vm_console::Error),
+    /// Name lookup found no matching VM.
+    #[error("no VM named {0:?}")]
+    VmNotFound(String),
+    /// Multiple VMs share the name and stdin is not a TTY so interactive
+    /// selection is not possible.
+    #[error("multiple VMs named {0:?}: pipe a UUID or run interactively")]
+    AmbiguousNonInteractive(String),
+    /// The user entered a selection that is out of range.
+    #[error("selection {0} is out of range")]
+    InvalidSelection(usize),
+    /// Reading the selection from stdin failed.
+    #[error("could not read selection: {0}")]
+    SelectionIo(#[from] std::io::Error),
+}
+
+/// CLI spelling of [`EgressPolicy`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum EgressArg {
+    /// Permit outbound internet access.
+    Internet,
+    /// Permit only gateway-local services such as DHCP and DNS.
+    Isolated,
+}
+
+impl From<EgressArg> for EgressPolicy {
+    fn from(value: EgressArg) -> Self {
+        match value {
+            EgressArg::Internet => Self::Internet,
+            EgressArg::Isolated => Self::Isolated,
+        }
+    }
+}
+
+/// Executes one `firecrab vm` command through the loopback REST API.
+pub fn run(client: &ApiClient, command: Command) -> Result<(), Error> {
+    match command {
+        Command::List { json } => {
+            let vms: Vec<VmResponse> = client.get("/api/vms")?;
+            print_output(json, &vms, format_list_human(&vms));
+        }
+        Command::Create {
+            name,
+            template,
+            cpu,
+            ram,
+            disk_gb,
+            network,
+            egress,
+            storage_root,
+            json,
+        } => {
+            let request = CreateVmRequest {
+                name,
+                template,
+                ram,
+                cpu,
+                disk_gb,
+                egress_policy: egress.into(),
+                micro_network_id: network,
+                storage_root,
+                shell_ids: Vec::new(),
+                port_forwards: Vec::new(),
+                env: BTreeMap::new(),
+            };
+            let vm: VmResponse = client.post("/api/vms", &request)?;
+            print_output(json, &vm, format_vm_human(&vm));
+        }
+        Command::Start { id, json } => {
+            let path = format!("/api/vms/{id}/start");
+            let vm: VmResponse = client.post_empty(&path)?;
+            print_output(json, &vm, format_vm_human(&vm));
+        }
+        Command::Stop { id, json } => {
+            let path = format!("/api/vms/{id}/stop");
+            let vm: VmResponse = client.post_empty(&path)?;
+            print_output(json, &vm, format_vm_human(&vm));
+        }
+        Command::Delete { id, json } => {
+            client.delete(&format!("/api/vms/{id}"))?;
+            if json {
+                println!("{}", format_json(&serde_json::json!({ "deleted": id })));
+            } else {
+                println!("deleted VM {id}");
+            }
+        }
+        Command::Console { target } => {
+            let id = resolve_vm_target(client, &target)?;
+            vm_console::attach(client.base_url(), id)?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolves a `target` string (UUID or VM name) to a VM UUID.
+///
+/// If `target` parses as a [`Uuid`] it is returned as-is — no network
+/// round-trip. Otherwise the API VM list is fetched and all VMs whose `.name`
+/// matches `target` are collected:
+/// - exactly one match → return its UUID
+/// - zero matches → [`Error::VmNotFound`]
+/// - two or more matches → interactive numbered selection on stderr/stdin
+///   (non-TTY stdin → [`Error::AmbiguousNonInteractive`])
+fn resolve_vm_target(client: &ApiClient, target: &str) -> Result<Uuid, Error> {
+    if let Ok(uuid) = Uuid::parse_str(target) {
+        return Ok(uuid);
+    }
+    let vms: Vec<VmResponse> = client.get("/api/vms")?;
+    let matches: Vec<VmResponse> = vms.into_iter().filter(|vm| vm.name == target).collect();
+    match matches.len() {
+        0 => Err(Error::VmNotFound(target.to_owned())),
+        1 => Ok(matches.into_iter().next().unwrap().id),
+        _ => select_from_matches(target, matches),
+    }
+}
+
+/// Prints a numbered list of matching VMs to stderr and reads the user's
+/// choice from stdin. Falls back to [`Error::AmbiguousNonInteractive`] when
+/// stdin is not a TTY (script / pipe context).
+fn select_from_matches(name: &str, candidates: Vec<VmResponse>) -> Result<Uuid, Error> {
+    use std::io::IsTerminal;
+
+    if !std::io::stdin().is_terminal() {
+        return Err(Error::AmbiguousNonInteractive(name.to_owned()));
+    }
+
+    eprintln!("Multiple VMs named {name:?} — select one:");
+    for (i, vm) in candidates.iter().enumerate() {
+        eprintln!(
+            "  [{n}] {id}  {state:<8}  {ip}",
+            n = i + 1,
+            id = vm.id,
+            state = state_name(vm.state),
+            ip = vm.ipv4.as_deref().unwrap_or("-"),
+        );
+    }
+    eprint!("Enter number [1-{}]: ", candidates.len());
+
+    let mut line = String::new();
+    std::io::stdin().read_line(&mut line)?;
+    let choice: usize = line.trim().parse().unwrap_or(0);
+    if choice == 0 || choice > candidates.len() {
+        return Err(Error::InvalidSelection(choice));
+    }
+    Ok(candidates.into_iter().nth(choice - 1).unwrap().id)
+}
+
+fn print_output<T: Serialize>(json: bool, value: &T, human: String) {
+    if json {
+        println!("{}", format_json(value));
+    } else {
+        print!("{human}");
+    }
+}
+
+fn format_json<T: Serialize + ?Sized>(value: &T) -> String {
+    serde_json::to_string_pretty(value).expect("CLI output serializes")
+}
+
+fn format_list_human(vms: &[VmResponse]) -> String {
+    let mut out = String::new();
+    writeln!(
+        out,
+        "ID\tNAME\tSTATE\tTEMPLATE\tVCPU\tRAM_MIB\tDISK_GIB\tIPV4"
+    )
+    .unwrap();
+    for vm in vms {
+        writeln!(
+            out,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            vm.id,
+            vm.name,
+            state_name(vm.state),
+            vm.template,
+            vm.cpu,
+            vm.ram,
+            vm.disk_gb,
+            vm.ipv4.as_deref().unwrap_or("-")
+        )
+        .unwrap();
+    }
+    out
+}
+
+fn format_vm_human(vm: &VmResponse) -> String {
+    let mut out = String::new();
+    writeln!(out, "VM {}", vm.id).unwrap();
+    writeln!(out, "  name:      {}", vm.name).unwrap();
+    writeln!(out, "  state:     {}", state_name(vm.state)).unwrap();
+    writeln!(out, "  template:  {}@{}", vm.template, vm.template_version).unwrap();
+    writeln!(
+        out,
+        "  resources: {} vCPU, {} MiB RAM, {} GiB disk",
+        vm.cpu, vm.ram, vm.disk_gb
+    )
+    .unwrap();
+    writeln!(out, "  network:   {}", vm.micro_network_id).unwrap();
+    writeln!(out, "  ipv4:      {}", vm.ipv4.as_deref().unwrap_or("-")).unwrap();
+    writeln!(out, "  egress:    {}", vm.egress_policy).unwrap();
+    writeln!(out, "  storage:   {}", vm.storage_root).unwrap();
+    out
+}
+
+fn state_name(state: VmState) -> &'static str {
+    match state {
+        VmState::Created => "created",
+        VmState::Starting => "starting",
+        VmState::Running => "running",
+        VmState::Stopping => "stopping",
+        VmState::Stopped => "stopped",
+        VmState::Error => "error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::IsTerminal;
+
+    use clap::Parser;
+
+    use super::*;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: Command,
+    }
+
+    fn id(value: &str) -> Uuid {
+        Uuid::parse_str(value).unwrap()
+    }
+
+    fn sample_vm() -> VmResponse {
+        VmResponse {
+            id: id("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+            name: "web-1".to_owned(),
+            state: VmState::Running,
+            template: "alpine-3.24.1".to_owned(),
+            template_version: "3.24.1".to_owned(),
+            cpu: 2,
+            ram: 1024,
+            disk_gb: 4,
+            startup_step: None,
+            egress_policy: EgressPolicy::Internet,
+            ipv4: Some("172.31.0.10".to_owned()),
+            ipv6: None,
+            mac: Some("02:fc:00:00:00:01".to_owned()),
+            hostname: "fc-aaaaaaaaaaaa".to_owned(),
+            startup_timeline: Vec::new(),
+            micro_network_id: id("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+            storage_root: "default".to_owned(),
+            cpu_usage_percent: None,
+            memory_used_mib: None,
+            memory_total_mib: None,
+            memory_used_percent: None,
+            usage_history: Vec::new(),
+            shell_refs: Vec::new(),
+            port_forwards: Vec::new(),
+            env: BTreeMap::new(),
+            ssh_host_fingerprint: None,
+        }
+    }
+
+    #[test]
+    fn create_parses_defaults_and_required_network() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "create",
+            "--name",
+            "web-1",
+            "--template",
+            "alpine-3.24.1",
+            "--network",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Create {
+                name,
+                template,
+                cpu,
+                ram,
+                disk_gb,
+                network,
+                egress,
+                storage_root,
+                json,
+            } => {
+                assert_eq!(name, "web-1");
+                assert_eq!(template, "alpine-3.24.1");
+                assert_eq!((cpu, ram, disk_gb), (1, 512, 2));
+                assert_eq!(network, id("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"));
+                assert_eq!(egress, EgressArg::Internet);
+                assert_eq!(storage_root, None);
+                assert!(!json);
+            }
+            _ => panic!("expected create command"),
+        }
+    }
+
+    #[test]
+    fn create_parses_resource_and_policy_options() {
+        let cli = TestCli::try_parse_from([
+            "test",
+            "create",
+            "--name",
+            "db-1",
+            "--template",
+            "rocky-9.8",
+            "--cpu",
+            "4",
+            "--ram",
+            "2048",
+            "--disk-gb",
+            "20",
+            "--network",
+            "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+            "--egress",
+            "isolated",
+            "--storage-root",
+            "fast",
+            "--json",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Create {
+                cpu,
+                ram,
+                disk_gb,
+                egress,
+                storage_root,
+                json,
+                ..
+            } => {
+                assert_eq!((cpu, ram, disk_gb), (4, 2048, 20));
+                assert_eq!(egress, EgressArg::Isolated);
+                assert_eq!(storage_root.as_deref(), Some("fast"));
+                assert!(json);
+            }
+            _ => panic!("expected create command"),
+        }
+    }
+
+    #[test]
+    fn lifecycle_commands_require_uuid_ids() {
+        assert!(TestCli::try_parse_from(["test", "start", "not-a-uuid"]).is_err());
+        let cli = TestCli::try_parse_from([
+            "test",
+            "stop",
+            "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            "--json",
+        ])
+        .unwrap();
+        assert!(matches!(cli.command, Command::Stop { json: true, .. }));
+    }
+
+    #[test]
+    fn console_accepts_uuid_name_and_terminal_alias() {
+        for subcmd in ["console", "terminal"] {
+            // UUID target
+            let cli =
+                TestCli::try_parse_from(["test", subcmd, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"])
+                    .unwrap();
+            assert!(matches!(
+                cli.command,
+                Command::Console { ref target } if target == "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+            ));
+
+            // VM name target
+            let cli = TestCli::try_parse_from(["test", subcmd, "web-1"]).unwrap();
+            assert!(matches!(
+                cli.command,
+                Command::Console { ref target } if target == "web-1"
+            ));
+        }
+        // Missing target is still an error
+        assert!(TestCli::try_parse_from(["test", "console"]).is_err());
+    }
+
+    #[test]
+    fn resolve_vm_target_parses_uuid_without_api_call() {
+        // resolve_vm_target must not reach the network when given a valid UUID —
+        // verified implicitly: ApiClient on port 1 is unreachable, yet no error.
+        let client = ApiClient::new("http://127.0.0.1:1".to_owned());
+        let uuid = Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+        let result = resolve_vm_target(&client, "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        assert_eq!(result.unwrap(), uuid);
+    }
+
+    #[test]
+    fn resolve_vm_target_returns_not_found_on_unreachable_api_for_name() {
+        // A name (not a UUID) triggers a GET /api/vms call; unreachable API → Api error.
+        let client = ApiClient::new("http://127.0.0.1:1".to_owned());
+        let result = resolve_vm_target(&client, "web-1");
+        assert!(matches!(result, Err(Error::Api(_))));
+    }
+
+    #[test]
+    fn select_from_matches_non_interactive_returns_ambiguous_error() {
+        // In a non-TTY test environment stdin is not a terminal, so
+        // select_from_matches must return AmbiguousNonInteractive immediately.
+        if std::io::stdin().is_terminal() {
+            return; // skip when running in an interactive shell
+        }
+        let candidates = vec![
+            {
+                let mut vm = sample_vm();
+                vm.id = Uuid::parse_str("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa").unwrap();
+                vm
+            },
+            {
+                let mut vm = sample_vm();
+                vm.id = Uuid::parse_str("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb").unwrap();
+                vm
+            },
+        ];
+        let result = select_from_matches("web-1", candidates);
+        assert!(matches!(result, Err(Error::AmbiguousNonInteractive(_))));
+    }
+
+    #[test]
+    fn list_human_has_a_header_and_vm_row() {
+        let text = format_list_human(&[sample_vm()]);
+        assert!(text.starts_with("ID\tNAME\tSTATE\tTEMPLATE\t"), "{text}");
+        assert!(
+            text.contains("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\tweb-1\trunning\talpine-3.24.1"),
+            "{text}"
+        );
+        assert!(text.contains("\t2\t1024\t4\t172.31.0.10\n"), "{text}");
+    }
+
+    #[test]
+    fn single_vm_human_includes_core_fields() {
+        let text = format_vm_human(&sample_vm());
+        assert!(text.contains("VM aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"));
+        assert!(text.contains("state:     running"));
+        assert!(text.contains("template:  alpine-3.24.1@3.24.1"));
+        assert!(text.contains("resources: 2 vCPU, 1024 MiB RAM, 4 GiB disk"));
+        assert!(text.contains("network:   bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"));
+        assert!(text.contains("egress:    internet"));
+    }
+
+    #[test]
+    fn list_json_is_pretty_and_preserves_api_field_names() {
+        let json = format_json(&[sample_vm()]);
+        assert!(json.contains("\n  {"), "{json}");
+        assert!(json.contains("\"diskGb\": 4"), "{json}");
+        assert!(json.contains("\"microNetworkId\""), "{json}");
+    }
+
+    #[test]
+    fn delete_json_is_a_pretty_receipt() {
+        let vm_id = id("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+        let json = format_json(&serde_json::json!({ "deleted": vm_id }));
+        assert_eq!(
+            json,
+            "{\n  \"deleted\": \"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa\"\n}"
+        );
+    }
+}

--- a/firecrab-cli/src/vm_console.rs
+++ b/firecrab-cli/src/vm_console.rs
@@ -1,0 +1,308 @@
+//! Interactive client for a running MicroVM's serial-console WebSocket.
+
+use std::io::IsTerminal;
+
+use futures_util::{SinkExt, StreamExt};
+use nix::sys::termios::{self, SetArg, Termios};
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
+use uuid::Uuid;
+
+/// ASCII Group Separator, conventionally entered as Ctrl+].
+const DETACH_BYTE: u8 = 0x1d;
+
+/// Failures while attaching to a VM serial console.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// The configured REST base cannot be converted to a WebSocket URL.
+    #[error("invalid API base URL: {0}")]
+    InvalidApiUrl(String),
+    /// The API rejected the WebSocket upgrade.
+    #[error("console handshake HTTP {status}: {body}")]
+    Handshake {
+        /// HTTP response status.
+        status: u16,
+        /// API error response body.
+        body: String,
+    },
+    /// Network, TLS, or WebSocket framing failure.
+    #[error("console connection failed: {0}")]
+    Connection(String),
+    /// Reading stdin or writing stdout failed.
+    #[error("console I/O failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// The local terminal could not enter raw mode.
+    #[error("terminal mode failed: {0}")]
+    Terminal(String),
+}
+
+/// Attaches the process terminal to the VM's ttyS0 stream until the VM stops,
+/// stdin closes, or the operator types Ctrl+].
+pub fn attach(api_base: &str, id: Uuid) -> Result<(), Error> {
+    let url = console_url(api_base, id)?;
+    eprintln!("attaching to VM {id} serial console (Ctrl+] to detach)");
+
+    let raw_terminal = RawTerminal::enter()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(Error::Io)?;
+    let result = runtime.block_on(stream(
+        url.as_str(),
+        tokio::io::stdin(),
+        tokio::io::stdout(),
+    ));
+
+    // Restore canonical input before printing a local status line. This also
+    // runs on every error path; Drop remains a second safety net for panics.
+    drop(raw_terminal);
+    if result.is_ok() {
+        eprintln!("\r\nconsole detached");
+    }
+    result
+}
+
+/// Converts an HTTP API base to the console WebSocket endpoint while
+/// preserving an optional reverse-proxy path prefix.
+fn console_url(api_base: &str, id: Uuid) -> Result<reqwest::Url, Error> {
+    let mut url =
+        reqwest::Url::parse(api_base).map_err(|error| Error::InvalidApiUrl(error.to_string()))?;
+    let websocket_scheme = match url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        other => {
+            return Err(Error::InvalidApiUrl(format!(
+                "unsupported scheme {other:?}; expected http or https"
+            )));
+        }
+    };
+    url.set_scheme(websocket_scheme)
+        .map_err(|_| Error::InvalidApiUrl("could not set WebSocket scheme".to_owned()))?;
+
+    let prefix = url.path().trim_end_matches('/');
+    url.set_path(&format!("{prefix}/ws/vms/{id}/console"));
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+async fn stream<R, W>(url: &str, mut input: R, mut output: W) -> Result<(), Error>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let (socket, _) = tokio_tungstenite::connect_async(url)
+        .await
+        .map_err(map_websocket_error)?;
+    let (mut sink, mut source) = socket.split();
+    let mut buffer = [0_u8; 4096];
+
+    loop {
+        tokio::select! {
+            read = input.read(&mut buffer) => {
+                let read = read?;
+                if read == 0 {
+                    let _ = sink.send(Message::Close(None)).await;
+                    return Ok(());
+                }
+
+                let (guest_input, detach) = split_at_detach(&buffer[..read]);
+                if !guest_input.is_empty() {
+                    sink.send(Message::Binary(guest_input.to_vec().into()))
+                        .await
+                        .map_err(map_websocket_error)?;
+                }
+                if detach {
+                    let _ = sink.send(Message::Close(None)).await;
+                    return Ok(());
+                }
+            }
+            frame = source.next() => {
+                let Some(frame) = frame else {
+                    return Ok(());
+                };
+                match frame.map_err(map_websocket_error)? {
+                    Message::Binary(bytes) => {
+                        output.write_all(&bytes).await?;
+                        output.flush().await?;
+                    }
+                    Message::Text(text) => {
+                        output.write_all(text.as_bytes()).await?;
+                        output.flush().await?;
+                    }
+                    Message::Close(_) => return Ok(()),
+                    Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
+                }
+            }
+        }
+    }
+}
+
+fn split_at_detach(input: &[u8]) -> (&[u8], bool) {
+    match input.iter().position(|byte| *byte == DETACH_BYTE) {
+        Some(position) => (&input[..position], true),
+        None => (input, false),
+    }
+}
+
+fn map_websocket_error(error: WebSocketError) -> Error {
+    if let WebSocketError::Http(response) = error {
+        let body = response
+            .body()
+            .as_deref()
+            .map(String::from_utf8_lossy)
+            .unwrap_or_default()
+            .into_owned();
+        return Error::Handshake {
+            status: response.status().as_u16(),
+            body,
+        };
+    }
+    Error::Connection(error.to_string())
+}
+
+/// Restores the exact input terminal attributes when the console exits.
+struct RawTerminal {
+    original: Termios,
+}
+
+impl RawTerminal {
+    fn enter() -> Result<Option<Self>, Error> {
+        let input = std::io::stdin();
+        if !input.is_terminal() {
+            return Ok(None);
+        }
+
+        let original =
+            termios::tcgetattr(&input).map_err(|error| Error::Terminal(error.to_string()))?;
+        let mut raw = original.clone();
+        termios::cfmakeraw(&mut raw);
+        termios::tcsetattr(&input, SetArg::TCSANOW, &raw)
+            .map_err(|error| Error::Terminal(error.to_string()))?;
+        Ok(Some(Self { original }))
+    }
+}
+
+impl Drop for RawTerminal {
+    fn drop(&mut self) {
+        let _ = termios::tcsetattr(std::io::stdin(), SetArg::TCSANOW, &self.original);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+    use tokio::time::sleep;
+    use tokio_tungstenite::accept_async;
+
+    use super::*;
+
+    const ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+    fn id() -> Uuid {
+        Uuid::parse_str(ID).unwrap()
+    }
+
+    #[test]
+    fn console_url_maps_http_https_and_proxy_prefixes() {
+        assert_eq!(
+            console_url("http://127.0.0.1:5523", id()).unwrap().as_str(),
+            format!("ws://127.0.0.1:5523/ws/vms/{ID}/console")
+        );
+        assert_eq!(
+            console_url("https://cloud.example/firecrab/", id())
+                .unwrap()
+                .as_str(),
+            format!("wss://cloud.example/firecrab/ws/vms/{ID}/console")
+        );
+    }
+
+    #[test]
+    fn console_url_rejects_non_http_schemes() {
+        let error = console_url("file:///tmp/firecrab.sock", id()).unwrap_err();
+        assert!(error.to_string().contains("expected http or https"));
+    }
+
+    #[test]
+    fn detach_byte_is_local_and_discards_everything_after_it() {
+        assert_eq!(
+            split_at_detach(b"echo ok\r"),
+            (b"echo ok\r".as_slice(), false)
+        );
+        assert_eq!(
+            split_at_detach(b"echo ok\r\x1dignored"),
+            (b"echo ok\r".as_slice(), true)
+        );
+    }
+
+    #[test]
+    fn non_tty_input_does_not_require_terminal_mode_changes() {
+        if !std::io::stdin().is_terminal() {
+            assert!(RawTerminal::enter().unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_stream_forwards_bytes_in_both_directions() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(tcp).await.unwrap();
+            socket
+                .send(Message::Binary(b"booted\r\n$ ".to_vec().into()))
+                .await
+                .unwrap();
+            let message = socket.next().await.unwrap().unwrap();
+            assert_eq!(message.into_data(), b"echo ok\r".as_slice());
+            socket.close(None).await.unwrap();
+        });
+
+        let (mut input_writer, input_reader) = tokio::io::duplex(64);
+        let input_task = tokio::spawn(async move {
+            sleep(Duration::from_millis(20)).await;
+            input_writer.write_all(b"echo ok\r").await.unwrap();
+        });
+        let mut output = Vec::new();
+        stream(
+            &format!("ws://{address}/ws/vms/{ID}/console"),
+            input_reader,
+            &mut output,
+        )
+        .await
+        .unwrap();
+
+        input_task.await.unwrap();
+        server.await.unwrap();
+        assert_eq!(output, b"booted\r\n$ ");
+    }
+
+    #[tokio::test]
+    async fn handshake_error_keeps_status_and_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut tcp, _) = listener.accept().await.unwrap();
+            tcp.write_all(
+                b"HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: 25\r\nConnection: close\r\n\r\n{\"code\":\"vm_not_running\"}",
+            )
+            .await
+            .unwrap();
+        });
+
+        let error = stream(
+            &format!("ws://{address}/ws/vms/{ID}/console"),
+            Cursor::new(Vec::<u8>::new()),
+            Vec::<u8>::new(),
+        )
+        .await
+        .unwrap_err();
+        server.await.unwrap();
+        assert!(matches!(error, Error::Handshake { status: 409, .. }));
+        assert!(error.to_string().contains("vm_not_running"), "{error}");
+    }
+}

--- a/public-docs/firecrab-cli.md
+++ b/public-docs/firecrab-cli.md
@@ -1,7 +1,8 @@
 # firecrab CLI
 
 `firecrab` is a host command-line client for the same loopback REST API the dashboard uses.
-It diagnoses host readiness, prints resolved configuration, and reports live status, all without a browser.
+It diagnoses host readiness, prints resolved configuration, reports live status, and manages images,
+MicroNetworks, and VM lifecycles without a browser.
 
 ## Contents
 
@@ -11,14 +12,17 @@ It diagnoses host readiness, prints resolved configuration, and reports live sta
 | [doctor](#doctor) | The 13 host-readiness checks |
 | [info](#info) | Version and resolved paths |
 | [status](#status) | Live systemd and API state |
+| [Host API commands](#host-api-commands) | Image, MicroNetwork, and VM operations |
 | [update](#update) | Release check and in-place upgrade |
 | [Develop](#develop) | Running the CLI from a checkout, no install |
 | [Related](#related) | Other documents |
 
 ## Architecture
 
-Each subcommand is independent: `doctor` reads the host directly, `info` reads only local configuration, and `status` is the only one that calls the API.
-None of the three starts or manages `firecrab-api` or `firecrab-net-helper` — the CLI is a client, not a second control plane.
+Each subcommand is independent: `doctor` reads the host directly, `info` reads only local configuration,
+and `status`, `image`, `network`, and `vm` call `firecrab-api`.
+The resource commands never talk to Firecracker, nftables, or `firecrab-net-helper` directly — the CLI
+is a client, not a second control plane.
 
 ```mermaid
 flowchart TB
@@ -26,6 +30,8 @@ flowchart TB
     Doctor["doctor"]
     Info["info"]
     Status["status"]
+    Resources["image / network / vm"]
+    Console["vm console"]
     Update["update"]
     Proc[("/dev/kvm, /proc/sys/net")]
     Tools["nft, ufw, systemctl,\ngetenforce, curl"]
@@ -37,12 +43,16 @@ flowchart TB
     CLI --> Doctor
     CLI --> Info
     CLI --> Status
+    CLI --> Resources
+    CLI --> Console
     CLI --> Update
     Doctor -->|read| Proc
     Doctor -->|shell out| Tools
     Info -->|resolve| Paths
     Status -->|is-active| Units
     Status -->|GET /api/host| API
+    Resources -->|REST API| API
+    Console -->|WebSocket serial stream| API
     Update -->|GET releases/latest| GH
     Update -->|ApplySelfUpdate| Helper
 ```
@@ -52,6 +62,8 @@ flowchart TB
 | `doctor` | `/proc`, `/dev/kvm`, and external tools (`nft`, `ufw`, `systemctl`, `getenforce`, `curl`) | No — privileged checks degrade to SKIP with a fix hint |
 | `info` | Only environment variables and install defaults | No |
 | `status` | `systemctl is-active` and `GET /api/host` | No |
+| `image`, `network`, and VM lifecycle commands | The corresponding `firecrab-api` REST resources | No |
+| `vm console` | The running VM's serial-console WebSocket | No |
 | `update` | `api.github.com`, the release asset host, and the net-helper socket | `--check` no; `--apply` yes (root or the `firecrab` account) |
 
 ## doctor
@@ -111,6 +123,83 @@ firecrab status --api http://127.0.0.1:5523
 - `host`: `GET /api/host` — load average, memory, disk, and uptime — or `null` with `hostError` set if the API is unreachable or answers an error.
 - Base URL resolution is the same as `info`: `--api`, then `FIRECRAB_API`, then `http://127.0.0.1:5523`.
 
+## Host API commands
+
+The resource commands use the same validation and lifecycle rules as the dashboard because every
+operation goes through `firecrab-api`.
+
+| Command | API operation |
+| --- | --- |
+| `firecrab image list [--json]` | `GET /api/images` |
+| `firecrab image inspect REFERENCE [--json]` | `GET /api/oci/inspect?reference=...` |
+| `firecrab image import REFERENCE [--json]` | `POST /api/oci/import` |
+| `firecrab image import-status ALIAS [--json]` | `GET /api/oci/import/{alias}` |
+| `firecrab network list [--json]` | `GET /api/micro-networks` |
+| `firecrab network create --name NAME --subnet-cidr CIDR [--json]` | `POST /api/micro-networks` |
+| `firecrab network delete ID [--json]` | `DELETE /api/micro-networks/{id}` |
+| `firecrab vm list [--json]` | `GET /api/vms` |
+| `firecrab vm create --name NAME --template ALIAS --network UUID [--cpu N] [--ram MIB] [--disk-gb GIB] [--egress internet\|isolated] [--storage-root ID] [--json]` | `POST /api/vms` |
+| `firecrab vm start ID [--json]` | `POST /api/vms/{id}/start` |
+| `firecrab vm stop ID [--json]` | `POST /api/vms/{id}/stop` |
+| `firecrab vm delete ID [--json]` | `DELETE /api/vms/{id}` |
+| `firecrab vm console ID` (`terminal` alias) | `GET /ws/vms/{id}/console` WebSocket upgrade |
+
+`vm create` defaults to one vCPU, 512 MiB RAM, and a 2 GiB disk. Override them with `--cpu N`,
+`--ram MIB`, and `--disk-gb GIB`. `--egress internet|isolated` selects the VM's outbound posture,
+and `--storage-root ID` selects a registered storage root. Pass `--json` to any resource command for
+machine-readable output.
+
+Attach to a running VM's serial console without a browser:
+
+```sh
+firecrab vm console VM_ID
+# Equivalent discoverable alias:
+firecrab vm terminal VM_ID
+```
+
+The initial stream includes up to 256 KiB of boot backlog, followed by live ttyS0 output. The CLI
+puts a local TTY in raw mode, so Ctrl+C and other control bytes reach the guest. Type Ctrl+] to
+detach without stopping the VM. Terminal settings are restored on normal exit, VM shutdown, and
+connection errors. An `http://` API base maps to `ws://`; `https://` maps to `wss://`. If the VM is
+not running, the command exits `1` and preserves the API's HTTP status and JSON error body.
+
+OCI import runs in the API background. Inspect first to confirm the host architecture and derived
+alias, start the import, then poll that alias until it succeeds:
+
+```sh
+firecrab image inspect nginx:1.27
+firecrab image import nginx:1.27
+firecrab image import-status nginx-1.27
+```
+
+`import` exits after the API accepts the job and prints the alias to poll. `import-status` exits `1`
+when the job has failed and includes the last non-empty log line in the error. See
+[OCI images](oci.md) for pipeline and registry authentication details.
+
+Create the dependencies in image → network → VM order:
+
+```sh
+firecrab image list
+firecrab network create --name app --subnet-cidr 172.31.20.0/24
+# Copy the network id from the result.
+firecrab vm create \
+  --name app-1 \
+  --template alpine-3.24.1 \
+  --network NETWORK_ID
+```
+
+The API base resolves in this order: global `--api URL`, `FIRECRAB_API`, then
+`http://127.0.0.1:5523`. The global flag may appear before or after a subcommand:
+
+```sh
+firecrab --api http://127.0.0.1:5523 vm list
+firecrab vm list --api http://127.0.0.1:5523
+```
+
+A successful resource command exits `0`. An unreachable API or an API error exits `1`; for a
+non-success HTTP response, the CLI prints both the HTTP status and the API response body so validation
+fields and request IDs remain visible.
+
 ## update
 
 Compares this build's version with the newest GitHub Release tag, and optionally installs it.
@@ -154,9 +243,10 @@ cargo build -p firecrab-cli
 ./target/debug/firecrab doctor
 ./target/debug/firecrab info
 
-# status needs a running API — point it at a dev instance
+# status and resource commands need a running API — point them at a dev instance
 # (see "Develop from source" in CONTRIBUTING.md for Terminals 1-3 of firecrab-api itself)
 ./target/debug/firecrab status --api http://127.0.0.1:5523
+./target/debug/firecrab image list --api http://127.0.0.1:5523
 ```
 
 - `cargo run -p firecrab-cli -- doctor` works too; `cargo build` first is only for repeat runs without a rebuild each time.

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -85,6 +85,59 @@ http://127.0.0.1:5523/
 The install never installs a guest image.
 Import one afterwards with [OCI import](oci.md) or the dashboard Images page.
 
+## CLI-only installation
+
+`firecrab` (the CLI) is a single static binary.
+Install it on a machine that already runs `firecrab-api` elsewhere, or on the host itself alongside an existing full install.
+
+### From a GitHub Release
+
+Download the host bundle for the target architecture and libc, then extract only the `firecrab` binary.
+
+```sh
+# x86_64 glibc host (Debian, Ubuntu, Fedora, Arch, openSUSE)
+curl -fsSL -o firecrab-host.tar.gz \
+  https://github.com/SteelCrab/firecrab/releases/latest/download/firecrab-host-x86_64-gnu.tar.gz
+tar -xzf firecrab-host.tar.gz firecrab
+sudo install -m 755 firecrab /usr/local/bin/firecrab
+```
+
+Replace `x86_64-gnu` with the correct variant for your machine:
+
+| Architecture | libc | Filename suffix |
+| --- | --- | --- |
+| x86\_64 | glibc (Debian, Ubuntu, Fedora, …) | `x86_64-gnu` |
+| x86\_64 | musl (Alpine) | `x86_64-musl` |
+| aarch64 | glibc | `aarch64-gnu` |
+| aarch64 | musl | `aarch64-musl` |
+
+Pin a version by replacing `latest` with a tag, for example `v0.1.0`.
+
+### From source
+
+```sh
+git clone https://github.com/SteelCrab/firecrab.git
+cd firecrab
+cargo build --release --locked -p firecrab-cli
+sudo install -m 755 target/release/firecrab /usr/local/bin/firecrab
+```
+
+Requires the repository Rust toolchain (`rust-toolchain.toml`).
+
+### On a host with a full install
+
+`install.sh` with `--no-frontend --no-deps` updates only the service binaries and skips the dashboard and package installs.
+Pass `--bin-dir` when installing from a local build:
+
+```sh
+# update all service binaries from the latest release, no dashboard refresh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install.sh \
+  | bash -s -- --no-frontend --no-deps
+
+# or from a local build
+./install.sh --bin-dir target/release --no-frontend --no-deps
+```
+
 ## Common options
 
 | Option | Result |

--- a/public-docs/oci.md
+++ b/public-docs/oci.md
@@ -79,6 +79,7 @@ flowchart TB
 
 ```sh
 curl -s 'http://127.0.0.1:5523/api/oci/inspect?reference=nginx:1.27'
+firecrab image inspect nginx:1.27
 ```
 
 - Docker Hub's anonymous quota is per source address, so a shared egress IP answers `429`.
@@ -95,7 +96,14 @@ curl -s 'http://127.0.0.1:5523/api/oci/inspect?reference=nginx:1.27'
 curl -s -X POST http://127.0.0.1:5523/api/oci/import \
   -H 'Content-Type: application/json' \
   -d '{"reference":"nginx:1.27"}'
+
+firecrab image import nginx:1.27
+firecrab image import-status nginx-1.27
 ```
+
+- `firecrab image import` returns after the API accepts the background job.
+- `firecrab image import-status <alias>` prints the current snapshot; `--json` preserves the API shape.
+- A failed snapshot exits `1` and reports the last non-empty import log line.
 
 | Failure | Answer |
 | --- | --- |

--- a/public-docs/storage.md
+++ b/public-docs/storage.md
@@ -50,7 +50,7 @@ Other installed and runtime files live outside `/var/lib/firecrab`.
 | `/etc/firecrab/api.env` | Operator-owned API configuration |
 | `/etc/systemd/system/firecrab-*.service` | Installed systemd units |
 | `/usr/local/lib/firecrab/` | API, network helper, and `extract-vmlinux` |
-| `/usr/local/bin/firecrab` | Host CLI (`doctor`/`info`/`status`) |
+| `/usr/local/bin/firecrab` | Host CLI (diagnostics, status, and VM/network/image operations) |
 | `/usr/local/share/firecrab/dashboard/` | Installed dashboard assets |
 | `/run/firecrab/` | Ephemeral helper socket, dnsmasq configuration, PID, hosts, and leases |
 | systemd journal and Linux networking state | Service logs, bridges, TAPs, nftables, and live processes |


### PR DESCRIPTION
 ## New Features

  - Add `image`, `network`, and `vm` host API commands.
  - Add VM serial-console WebSocket attachment with name resolution and Ctrl-]
  detach.
  - Add `service` command surface and host management helpers for dependencies,
  payloads, layout, SELinux, systemd, and uninstall.
  - Extend the CLI API client and command runner with JSON requests, privileged
  execution, and request tests.

  ## Docs

  - Document host API commands, OCI import workflows, VM console usage, and
  CLI-only installation.
  - Update storage and OCI command references.

  ## Tests

  - Add API client, resource command, VM console, and service helper coverage.
  - Verify formatting, Clippy, workspace tests, LLVM coverage, rustdoc
  coverage, and documentation links.
  - Patch coverage: 87.97%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands for managing virtual machines, networks, and images, including JSON output support.
  * Added interactive VM serial-console access.
  * Added service installation, lifecycle, dependency, systemd, and uninstall workflows.
  * Added configurable API endpoint selection and expanded API operations.
  * Added request serialization support for VM and network creation.

* **Documentation**
  * Documented new CLI commands, installation options, OCI workflows, and host operations.

* **Tests**
  * Added broad coverage for API requests, CLI behavior, formatting, service workflows, and console interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->