### PR TITLE
fix(net-helper): call render_vm_policy_for_network from the dual-stack tests

### DIFF
--- a/.github/clippy-warning-baseline.json
+++ b/.github/clippy-warning-baseline.json
@@ -3,7 +3,6 @@
     "clippy::assertions_on_constants": 1,
     "clippy::await_holding_lock": 1,
     "clippy::borrow_deref_ref": 1,
-    "clippy::cloned_ref_to_slice_refs": 1,
     "clippy::collapsible_if": 8,
     "clippy::err_expect": 1,
     "clippy::if_same_then_else": 1,
@@ -16,11 +15,10 @@
     "clippy::unnecessary_get_then_check": 1,
     "clippy::unnecessary_to_owned": 3,
     "clippy::zombie_processes": 2,
-    "dead_code": 18
+    "dead_code": 17
   },
   "packages": {
-    "firecrab-api": 43,
-    "firecrab-net-helper": 2
+    "firecrab-api": 43
   },
-  "total": 45
+  "total": 43
 }

--- a/firecrab-net-helper/src/firewall.rs
+++ b/firecrab-net-helper/src/firewall.rs
@@ -1241,7 +1241,7 @@ mod tests {
     fn a_dual_stack_vm_policy_pins_its_v6_source_the_way_it_pins_v4() {
         let policy = dual_stack_policy();
         let tag = policy.vm_id.simple();
-        let ruleset = render_vm_policy("eth0", &policy);
+        let ruleset = render_vm_policy_for_network("eth0", &policy, true);
 
         // IPv6 frames are no longer dropped wholesale for this VM...
         assert!(ruleset.contains("ether type != { ip, arp, ip6 } drop"));
@@ -1265,7 +1265,11 @@ mod tests {
 
     #[test]
     fn an_ipv4_only_vm_policy_still_drops_every_v6_frame() {
-        let ruleset = render_vm_policy("eth0", &sample_policy(EgressPolicy::Internet, false));
+        let ruleset = render_vm_policy_for_network(
+            "eth0",
+            &sample_policy(EgressPolicy::Internet, false),
+            true,
+        );
         assert!(ruleset.contains("ether type != { ip, arp } drop"));
         assert!(!ruleset.contains("vm_egress6"));
     }


### PR DESCRIPTION
## Bug Fixes

- `main` did not compile: `render_vm_policy` was deleted by #192's cleanup while two
  dual-stack test callers, added independently by `c80c9eb`, still referenced it
- Rewrites those two call sites to `render_vm_policy_for_network(uplink, policy, true)`,
  matching the other 11 the cleanup already converted

### Verify

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked
cargo test -p firecrab-net-helper --locked
```

### Results

- `cargo check -p firecrab-net-helper --all-targets` on `main`: 2 errors → clean
- 46/46 `firewall::` tests pass, including both repaired ones
- Applied onto PR #227's merge commit (`6a10664`): 3 errors → compiles clean, so #227
  goes green without touching that branch
- One pre-existing host-dependent failure remains
  (`bridge::tests::teardown_all_is_a_no_op_when_nothing_firecrab_owns_is_present`);
  it reproduces on untouched branches and needs a host with no `mnb*`/`fct*` interfaces

Closes #228
