### PR TITLE
fix(rootfs): repair a missing network-ready unit symlink on an already-provisioned disk

### DIFF
--- a/firecrab-api/src/rootfs.rs
+++ b/firecrab-api/src/rootfs.rs
@@ -666,6 +666,7 @@ fn patch_network_ready_script(rootfs: &Path) -> Result<(), RootfsError> {
         // debugfs `write` creates regular files as 0664; the oneshot unit
         // invokes this path directly, so it must stay executable.
         set_guest_file_mode(rootfs, NETWORK_READY_SCRIPT_PATH, "0100755");
+        ensure_network_ready_unit_enabled(rootfs)?;
     }
     let has_openrc_script = guest_path_exists(rootfs, NETWORK_READY_OPENRC_PATH);
     if has_openrc_script {
@@ -675,9 +676,54 @@ fn patch_network_ready_script(rootfs: &Path) -> Result<(), RootfsError> {
             network_ready_openrc().as_bytes(),
         )?;
         set_guest_file_mode(rootfs, NETWORK_READY_OPENRC_PATH, "0100755");
+        ensure_network_ready_openrc_enabled(rootfs)?;
     }
     if !has_systemd_script && !has_openrc_script {
         install_network_ready_fallback(rootfs)?;
+    }
+    Ok(())
+}
+
+/// Repairs a disk whose readiness script survived on disk (e.g. from an
+/// earlier, partial provisioning pass) while its systemd unit and
+/// `multi-user.target.wants` symlink never landed — issue #224, found on two
+/// live `debian-latest` VMs where the guest never attempted DHCP because
+/// systemd had nothing telling it to run the script at all. A no-op once the
+/// unit is already there, so an image with its own pre-baked, correctly
+/// enabled unit is left untouched.
+fn ensure_network_ready_unit_enabled(rootfs: &Path) -> Result<(), RootfsError> {
+    if !guest_path_exists(rootfs, "/etc/systemd/system") {
+        return Ok(());
+    }
+    if !guest_path_exists(rootfs, NETWORK_READY_UNIT_PATH) {
+        write_into_image(
+            rootfs,
+            NETWORK_READY_UNIT_PATH,
+            NETWORK_READY_UNIT.as_bytes(),
+        )?;
+    }
+    if guest_path_exists(rootfs, "/etc/systemd/system/multi-user.target.wants")
+        && !guest_path_exists(rootfs, NETWORK_READY_UNIT_WANTS_PATH)
+    {
+        ensure_symlink(
+            rootfs,
+            NETWORK_READY_UNIT_WANTS_PATH,
+            NETWORK_READY_UNIT_PATH,
+        )?;
+    }
+    Ok(())
+}
+
+/// OpenRC counterpart of [`ensure_network_ready_unit_enabled`].
+fn ensure_network_ready_openrc_enabled(rootfs: &Path) -> Result<(), RootfsError> {
+    if guest_path_exists(rootfs, "/etc/runlevels/default")
+        && !guest_path_exists(rootfs, NETWORK_READY_OPENRC_RUNLEVEL_PATH)
+    {
+        ensure_symlink(
+            rootfs,
+            NETWORK_READY_OPENRC_RUNLEVEL_PATH,
+            NETWORK_READY_OPENRC_PATH,
+        )?;
     }
     Ok(())
 }
@@ -1630,6 +1676,86 @@ mod tests {
         // Patching an existing script must not also install the fallback
         // unit — the image's own pre-baked unit is the one that runs it.
         assert!(!guest_path_exists(&rootfs, NETWORK_READY_UNIT_PATH));
+    }
+
+    /// #224: two live `debian-latest` VM disks had the readiness script on
+    /// disk (from an earlier, partial provisioning pass) but no
+    /// `multi-user.target.wants` symlink — systemd never started it, so the
+    /// guest never attempted DHCP. `patch_network_ready_script` must repair
+    /// a missing unit/symlink even when the script already exists, not just
+    /// rewrite the script's content.
+    #[test]
+    fn specialize_guest_repairs_a_stale_disks_missing_network_ready_unit() {
+        let directory = tempdir().unwrap();
+        let rootfs = directory.path().join("rootfs.ext4");
+        real_rootfs_with_guest_dirs(&rootfs);
+        run_debugfs(&rootfs, "mkdir /usr").unwrap();
+        run_debugfs(&rootfs, "mkdir /usr/local").unwrap();
+        run_debugfs(&rootfs, "mkdir /usr/local/sbin").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd/system").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd/system/multi-user.target.wants").unwrap();
+        write_into_image(
+            &rootfs,
+            NETWORK_READY_SCRIPT_PATH,
+            b"#!/bin/sh\necho stale placeholder\n",
+        )
+        .unwrap();
+        // The unit file and its enablement symlink are both absent — the
+        // exact state found on the two affected VM disks.
+
+        specialize_guest(&rootfs, Uuid::new_v4(), &BTreeMap::new()).unwrap();
+
+        let unit = debugfs_cat(&rootfs, NETWORK_READY_UNIT_PATH);
+        assert!(
+            unit.contains("ExecStart=/usr/local/sbin/firecrab-network-ready.sh"),
+            "{unit}"
+        );
+        assert!(
+            guest_path_exists(&rootfs, NETWORK_READY_UNIT_WANTS_PATH),
+            "unit must be (re)enabled, not just (re)written"
+        );
+    }
+
+    /// Repairing must stay a no-op once the unit is already correctly
+    /// enabled — it must not, say, replace a real image's own unit content.
+    #[test]
+    fn specialize_guest_does_not_disturb_an_already_enabled_network_ready_unit() {
+        let directory = tempdir().unwrap();
+        let rootfs = directory.path().join("rootfs.ext4");
+        real_rootfs_with_guest_dirs(&rootfs);
+        run_debugfs(&rootfs, "mkdir /usr").unwrap();
+        run_debugfs(&rootfs, "mkdir /usr/local").unwrap();
+        run_debugfs(&rootfs, "mkdir /usr/local/sbin").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd/system").unwrap();
+        run_debugfs(&rootfs, "mkdir /etc/systemd/system/multi-user.target.wants").unwrap();
+        write_into_image(
+            &rootfs,
+            NETWORK_READY_SCRIPT_PATH,
+            b"#!/bin/sh\necho stale placeholder\n",
+        )
+        .unwrap();
+        write_into_image(
+            &rootfs,
+            NETWORK_READY_UNIT_PATH,
+            b"[Unit]\nDescription=the image's own unit\n",
+        )
+        .unwrap();
+        ensure_symlink(
+            &rootfs,
+            NETWORK_READY_UNIT_WANTS_PATH,
+            NETWORK_READY_UNIT_PATH,
+        )
+        .unwrap();
+
+        specialize_guest(&rootfs, Uuid::new_v4(), &BTreeMap::new()).unwrap();
+
+        let unit = debugfs_cat(&rootfs, NETWORK_READY_UNIT_PATH);
+        assert!(
+            unit.contains("the image's own unit"),
+            "an already-enabled unit must not be overwritten: {unit}"
+        );
     }
 
     /// #220: `nginx-1.27` was never built through `install-*-rootfs.sh`, so


### PR DESCRIPTION
## Bug Fixes

- `patch_network_ready_script` now repairs a missing systemd unit / `multi-user.target.wants`
  symlink (or the OpenRC runlevel symlink) even when the readiness script already exists on
  disk — previously it only wrote the unit on a from-scratch install, so a disk whose script
  survived from an earlier, partial provisioning pass stayed permanently unwired
- Two live `debian-latest` VMs had exactly this: the script present, no `.wants` symlink,
  systemd never starting it, the guest never attempting DHCP

## Tests

- `specialize_guest_repairs_a_stale_disks_missing_network_ready_unit` — reproduces the exact
  state found on the two affected disks, written first and confirmed failing before the fix
- `specialize_guest_does_not_disturb_an_already_enabled_network_ready_unit` — an image with
  its own pre-baked, correctly enabled unit is left untouched (repair is a no-op)

### Verify

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked
cargo test -p firecrab-api --locked
python3 scripts/check-doc-links.py
```

### Results

- Both new tests pass; all 4 `network_ready`-scoped `rootfs::tests` (existing + new) pass
  with no regressions
- 738/738 `firecrab-api` tests pass; one pre-existing timing flake
  (`start_request_returns_starting_before_a_slow_guest_is_ready`) reproduces on `main` under
  full-suite parallel load and passes in isolation — unrelated to this change
- Already-affected VM disks aren't migrated retroactively — they self-heal on their next
  normal start once this lands (per the issue's stated scope)

Closes #224
