### PR TITLE
fix(console): print a session-ended banner when exit restarts the guest shell

### DIFF
--- a/firecrab-api/src/oci/provision.rs
+++ b/firecrab-api/src/oci/provision.rs
@@ -210,10 +210,11 @@ fn inject_blocking(
             set_root_shell(tree, &shell)?;
         }
         ensure_securetty(tree, &mut unwind)?;
+        let agetty = first_existing(tree, GUEST_AGETTY_CANDIDATES);
         install_file(
             tree,
             GUEST_INITTAB,
-            inittab(first_existing(tree, GUEST_AGETTY_CANDIDATES).as_deref()).as_bytes(),
+            inittab(agetty.as_deref()).as_bytes(),
             0o644,
             &mut unwind,
         )?;
@@ -231,6 +232,15 @@ fn inject_blocking(
             0o755,
             &mut unwind,
         )?;
+        if let Some(agetty) = agetty.as_deref() {
+            install_file(
+                tree,
+                GUEST_AGETTY_WRAPPER,
+                agetty_wrapper_script(agetty).as_bytes(),
+                0o755,
+                &mut unwind,
+            )?;
+        }
         install_file(
             tree,
             GUEST_MOTD,
@@ -708,9 +718,10 @@ fn guest_path_unusable(guest_path: &str, reason: GuestPathViolation) -> ResolveE
 /// wrapper still prints MOTD and drops into ash.
 pub(crate) fn inittab(agetty: Option<&str>) -> String {
     let console = match agetty {
-        Some(path) => format!(
-            "ttyS0::respawn:{path} --autologin root --noclear --keep-baud 115200,57600,38400,9600 ttyS0 linux"
-        ),
+        // Wrapped so `exit` prints a session-boundary banner (issue #223)
+        // before agetty re-enters — a bare `respawn:{path} --autologin`
+        // gives no sign the shell ever restarted.
+        Some(_) => format!("ttyS0::respawn:{GUEST_TOOLBOX} sh {GUEST_AGETTY_WRAPPER}"),
         None => format!("::respawn:-{GUEST_TOOLBOX} sh {GUEST_CONSOLE_SCRIPT}"),
     };
     format!(
@@ -951,6 +962,19 @@ if [ ! -f /etc/firecrab/base-packages.ok ]; then
 fi
 "#;
 
+/// Guest path of the agetty respawn wrapper (issue #223).
+pub(crate) const GUEST_AGETTY_WRAPPER: &str = "/etc/firecrab/rc.agetty";
+
+/// Printed on every console respawn after the first (issue #223): busybox
+/// `respawn` and agetty's `--autologin` both re-enter silently, so `exit`
+/// otherwise looks like it did nothing. `/run` is tmpfs — a genuine reboot
+/// always starts clean, so this only fires when the guest shell actually exited.
+const SESSION_BANNER_PRELUDE: &str = r#"if [ -f /run/firecrab-console-active ]; then
+  printf '\n=== session ended — starting a new one ===\n\n'
+fi
+$BB touch /run/firecrab-console-active
+"#;
+
 /// Interactive console: MOTD, fastfetch when present, then ash.
 pub(crate) fn console_script() -> String {
     format!(
@@ -962,7 +986,7 @@ export PATH
 export LANG="${{LANG:-C.UTF-8}}"
 export LC_ALL="$LANG" LC_CTYPE="$LANG"
 $BB stty iutf8 2>/dev/null
-if [ -s /etc/hostname ]; then
+{SESSION_BANNER_PRELUDE}if [ -s /etc/hostname ]; then
   $BB hostname -F /etc/hostname 2>/dev/null
   $BB cat /etc/hostname > /proc/sys/kernel/hostname 2>/dev/null
 fi
@@ -973,6 +997,21 @@ elif [ -x /usr/bin/neofetch ]; then
   /usr/bin/neofetch
 fi
 exec $BB sh
+"#
+    )
+}
+
+/// Wraps `agetty --autologin` so `exit` has a visible effect (issue #223).
+/// A bare respawn is invisible — `--autologin` re-enters with no prompt and
+/// no output change. Prints the same session-boundary banner as
+/// [`console_script`] before handing off; `exec` still makes agetty the
+/// tty's session leader exactly as a direct inittab invocation would.
+pub(crate) fn agetty_wrapper_script(agetty: &str) -> String {
+    format!(
+        r#"#!{GUEST_TOOLBOX} sh
+# Firecrab injected agetty wrapper (public-docs/oci.md).
+BB={GUEST_TOOLBOX}
+{SESSION_BANNER_PRELUDE}exec {agetty} --autologin root --noclear --keep-baud 115200,57600,38400,9600 ttyS0 linux
 "#
     )
 }

--- a/firecrab-api/src/oci/provision_tests.rs
+++ b/firecrab-api/src/oci/provision_tests.rs
@@ -481,15 +481,31 @@ async fn an_image_with_agetty_and_bash_uses_the_serial_getty() {
         .expect("inject");
 
     let inittab = String::from_utf8(read_guest(&tree, "/etc/inittab")).expect("inittab");
+    // #223: routed through the agetty wrapper (session-ended banner on
+    // respawn), not a bare `respawn:/usr/sbin/agetty` line.
     assert!(
-        inittab.contains(
-            "ttyS0::respawn:/usr/sbin/agetty --autologin root --noclear --keep-baud 115200,57600,38400,9600 ttyS0 linux"
-        ),
+        inittab.contains(&format!(
+            "ttyS0::respawn:{} sh {}",
+            provision::GUEST_TOOLBOX,
+            provision::GUEST_AGETTY_WRAPPER
+        )),
         "{inittab}"
     );
     assert!(
         !inittab.contains("rc.console"),
         "agetty replaces the ash wrapper: {inittab}"
+    );
+    let wrapper =
+        String::from_utf8(read_guest(&tree, provision::GUEST_AGETTY_WRAPPER)).expect("wrapper");
+    assert!(
+        wrapper.contains(
+            "exec /usr/sbin/agetty --autologin root --noclear --keep-baud 115200,57600,38400,9600 ttyS0 linux"
+        ),
+        "{wrapper}"
+    );
+    assert!(
+        wrapper.contains("session ended"),
+        "wrapper must print a session-boundary banner on respawn: {wrapper}"
     );
     let passwd = String::from_utf8(read_guest(&tree, "/etc/passwd")).expect("passwd");
     assert!(
@@ -1154,4 +1170,34 @@ fn base_package_install_pulls_in_udev_where_systemd_ships_without_it() {
         !block_with("pacman -Sy").contains("udev"),
         "Arch folds udev into the systemd package; a separate `udev` package does not exist"
     );
+}
+
+/// #223: `exit` must look like it did something. Both console entry points
+/// gate the banner on a tmpfs marker (`/run` is wiped every real reboot),
+/// so it only fires on an actual respawn, never on the guest's first attach.
+#[test]
+fn console_and_agetty_wrapper_gate_the_session_banner_on_a_tmpfs_marker() {
+    for script in [
+        provision::console_script(),
+        provision::agetty_wrapper_script("/usr/sbin/agetty"),
+    ] {
+        let marker_check = script
+            .find("if [ -f /run/firecrab-console-active ]")
+            .unwrap_or_else(|| panic!("no first-attach guard in:\n{script}"));
+        let banner = script
+            .find("session ended")
+            .unwrap_or_else(|| panic!("no session-ended banner in:\n{script}"));
+        let touch = script
+            .find("touch /run/firecrab-console-active")
+            .unwrap_or_else(|| panic!("marker is never (re)created in:\n{script}"));
+        assert!(
+            marker_check < banner,
+            "banner must be inside the marker-file guard, not unconditional: {script}"
+        );
+        assert!(
+            touch > banner,
+            "marker must be (re)touched after printing, so the very next \
+             respawn also sees it: {script}"
+        );
+    }
 }

--- a/firecrab-api/src/rootfs.rs
+++ b/firecrab-api/src/rootfs.rs
@@ -427,6 +427,18 @@ fn patch_oci_console(rootfs: &Path) {
     );
     set_guest_file_mode(rootfs, "/etc/firecrab/rc.boot", "0100755");
     set_guest_file_mode(rootfs, "/etc/firecrab/rc.console", "0100755");
+    if let Some(agetty) = agetty.as_deref() {
+        let _ = write_into_image(
+            rootfs,
+            crate::oci::provision::GUEST_AGETTY_WRAPPER,
+            crate::oci::provision::agetty_wrapper_script(agetty).as_bytes(),
+        );
+        set_guest_file_mode(
+            rootfs,
+            crate::oci::provision::GUEST_AGETTY_WRAPPER,
+            "0100755",
+        );
+    }
 }
 
 /// Puts missing `ping`/`wget`/`vi` on PATH for an already-imported OCI disk.
@@ -1489,9 +1501,24 @@ mod tests {
         specialize_guest(&rootfs, Uuid::new_v4(), &BTreeMap::new()).unwrap();
 
         let inittab = debugfs_cat(&rootfs, "/etc/inittab");
+        // #223: routed through the agetty wrapper (session-ended banner on
+        // respawn), not a bare `respawn:/usr/sbin/agetty` line.
         assert!(
-            inittab.contains("ttyS0::respawn:/usr/sbin/agetty"),
+            inittab.contains(&format!(
+                "ttyS0::respawn:{} sh {}",
+                crate::oci::provision::GUEST_TOOLBOX,
+                crate::oci::provision::GUEST_AGETTY_WRAPPER
+            )),
             "{inittab}"
+        );
+        let wrapper = debugfs_cat(&rootfs, crate::oci::provision::GUEST_AGETTY_WRAPPER);
+        assert!(
+            wrapper.contains("exec /usr/sbin/agetty --autologin root"),
+            "{wrapper}"
+        );
+        assert!(
+            wrapper.contains("session ended"),
+            "wrapper must print a session-boundary banner on respawn: {wrapper}"
         );
         let passwd = debugfs_cat(&rootfs, "/etc/passwd");
         assert!(

--- a/firecrab-api/src/rootfs.rs
+++ b/firecrab-api/src/rootfs.rs
@@ -427,7 +427,7 @@ fn patch_oci_console(rootfs: &Path) {
     );
     set_guest_file_mode(rootfs, "/etc/firecrab/rc.boot", "0100755");
     set_guest_file_mode(rootfs, "/etc/firecrab/rc.console", "0100755");
-    if let Some(agetty) = agetty.as_deref() {
+    if let Some(agetty) = agetty {
         let _ = write_into_image(
             rootfs,
             crate::oci::provision::GUEST_AGETTY_WRAPPER,


### PR DESCRIPTION
## New Features

- The injected guest console now prints a `session ended — starting a new one` banner
  whenever `exit` actually restarts the shell — both `console_script()` (no-agetty ash
  wrapper) and a new `agetty_wrapper_script()` (agetty's `--autologin` respawn), which
  previously re-entered with no visible sign anything happened
- The banner is gated on a `/run`-tmpfs marker so it only fires on a genuine respawn,
  never on the guest's first console attach after boot — `/run` is wiped every real reboot

## Bug Fixes

- `inittab()`'s agetty line now routes through the wrapper (`{busybox} sh
  /etc/firecrab/rc.agetty`) instead of `exec`ing agetty directly from inittab, so the
  banner can print before agetty re-enters; `exec` inside the wrapper still hands off to
  agetty exactly as a direct inittab invocation would (same session-leader/tty semantics)

## Tests

- `console_and_agetty_wrapper_gate_the_session_banner_on_a_tmpfs_marker` — asserts the
  marker guard wraps the banner and the marker is re-touched after printing, in both scripts
- Updated `an_image_with_agetty_and_bash_uses_the_serial_getty` and
  `specialize_guest_points_serial_console_at_agetty` for the new wrapper-routed inittab line
- Manually syntax-checked both rendered scripts with `dash -n` (POSIX/ash-compatible)

### Verify

```sh
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked
cargo test -p firecrab-api --locked
python3 scripts/check-doc-links.py
```

### Results

- 738/738 `firecrab-api` tests pass; the pre-existing parallel-load timing flakes already
  tracked this session (`start_request_returns_starting_before_a_slow_guest_is_ready`,
  `registry_fixture::dropping_the_fixture_stops_the_listener_and_deletes_scratch`) each
  reproduce in isolation as unrelated and pass in isolation
- Scope note: this fixes the busybox-injected console path (`inject_blocking` /
  `patch_oci_console`, gated on `/etc/firecrab` existing) used for bare OCI-container
  imports with no init of their own. Whether any specific catalog image's *booting* disk
  actually exercises this path versus a real distro init was not reconfirmed here — the
  fix targets the mechanism as designed and covered by tests, independent of that question

Closes #223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved serial console session handling when a guest provides `agetty`.
  - Console sessions now display a clear “session ended” banner when respawning, helping distinguish separate sessions.
  - Automatic root login behavior is preserved while routing console startup through the updated session handling.

- **Bug Fixes**
  - Improved reliability of console respawning and session-boundary detection across guest images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->