### PR TITLE
fix(oci): install udev on apt-get and zypper images that ship without it

### DIFF
--- a/firecrab-api/src/oci/provision.rs
+++ b/firecrab-api/src/oci/provision.rs
@@ -927,7 +927,7 @@ if [ ! -f /etc/firecrab/base-packages.ok ]; then
   if [ -x /usr/bin/apt-get ]; then
     if DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -qq \
       && DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y -qq \
-        iputils-ping iproute2 ca-certificates curl procps openssh-server; then
+        iputils-ping iproute2 ca-certificates curl procps openssh-server udev; then
       ok=1
     fi
   elif [ -x /usr/bin/dnf ]; then
@@ -941,7 +941,7 @@ if [ ! -f /etc/firecrab/base-packages.ok ]; then
   elif [ -x /usr/bin/apk ]; then
     /usr/bin/apk add --no-cache iputils iproute2 ca-certificates curl procps openssh && ok=1
   elif [ -x /usr/bin/zypper ]; then
-    /usr/bin/zypper --non-interactive install -y iputils iproute2 ca-certificates curl procps openssh && ok=1
+    /usr/bin/zypper --non-interactive install -y iputils iproute2 ca-certificates curl procps openssh udev && ok=1
   elif [ -x /usr/bin/pacman ]; then
     /usr/bin/pacman -Sy --noconfirm --needed iputils iproute2 ca-certificates curl procps-ng openssh && ok=1
   else

--- a/firecrab-api/src/oci/provision_tests.rs
+++ b/firecrab-api/src/oci/provision_tests.rs
@@ -1109,3 +1109,49 @@ async fn a_provisioned_tree_records_the_program_it_will_boot() {
         &Sha256Digest::of_bytes(&program)
     );
 }
+
+/// `debugfs`-audited: apt-get and zypper images ship no `systemd-udevd`
+/// (issue #225), while dnf-based Rocky already carries it and apk-based
+/// Alpine isn't systemd at all. Pull `udev` in only where it's confirmed
+/// missing and a real, separate package.
+#[test]
+fn base_package_install_pulls_in_udev_where_systemd_ships_without_it() {
+    let script = provision::BASE_PACKAGE_INSTALL;
+
+    // Each branch's command may wrap onto a continuation line (apt-get's
+    // `\`), so join unindented and compare each `elif` block, not one line.
+    let joined = script.replace("\\\n", " ");
+    let block_with = |needle: &str| {
+        joined
+            .lines()
+            .find(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("no line contains {needle:?} in:\n{joined}"))
+    };
+
+    assert!(
+        block_with("apt-get install").contains("udev"),
+        "Debian/Ubuntu ship no systemd-udevd on a minimal OCI base — #225"
+    );
+    assert!(
+        block_with("zypper --non-interactive install").contains("udev"),
+        "openSUSE ships no systemd-udevd on a minimal OCI base — #225"
+    );
+
+    // Rocky/RHEL already carries systemd-udev; Alpine isn't systemd; Arch
+    // folds udev into the `systemd` package itself — adding a separate
+    // `udev` package there would 404 and break the whole install chain.
+    for needle in ["dnf install", "microdnf -y install", "yum install"] {
+        assert!(
+            !block_with(needle).contains("udev"),
+            "{needle} line must stay untouched — dnf-family already ships systemd-udev"
+        );
+    }
+    assert!(
+        !block_with("apk add").contains("udev"),
+        "Alpine is not systemd"
+    );
+    assert!(
+        !block_with("pacman -Sy").contains("udev"),
+        "Arch folds udev into the systemd package; a separate `udev` package does not exist"
+    );
+}


### PR DESCRIPTION
## Bug Fixes

- Install `udev` during first-boot package provisioning on the distros confirmed missing it
  (apt-get, zypper) — without it, `systemd-udevd` never runs and every `.device` unit
  (e.g. `dev-ttyS0.device`) blocks for the full 90s `DefaultDeviceTimeoutSec`

## Tests

- `base_package_install_pulls_in_udev_where_systemd_ships_without_it` — asserts `udev` is
  pulled in on apt-get/zypper and confirms the dnf/microdnf/yum/apk/pacman branches stay
  untouched (Rocky/RHEL already ships `systemd-udev`, Alpine isn't systemd, Arch folds udev
  into the `systemd` package itself so a separate package would 404)

### Verify

\`\`\`sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked
cargo test -p firecrab-api --locked
python3 scripts/check-doc-links.py
\`\`\`

### Results

- `debugfs`-audited every cached rootfs image before scoping the fix:
  `debian-latest`, `nginx-1.27`, `nginx-stable`, `postgres-16`, `postgres-18.6-bookworm`,
  `python-3.14.7-trixie`, `ubuntu-24.04`, `ubuntu-26.10` (all apt-get) and
  `opensuse-leap-latest` (zypper) were missing `systemd-udevd.service`; `rocky-rootfs-9.8`
  (dnf) already had it; Alpine images aren't systemd at all
- New test written first, confirmed failing, then made to pass (TDD)
- 737/737 `firecrab-api` tests pass; one pre-existing timing flake
  (`start_request_returns_starting_before_a_slow_guest_is_ready`) reproduces on `main`
  under full-suite parallel load and passes in isolation — unrelated to this change
- Note: this only fixes *future* boots of a freshly-provisioned or restarted guest — the
  very first boot still eats the 90s device timeout before the package installs, since
  udev isn't present yet at that point in the same boot

Closes #225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debian-based and SUSE-based system images now install the required `udev` package during first boot.
* **Tests**
  * Added coverage to verify `udev` is included only for supported distribution package managers and remains unchanged for other distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->