### PR TITLE
feat(cli): add cross-platform remote host client

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
         # before they reach a tagged build.
         run: cargo test --workspace --release --locked
 
+      - name: CLI installer contract
+        run: bash scripts/test-install-cli-release.sh
+
   build-release:
     name: Build (${{ matrix.target }})
     needs: release-test
@@ -104,6 +107,98 @@ jobs:
           name: firecrab-${{ matrix.target }}
           path: firecrab-${{ matrix.target }}.tar.gz
 
+  build-cli:
+    name: CLI (${{ matrix.target }})
+    needs: [release-test, license-compliance]
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            runner: ubuntu-24.04
+            asset: firecrab-cli-x86_64-linux.tar.gz
+            musl: true
+          - target: aarch64-unknown-linux-musl
+            runner: ubuntu-24.04-arm
+            asset: firecrab-cli-aarch64-linux.tar.gz
+            musl: true
+          - target: x86_64-apple-darwin
+            runner: macos-15-intel
+            asset: firecrab-cli-x86_64-macos.tar.gz
+            musl: false
+          - target: aarch64-apple-darwin
+            runner: macos-15
+            asset: firecrab-cli-aarch64-macos.tar.gz
+            musl: false
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            asset: firecrab-cli-x86_64-windows.zip
+            musl: false
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download compliance material
+        uses: actions/download-artifact@v8
+        with:
+          name: firecrab-license-compliance
+          path: compliance
+
+      - name: Install pinned toolchain
+        run: rustup show
+
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Install musl linker
+        if: matrix.musl
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Test CLI
+        run: cargo test --release --locked --target ${{ matrix.target }} -p firecrab-cli
+
+      - name: Build CLI
+        run: cargo build --release --locked --target ${{ matrix.target }} -p firecrab-cli
+
+      - name: Smoke CLI on Unix
+        if: runner.os != 'Windows'
+        run: ./target/${{ matrix.target }}/release/firecrab --version
+
+      - name: Package CLI on Unix
+        if: runner.os != 'Windows'
+        run: |
+          mkdir package
+          cp target/${{ matrix.target }}/release/firecrab package/
+          cp LICENSE package/
+          cp compliance/THIRD_PARTY_NOTICES.txt package/
+          cp compliance/release-license-inventory.json package/
+          tar -czf "${{ matrix.asset }}" -C package \
+            firecrab LICENSE THIRD_PARTY_NOTICES.txt release-license-inventory.json
+
+      - name: Test and smoke CLI on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          ./scripts/test-install-cli.ps1
+          & "target/${{ matrix.target }}/release/firecrab.exe" --version
+
+      - name: Package CLI on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory package | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/firecrab.exe" package/
+          Copy-Item LICENSE package/
+          Copy-Item compliance/THIRD_PARTY_NOTICES.txt package/
+          Copy-Item compliance/release-license-inventory.json package/
+          Compress-Archive -Path package/* -DestinationPath "${{ matrix.asset }}"
+
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: firecrab-cli-${{ matrix.target }}
+          path: ${{ matrix.asset }}
+
   build-dashboard:
     name: Build dashboard
     needs: release-test
@@ -171,6 +266,8 @@ jobs:
       - name: M2Image release compliance contracts
         run: |
           shellcheck \
+            install-cli.sh \
+            scripts/test-install-cli-release.sh \
             scripts/collect-m2image-compliance.sh \
             scripts/package-m2images.sh \
             scripts/package-m2image-sources.sh \
@@ -190,6 +287,9 @@ jobs:
             x86_64-unknown-linux-gnu
             aarch64-unknown-linux-musl
             aarch64-unknown-linux-gnu
+            x86_64-apple-darwin
+            aarch64-apple-darwin
+            x86_64-pc-windows-msvc
           )
           metadata_args=()
           for target in "${targets[@]}"; do
@@ -376,6 +476,7 @@ jobs:
     name: Publish GitHub Release
     needs:
       - build-release
+      - build-cli
       - package-host
       - smoke-host-x86_64-gnu
       - smoke-host-aarch64
@@ -398,10 +499,13 @@ jobs:
           mkdir -p dist
           find artifacts -type f -name 'firecrab-host-*.tar.gz' -print
           find artifacts -type f -name 'firecrab-host-*.tar.gz' -exec cp -t dist {} +
+          find artifacts -type f \( -name 'firecrab-cli-*.tar.gz' -o -name 'firecrab-cli-*.zip' \) -print
+          find artifacts -type f \( -name 'firecrab-cli-*.tar.gz' -o -name 'firecrab-cli-*.zip' \) -exec cp -t dist {} +
           cp artifacts/firecrab-license-compliance/THIRD_PARTY_NOTICES.txt dist/
           cp artifacts/firecrab-license-compliance/release-license-inventory.json dist/
           cp LICENSE dist/LICENSE
           cp licenses/GPL-2.0-only.txt dist/GPL-2.0-only.txt
+          cp install-cli.sh install-cli.ps1 dist/
           ./scripts/bake-install-sh.sh "${GITHUB_REF_NAME}" dist/install.sh
           (cd dist && sha256sum ./* > SHA256SUMS)
           ls -l dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +322,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +363,28 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "digest"
@@ -347,6 +405,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -443,8 +510,10 @@ name = "firecrab-cli"
 version = "0.1.3"
 dependencies = [
  "clap",
+ "crossterm",
  "firecrab-api-types",
  "firecrab-helper-protocol",
+ "fs2",
  "futures-util",
  "nix",
  "reqwest",
@@ -455,6 +524,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
+ "toml",
  "uuid",
 ]
 
@@ -516,6 +586,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1009,6 +1089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1516,6 +1603,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1794,27 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1965,6 +2091,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,6 +2287,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -2363,6 +2534,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2642,18 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/docs/tests/cli-cross-platform.md
+++ b/docs/tests/cli-cross-platform.md
@@ -1,0 +1,66 @@
+# Cross-platform CLI verification
+
+## Contents
+
+- [Automated checks](#automated-checks)
+- [Keyword checklist](#keyword-checklist)
+- [Manual verification](#manual-verification)
+
+## Automated checks
+
+```sh
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets
+cargo test -p firecrab-cli --locked
+bash scripts/test-install-cli-release.sh
+pwsh -File scripts/test-install-cli.ps1
+python3 scripts/check-doc-links.py
+```
+
+Native release CI runs `cargo test` and `cargo build` for these targets:
+
+- `x86_64-unknown-linux-musl`
+- `aarch64-unknown-linux-musl`
+- `x86_64-apple-darwin`
+- `aarch64-apple-darwin`
+- `x86_64-pc-windows-msvc`
+
+## Keyword checklist
+
+- `~/firecrab/config.toml`
+- `USERPROFILE`
+- `FIRECRAB_CONFIG_DIR`
+- `host add/list/use/show/remove`
+- serialized profile mutation and unknown-key rejection
+- `--api` and `--host` precedence
+- Linux-only host administration commands
+- cross-platform raw terminal restoration
+- SHA-256 release verification
+- replacement without following an existing installer symlink
+- user-writable installation and `PATH`
+
+## Manual verification
+
+### Terminal session 1 — Linux host, root required
+
+```sh
+sudo systemctl status firecrab-api firecrab-net-helper
+curl -fsS http://127.0.0.1:5523/api/host
+```
+
+Keep the API on loopback unless remote authentication and TLS are configured.
+
+### Terminal session 2 — Linux, macOS, or Windows client, no root
+
+Forward the host loopback API through SSH, then save and exercise the endpoint:
+
+```sh
+ssh -fN -L 15523:127.0.0.1:5523 user@firecrab-host
+firecrab host add dev http://127.0.0.1:15523 --use
+firecrab host show
+firecrab vm list
+firecrab host list
+```
+
+Confirm `~/firecrab/config.toml` exists and contains `current_host = "dev"`.
+On Windows, confirm the file under `%USERPROFILE%\firecrab\config.toml`.

--- a/firecrab-cli/Cargo.toml
+++ b/firecrab-cli/Cargo.toml
@@ -11,18 +11,23 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+crossterm = "0.29"
 firecrab-api-types = { path = "../firecrab-api-types" }
-firecrab-helper-protocol = { path = "../firecrab-helper-protocol" }
+fs2 = "0.4"
 futures-util = "0.3"
-nix = { version = "0.30", features = ["term", "user"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 tempfile = "3.27.0"
 thiserror = { workspace = true }
+toml = "0.9"
 # Helper framing and the VM console are async-only, so their paths use
 # current-thread runtimes. doctor/info/status stay fully synchronous.
 tokio = { version = "1", features = ["rt", "net", "io-util", "io-std", "time", "macros"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 uuid = { workspace = true, features = ["v4"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+firecrab-helper-protocol = { path = "../firecrab-helper-protocol" }
+nix = { version = "0.30", features = ["user"] }

--- a/firecrab-cli/src/api_client.rs
+++ b/firecrab-cli/src/api_client.rs
@@ -35,18 +35,23 @@ impl std::fmt::Display for ApiError {
 
 impl std::error::Error for ApiError {}
 
-/// `--api` flag > `FIRECRAB_API` env > `DEFAULT_API_BASE`. Trailing slash
-/// stripped so callers can always do `format!("{base}/api/host")`.
-pub fn resolve_api_base(flag: Option<&str>) -> String {
-    if let Some(f) = flag {
-        return f.trim_end_matches('/').to_owned();
+/// Resolves `--api` > `FIRECRAB_API` > `--host` > current host > loopback.
+pub fn resolve_api_base(
+    flag: Option<&str>,
+    requested_host: Option<&str>,
+) -> Result<String, crate::hosts::Error> {
+    if let Some(flag) = flag {
+        return crate::hosts::normalize_url(flag);
     }
-    if let Ok(env_val) = std::env::var("FIRECRAB_API")
-        && !env_val.is_empty()
+    if let Ok(environment) = std::env::var("FIRECRAB_API")
+        && !environment.is_empty()
     {
-        return env_val.trim_end_matches('/').to_owned();
+        return crate::hosts::normalize_url(&environment);
     }
-    DEFAULT_API_BASE.to_owned()
+    let selected = crate::hosts::selected(requested_host)?;
+    Ok(selected
+        .map(|host| host.url)
+        .unwrap_or_else(|| DEFAULT_API_BASE.to_owned()))
 }
 
 /// Thin blocking HTTP client for firecrab-api, used by `status`/other
@@ -294,7 +299,7 @@ mod tests {
     #[test]
     fn resolve_api_base_prefers_flag() {
         assert_eq!(
-            resolve_api_base(Some("http://example.test:9000/")),
+            resolve_api_base(Some("http://example.test:9000/"), Some("ignored")).unwrap(),
             "http://example.test:9000"
         );
     }
@@ -302,10 +307,13 @@ mod tests {
     #[test]
     fn resolve_api_base_falls_back_to_default() {
         let _guard = ENV_LOCK.lock().unwrap();
+        let directory = tempfile::tempdir().unwrap();
         // SAFETY: serialized by ENV_LOCK against the other test in this
         // file that touches FIRECRAB_API; no other test reads it.
         unsafe { std::env::remove_var("FIRECRAB_API") };
-        assert_eq!(resolve_api_base(None), DEFAULT_API_BASE);
+        unsafe { std::env::set_var("FIRECRAB_CONFIG_DIR", directory.path()) };
+        assert_eq!(resolve_api_base(None, None).unwrap(), DEFAULT_API_BASE);
+        unsafe { std::env::remove_var("FIRECRAB_CONFIG_DIR") };
     }
 
     #[test]
@@ -313,9 +321,44 @@ mod tests {
         let _guard = ENV_LOCK.lock().unwrap();
         // SAFETY: serialized by ENV_LOCK — see the note above.
         unsafe { std::env::set_var("FIRECRAB_API", "http://env-example.test:1234/") };
-        let result = resolve_api_base(None);
+        let result = resolve_api_base(None, Some("ignored")).unwrap();
         unsafe { std::env::remove_var("FIRECRAB_API") };
         assert_eq!(result, "http://env-example.test:1234");
+    }
+
+    #[test]
+    fn resolve_api_base_reads_an_explicit_and_current_saved_host() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let directory = tempfile::tempdir().unwrap();
+        std::fs::write(
+            directory.path().join("config.toml"),
+            r#"
+current_host = "lab"
+
+[hosts.lab]
+url = "http://lab.example:5523"
+
+[hosts.prod]
+url = "https://prod.example:5523/"
+"#,
+        )
+        .unwrap();
+        // SAFETY: ENV_LOCK serializes every environment-changing test here.
+        unsafe {
+            std::env::remove_var("FIRECRAB_API");
+            std::env::set_var("FIRECRAB_CONFIG_DIR", directory.path());
+        }
+
+        assert_eq!(
+            resolve_api_base(None, Some("prod")).unwrap(),
+            "https://prod.example:5523"
+        );
+        assert_eq!(
+            resolve_api_base(None, None).unwrap(),
+            "http://lab.example:5523"
+        );
+
+        unsafe { std::env::remove_var("FIRECRAB_CONFIG_DIR") };
     }
 
     #[test]

--- a/firecrab-cli/src/hosts.rs
+++ b/firecrab-cli/src/hosts.rs
@@ -1,0 +1,938 @@
+//! Named `firecrab-api` endpoints stored in the user's firecrab directory.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use clap::Subcommand;
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+
+use crate::api_client::{ApiClient, ApiError};
+
+/// Filename below the resolved firecrab user directory.
+const CONFIG_FILE: &str = "config.toml";
+
+/// Saved-host operations exposed by `firecrab host`.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Save a named firecrab host.
+    Add {
+        /// Short name used by `--host` and `host use`.
+        name: String,
+        /// API base URL, for example `https://firecrab.example.com:5523`.
+        url: String,
+        /// Make this host current immediately.
+        #[arg(long)]
+        r#use: bool,
+    },
+    /// List saved hosts and mark the current one.
+    List {
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Make a saved host current.
+    Use {
+        /// Name of a saved host.
+        name: String,
+    },
+    /// Resolve a host and verify that its API is reachable.
+    Show {
+        /// Saved name; the current host or loopback default when omitted.
+        name: Option<String>,
+        /// Emit machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Remove a saved host.
+    Remove {
+        /// Name of a saved host.
+        name: String,
+    },
+}
+
+/// A named host entry in `~/firecrab/config.toml`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct HostEntry {
+    /// Normalized HTTP(S) API base URL.
+    url: String,
+}
+
+/// Complete user-level CLI configuration.
+#[derive(Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct HostsConfig {
+    /// Name used when neither `--api`, `FIRECRAB_API`, nor `--host` is set.
+    current_host: Option<String>,
+    /// Stable ordering keeps both human output and the TOML file predictable.
+    #[serde(default)]
+    hosts: BTreeMap<String, HostEntry>,
+}
+
+/// A host name and URL selected from the configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedHost {
+    /// Saved name, absent only for the built-in loopback default.
+    pub name: Option<String>,
+    /// Normalized HTTP(S) API base URL.
+    pub url: String,
+}
+
+/// Configuration and host-selection failures.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// No supported home-directory variable is available.
+    #[error("cannot locate the user home directory; set HOME, USERPROFILE, or FIRECRAB_CONFIG_DIR")]
+    NoHomeDirectory,
+    /// Reading the configuration failed.
+    #[error("failed to read {path}: {source}")]
+    Read {
+        /// File that could not be read.
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// TOML parsing failed.
+    #[error("failed to parse {path}: {source}")]
+    Parse {
+        /// File containing invalid TOML.
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+    /// TOML serialization failed.
+    #[error("failed to serialize {path}: {source}")]
+    Serialize {
+        /// Destination file.
+        path: PathBuf,
+        #[source]
+        source: toml::ser::Error,
+    },
+    /// Creating or atomically replacing the configuration failed.
+    #[error("failed to write {path}: {source}")]
+    Write {
+        /// Destination file.
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// Acquiring the sibling configuration lock failed.
+    #[error("failed to lock {path}: {source}")]
+    Lock {
+        /// Lock file that could not be acquired.
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    /// A host name is unsafe or ambiguous on the command line.
+    #[error("invalid host name {0:?}; use letters, digits, '.', '_' or '-'")]
+    InvalidName(String),
+    /// The endpoint is not a usable HTTP(S) base URL.
+    #[error("invalid API URL {url:?}: {reason}")]
+    InvalidUrl {
+        /// Rejected input.
+        url: String,
+        /// Actionable validation reason.
+        reason: String,
+    },
+    /// The requested name is absent from the configuration.
+    #[error("no saved host named {0:?}; run `firecrab host list`")]
+    UnknownHost(String),
+    /// `host add` would silently replace an existing endpoint.
+    #[error("host {0:?} already exists; remove it before adding a replacement")]
+    DuplicateHost(String),
+    /// The configuration points at a deleted or manually renamed entry.
+    #[error("current_host {0:?} has no matching entry in the config")]
+    MissingCurrentHost(String),
+    /// The selected endpoint did not answer its status probe.
+    #[error("failed to connect to host {name:?} at {url}: {source}")]
+    Connection {
+        /// Saved name or `default` for loopback.
+        name: String,
+        /// Resolved endpoint.
+        url: String,
+        #[source]
+        source: ApiError,
+    },
+}
+
+impl HostsConfig {
+    /// Loads TOML from `path`, treating a missing file as an empty config.
+    fn load(path: &Path) -> Result<Self, Error> {
+        match fs::read_to_string(path) {
+            Ok(text) => toml::from_str(&text).map_err(|source| Error::Parse {
+                path: path.to_owned(),
+                source,
+            }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(source) => Err(Error::Read {
+                path: path.to_owned(),
+                source,
+            }),
+        }
+    }
+
+    /// Serializes and atomically replaces `path` from a sibling temporary file.
+    fn save(&self, path: &Path) -> Result<(), Error> {
+        let parent = path.parent().ok_or_else(|| Error::Write {
+            path: path.to_owned(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "config path has no parent directory",
+            ),
+        })?;
+        fs::create_dir_all(parent).map_err(|source| Error::Write {
+            path: path.to_owned(),
+            source,
+        })?;
+        let text = toml::to_string_pretty(self).map_err(|source| Error::Serialize {
+            path: path.to_owned(),
+            source,
+        })?;
+        let mut temporary =
+            tempfile::NamedTempFile::new_in(parent).map_err(|source| Error::Write {
+                path: path.to_owned(),
+                source,
+            })?;
+        temporary
+            .write_all(text.as_bytes())
+            .and_then(|()| temporary.as_file().sync_all())
+            .map_err(|source| Error::Write {
+                path: path.to_owned(),
+                source,
+            })?;
+        temporary.persist(path).map_err(|error| Error::Write {
+            path: path.to_owned(),
+            source: error.error,
+        })?;
+        Ok(())
+    }
+}
+
+/// Acquires an exclusive lock separate from the atomically replaced config file.
+fn lock_config(path: &Path) -> Result<fs::File, Error> {
+    let parent = path.parent().ok_or_else(|| Error::Write {
+        path: path.to_owned(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "config path has no parent directory",
+        ),
+    })?;
+    fs::create_dir_all(parent).map_err(|source| Error::Write {
+        path: path.to_owned(),
+        source,
+    })?;
+    let mut filename = path
+        .file_name()
+        .ok_or_else(|| Error::Write {
+            path: path.to_owned(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "config path has no filename",
+            ),
+        })?
+        .to_os_string();
+    filename.push(".lock");
+    let lock_path = parent.join(filename);
+    let lock = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|source| Error::Lock {
+            path: lock_path.clone(),
+            source,
+        })?;
+    lock.lock_exclusive().map_err(|source| Error::Lock {
+        path: lock_path,
+        source,
+    })?;
+    Ok(lock)
+}
+
+/// Loads, changes, and persists one configuration while holding its file lock.
+fn change_config<T>(
+    path: &Path,
+    change: impl FnOnce(&mut HostsConfig) -> Result<T, Error>,
+) -> Result<T, Error> {
+    let lock = lock_config(path)?;
+    let mut config = HostsConfig::load(path)?;
+    let result = change(&mut config)?;
+    config.save(path)?;
+    drop(lock);
+    Ok(result)
+}
+
+/// Filters empty environment values before they become relative paths.
+fn non_empty(value: Option<OsString>) -> Option<OsString> {
+    value.filter(|item| !item.is_empty())
+}
+
+/// Pure platform-aware half of [`config_path`].
+fn config_path_from(
+    override_dir: Option<OsString>,
+    home: Option<OsString>,
+    user_profile: Option<OsString>,
+    windows: bool,
+) -> Option<PathBuf> {
+    if let Some(directory) = non_empty(override_dir) {
+        return Some(PathBuf::from(directory).join(CONFIG_FILE));
+    }
+    let home = if windows {
+        non_empty(user_profile).or_else(|| non_empty(home))
+    } else {
+        non_empty(home).or_else(|| non_empty(user_profile))
+    }?;
+    Some(PathBuf::from(home).join("firecrab").join(CONFIG_FILE))
+}
+
+/// Returns the configured path, normally `~/firecrab/config.toml`.
+pub fn config_path() -> Result<PathBuf, Error> {
+    config_path_from(
+        std::env::var_os("FIRECRAB_CONFIG_DIR"),
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+        cfg!(windows),
+    )
+    .ok_or(Error::NoHomeDirectory)
+}
+
+/// Validates and normalizes an endpoint from a flag, environment, or config.
+pub fn normalize_url(input: &str) -> Result<String, Error> {
+    let input = input.trim();
+    let parsed = reqwest::Url::parse(input).map_err(|source| Error::InvalidUrl {
+        url: input.to_owned(),
+        reason: source.to_string(),
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(Error::InvalidUrl {
+            url: input.to_owned(),
+            reason: "expected an http:// or https:// URL".to_owned(),
+        });
+    }
+    if parsed.host_str().is_none() {
+        return Err(Error::InvalidUrl {
+            url: input.to_owned(),
+            reason: "host is missing".to_owned(),
+        });
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(Error::InvalidUrl {
+            url: input.to_owned(),
+            reason: "embedded credentials are not allowed".to_owned(),
+        });
+    }
+    if parsed.query().is_some() || parsed.fragment().is_some() {
+        return Err(Error::InvalidUrl {
+            url: input.to_owned(),
+            reason: "query strings and fragments are not allowed".to_owned(),
+        });
+    }
+    Ok(parsed.as_str().trim_end_matches('/').to_owned())
+}
+
+/// Restricts names to the portable characters accepted on every shell.
+fn validate_name(name: &str) -> Result<(), Error> {
+    if !name.is_empty()
+        && name.len() <= 64
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "._-".contains(character))
+    {
+        return Ok(());
+    }
+    Err(Error::InvalidName(name.to_owned()))
+}
+
+/// Resolves a requested or current host from one explicit config path.
+fn selected_at(path: &Path, requested: Option<&str>) -> Result<Option<SelectedHost>, Error> {
+    let config = HostsConfig::load(path)?;
+    let name = match requested {
+        Some(name) => name,
+        None => match config.current_host.as_deref() {
+            Some(name) => name,
+            None => return Ok(None),
+        },
+    };
+    let entry = config.hosts.get(name).ok_or_else(|| match requested {
+        Some(_) => Error::UnknownHost(name.to_owned()),
+        None => Error::MissingCurrentHost(name.to_owned()),
+    })?;
+    Ok(Some(SelectedHost {
+        name: Some(name.to_owned()),
+        url: normalize_url(&entry.url)?,
+    }))
+}
+
+/// Resolves an explicit or current saved host without applying API overrides.
+pub fn selected(requested: Option<&str>) -> Result<Option<SelectedHost>, Error> {
+    match config_path() {
+        Ok(path) => selected_at(&path, requested),
+        Err(Error::NoHomeDirectory) if requested.is_none() => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Adds one entry and reports whether it became current.
+fn add_at(path: &Path, name: &str, url: &str, make_current: bool) -> Result<bool, Error> {
+    validate_name(name)?;
+    let url = normalize_url(url)?;
+    change_config(path, |config| {
+        if config.hosts.contains_key(name) {
+            return Err(Error::DuplicateHost(name.to_owned()));
+        }
+        let becomes_current = make_current || config.hosts.is_empty();
+        config.hosts.insert(name.to_owned(), HostEntry { url });
+        if becomes_current {
+            config.current_host = Some(name.to_owned());
+        }
+        Ok(becomes_current)
+    })
+}
+
+/// Changes the current host in one explicit config file.
+fn use_at(path: &Path, name: &str) -> Result<(), Error> {
+    change_config(path, |config| {
+        if !config.hosts.contains_key(name) {
+            return Err(Error::UnknownHost(name.to_owned()));
+        }
+        config.current_host = Some(name.to_owned());
+        Ok(())
+    })
+}
+
+/// Removes one entry and reports whether it had been current.
+fn remove_at(path: &Path, name: &str) -> Result<bool, Error> {
+    change_config(path, |config| {
+        if config.hosts.remove(name).is_none() {
+            return Err(Error::UnknownHost(name.to_owned()));
+        }
+        let was_current = config.current_host.as_deref() == Some(name);
+        if was_current {
+            config.current_host = None;
+        }
+        Ok(was_current)
+    })
+}
+
+/// Formats the stable tabular output of `host list`.
+fn format_list(config: &HostsConfig) -> String {
+    if config.hosts.is_empty() {
+        return "no saved hosts (run `firecrab host add`)\n".to_owned();
+    }
+    let mut output = String::from("NAME\tURL\tCURRENT\n");
+    for (name, entry) in &config.hosts {
+        let current = config.current_host.as_deref() == Some(name.as_str());
+        output.push_str(&format!(
+            "{name}\t{}\t{}\n",
+            entry.url,
+            if current { "*" } else { "" }
+        ));
+    }
+    output
+}
+
+/// Probes and prints one fully resolved host.
+fn show_host(selected: SelectedHost, json: bool) -> Result<(), Error> {
+    let status = ApiClient::new(selected.url.clone()).get_host_status();
+    let name = selected.name.unwrap_or_else(|| "default".to_owned());
+    let host = status.map_err(|source| Error::Connection {
+        name: name.clone(),
+        url: selected.url.clone(),
+        source,
+    })?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "name": name,
+                "url": selected.url,
+                "reachable": true,
+                "host": host,
+            }))
+            .expect("host status always serializes")
+        );
+    } else {
+        println!(
+            "{name}\t{}\treachable\tload {:.2}\tmemory {}/{} MiB available\tuptime {}s",
+            selected.url,
+            host.load_average_1m,
+            host.memory_available_mib,
+            host.memory_total_mib,
+            host.uptime_seconds
+        );
+    }
+    Ok(())
+}
+
+/// Resolves `host show` while allowing its positional name to be authoritative.
+fn selection_for_show_at(
+    path: &Path,
+    positional_name: Option<&str>,
+    api: Option<&str>,
+    global_host: Option<&str>,
+) -> Result<SelectedHost, Error> {
+    if let Some(name) = positional_name {
+        return selected_at(path, Some(name))?.ok_or_else(|| Error::UnknownHost(name.to_owned()));
+    }
+    if let Some(api) = api {
+        return Ok(SelectedHost {
+            name: None,
+            url: normalize_url(api)?,
+        });
+    }
+    if let Ok(environment) = std::env::var("FIRECRAB_API")
+        && !environment.is_empty()
+    {
+        return Ok(SelectedHost {
+            name: None,
+            url: normalize_url(&environment)?,
+        });
+    }
+    Ok(selected_at(path, global_host)?.unwrap_or(SelectedHost {
+        name: None,
+        url: crate::api_client::DEFAULT_API_BASE.to_owned(),
+    }))
+}
+
+/// Resolves `host show` without requiring a config directory for direct endpoints.
+fn selection_for_show(
+    positional_name: Option<&str>,
+    api: Option<&str>,
+    global_host: Option<&str>,
+) -> Result<SelectedHost, Error> {
+    if positional_name.is_some() {
+        return selection_for_show_at(&config_path()?, positional_name, api, global_host);
+    }
+    if let Some(api) = api {
+        return Ok(SelectedHost {
+            name: None,
+            url: normalize_url(api)?,
+        });
+    }
+    if let Ok(environment) = std::env::var("FIRECRAB_API")
+        && !environment.is_empty()
+    {
+        return Ok(SelectedHost {
+            name: None,
+            url: normalize_url(&environment)?,
+        });
+    }
+    match config_path() {
+        Ok(path) => selection_for_show_at(&path, None, None, global_host),
+        Err(Error::NoHomeDirectory) if global_host.is_none() => Ok(SelectedHost {
+            name: None,
+            url: crate::api_client::DEFAULT_API_BASE.to_owned(),
+        }),
+        Err(error) => Err(error),
+    }
+}
+
+/// Executes one `firecrab host` command.
+pub fn run(command: Command, api: Option<&str>, global_host: Option<&str>) -> Result<(), Error> {
+    if let Command::Show { name, json } = command {
+        return show_host(selection_for_show(name.as_deref(), api, global_host)?, json);
+    }
+    let path = config_path()?;
+    run_at(&path, command, api, global_host)
+}
+
+/// Executes one host command against an explicit config path.
+fn run_at(
+    path: &Path,
+    command: Command,
+    api: Option<&str>,
+    global_host: Option<&str>,
+) -> Result<(), Error> {
+    match command {
+        Command::Add { name, url, r#use } => {
+            let current = add_at(path, &name, &url, r#use)?;
+            println!(
+                "added {name} -> {}{}",
+                normalize_url(&url)?,
+                if current { " (current)" } else { "" }
+            );
+            Ok(())
+        }
+        Command::List { json } => {
+            let config = HostsConfig::load(path)?;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&config).expect("host config always serializes")
+                );
+            } else {
+                print!("{}", format_list(&config));
+            }
+            Ok(())
+        }
+        Command::Use { name } => {
+            use_at(path, &name)?;
+            println!("current host is now {name}");
+            Ok(())
+        }
+        Command::Show { name, json } => {
+            let selected = selection_for_show_at(path, name.as_deref(), api, global_host)?;
+            show_host(selected, json)
+        }
+        Command::Remove { name } => {
+            let was_current = remove_at(path, &name)?;
+            println!(
+                "removed {name}{}",
+                if was_current {
+                    " (current host cleared)"
+                } else {
+                    ""
+                }
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    use super::*;
+
+    fn temp_config() -> (tempfile::TempDir, PathBuf) {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("firecrab").join(CONFIG_FILE);
+        (directory, path)
+    }
+
+    #[test]
+    fn config_path_uses_the_requested_cross_platform_home() {
+        let unix = config_path_from(None, Some("/home/alice".into()), None, false).unwrap();
+        assert_eq!(unix, Path::new("/home/alice/firecrab/config.toml"));
+
+        let windows = config_path_from(
+            None,
+            Some("ignored".into()),
+            Some(r"C:\Users\alice".into()),
+            true,
+        )
+        .unwrap();
+        assert_eq!(windows, Path::new(r"C:\Users\alice/firecrab/config.toml"));
+    }
+
+    #[test]
+    fn config_path_override_is_platform_independent() {
+        let path = config_path_from(Some("portable".into()), None, None, true).unwrap();
+        assert_eq!(path, Path::new("portable/config.toml"));
+    }
+
+    #[test]
+    fn missing_config_loads_as_empty() {
+        let (_directory, path) = temp_config();
+        assert_eq!(HostsConfig::load(&path).unwrap(), HostsConfig::default());
+    }
+
+    #[test]
+    fn config_round_trip_is_toml_and_creates_parent_directory() {
+        let (_directory, path) = temp_config();
+        add_at(&path, "prod", "https://prod.example:5523/", false).unwrap();
+
+        let text = fs::read_to_string(&path).unwrap();
+        assert!(text.contains("current_host = \"prod\""));
+        assert!(text.contains("[hosts.prod]"));
+        assert_eq!(
+            selected_at(&path, None).unwrap().unwrap(),
+            SelectedHost {
+                name: Some("prod".to_owned()),
+                url: "https://prod.example:5523".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_toml_is_reported_instead_of_ignored() {
+        let (_directory, path) = temp_config();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "current_host = [").unwrap();
+        assert!(matches!(HostsConfig::load(&path), Err(Error::Parse { .. })));
+    }
+
+    #[test]
+    fn unknown_toml_fields_are_rejected_before_a_mutation_can_drop_them() {
+        let (_directory, path) = temp_config();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            &path,
+            r#"
+future_setting = "keep"
+current_host = "prod"
+
+[hosts.prod]
+url = "https://prod.example:5523"
+"#,
+        )
+        .unwrap();
+
+        assert!(matches!(use_at(&path, "prod"), Err(Error::Parse { .. })));
+        assert!(
+            fs::read_to_string(path)
+                .unwrap()
+                .contains("future_setting = \"keep\"")
+        );
+    }
+
+    #[test]
+    fn url_validation_accepts_http_paths_and_rejects_unsafe_bases() {
+        assert_eq!(
+            normalize_url(" https://example.test/firecrab/ ").unwrap(),
+            "https://example.test/firecrab"
+        );
+        for invalid in [
+            "example.test:5523",
+            "file:///tmp/api",
+            "https://user:secret@example.test",
+            "https://example.test?q=1",
+        ] {
+            assert!(matches!(
+                normalize_url(invalid),
+                Err(Error::InvalidUrl { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn host_names_are_restricted_to_portable_characters() {
+        for valid in ["prod", "seoul-1", "lab.a", "lab_a"] {
+            assert!(validate_name(valid).is_ok());
+        }
+        for invalid in ["", "two words", "slash/name", "한글"] {
+            assert!(matches!(validate_name(invalid), Err(Error::InvalidName(_))));
+        }
+    }
+
+    #[test]
+    fn first_add_becomes_current_and_explicit_use_switches_it() {
+        let (_directory, path) = temp_config();
+        assert!(add_at(&path, "first", "http://first:5523", false).unwrap());
+        assert!(!add_at(&path, "second", "http://second:5523", false).unwrap());
+        use_at(&path, "second").unwrap();
+        assert_eq!(
+            selected_at(&path, None).unwrap().unwrap().name.as_deref(),
+            Some("second")
+        );
+    }
+
+    #[test]
+    fn concurrent_mutations_preserve_every_profile() {
+        let (_directory, path) = temp_config();
+        let workers = 12;
+        let ready = Arc::new(Barrier::new(workers + 1));
+        let mut joins = Vec::new();
+        for number in 0..workers {
+            let path = path.clone();
+            let ready = Arc::clone(&ready);
+            joins.push(thread::spawn(move || {
+                ready.wait();
+                add_at(
+                    &path,
+                    &format!("host-{number}"),
+                    &format!("http://127.0.0.1:{}", 20_000 + number),
+                    false,
+                )
+            }));
+        }
+        ready.wait();
+        for join in joins {
+            join.join().unwrap().unwrap();
+        }
+
+        assert_eq!(HostsConfig::load(&path).unwrap().hosts.len(), workers);
+    }
+
+    #[test]
+    fn add_rejects_duplicates_and_selection_rejects_unknown_names() {
+        let (_directory, path) = temp_config();
+        add_at(&path, "prod", "http://prod:5523", false).unwrap();
+        assert!(matches!(
+            add_at(&path, "prod", "http://other:5523", false),
+            Err(Error::DuplicateHost(name)) if name == "prod"
+        ));
+        assert!(matches!(
+            selected_at(&path, Some("missing")),
+            Err(Error::UnknownHost(name)) if name == "missing"
+        ));
+    }
+
+    #[test]
+    fn removing_current_clears_selection_without_removing_other_hosts() {
+        let (_directory, path) = temp_config();
+        add_at(&path, "first", "http://first:5523", false).unwrap();
+        add_at(&path, "second", "http://second:5523", false).unwrap();
+        assert!(remove_at(&path, "first").unwrap());
+        assert!(selected_at(&path, None).unwrap().is_none());
+        assert!(selected_at(&path, Some("second")).unwrap().is_some());
+    }
+
+    #[test]
+    fn list_is_sorted_and_marks_current() {
+        let config = HostsConfig {
+            current_host: Some("zeta".to_owned()),
+            hosts: BTreeMap::from([
+                (
+                    "zeta".to_owned(),
+                    HostEntry {
+                        url: "http://zeta:5523".to_owned(),
+                    },
+                ),
+                (
+                    "alpha".to_owned(),
+                    HostEntry {
+                        url: "http://alpha:5523".to_owned(),
+                    },
+                ),
+            ]),
+        };
+        assert_eq!(
+            format_list(&config),
+            "NAME\tURL\tCURRENT\nalpha\thttp://alpha:5523\t\nzeta\thttp://zeta:5523\t*\n"
+        );
+    }
+
+    #[test]
+    fn command_dispatch_persists_lists_switches_and_removes_hosts() {
+        let (_directory, path) = temp_config();
+        run_at(
+            &path,
+            Command::Add {
+                name: "first".to_owned(),
+                url: "http://first:5523/".to_owned(),
+                r#use: false,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        run_at(
+            &path,
+            Command::Add {
+                name: "second".to_owned(),
+                url: "https://second:5523".to_owned(),
+                r#use: true,
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        run_at(&path, Command::List { json: false }, None, None).unwrap();
+        run_at(&path, Command::List { json: true }, None, None).unwrap();
+        run_at(
+            &path,
+            Command::Use {
+                name: "first".to_owned(),
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        run_at(
+            &path,
+            Command::Remove {
+                name: "second".to_owned(),
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        run_at(
+            &path,
+            Command::Remove {
+                name: "first".to_owned(),
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(HostsConfig::load(&path).unwrap(), HostsConfig::default());
+    }
+
+    #[test]
+    fn show_host_probes_the_selected_api() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let read = stream.read(&mut request).unwrap();
+            assert!(String::from_utf8_lossy(&request[..read]).starts_with("GET /api/host "));
+            let body = r#"{"loadAverage1m":0.5,"memoryTotalMib":2048,"memoryAvailableMib":1024,"diskTotalGib":100,"diskAvailableGib":80,"uptimeSeconds":3600}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+        });
+
+        show_host(
+            SelectedHost {
+                name: Some("test".to_owned()),
+                url,
+            },
+            false,
+        )
+        .unwrap();
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn show_host_reports_name_and_url_on_connection_failure() {
+        let error = show_host(
+            SelectedHost {
+                name: Some("offline".to_owned()),
+                url: "http://127.0.0.1:1".to_owned(),
+            },
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::Connection { name, url, .. }
+                if name == "offline" && url == "http://127.0.0.1:1"
+        ));
+    }
+
+    #[test]
+    fn explicit_show_name_wins_over_global_api_selection() {
+        let (_directory, path) = temp_config();
+        add_at(&path, "prod", "https://prod.example:5523", false).unwrap();
+        assert_eq!(
+            selection_for_show_at(
+                &path,
+                Some("prod"),
+                Some("https://override.example:5523"),
+                None,
+            )
+            .unwrap(),
+            SelectedHost {
+                name: Some("prod".to_owned()),
+                url: "https://prod.example:5523".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn direct_show_selection_does_not_require_a_config_path() {
+        assert_eq!(
+            selection_for_show(None, Some("https://direct.example:5523/"), None).unwrap(),
+            SelectedHost {
+                name: None,
+                url: "https://direct.example:5523".to_owned(),
+            }
+        );
+    }
+}

--- a/firecrab-cli/src/main.rs
+++ b/firecrab-cli/src/main.rs
@@ -1,26 +1,36 @@
 use clap::{Parser, Subcommand};
 
 mod api_client;
+#[cfg(target_os = "linux")]
 mod doctor;
 #[cfg(test)]
 mod host_api_tests;
+mod hosts;
 mod image;
+#[cfg(target_os = "linux")]
 mod info;
 mod network;
+#[cfg(target_os = "linux")]
 mod service;
+#[cfg(target_os = "linux")]
 mod shell;
+#[cfg(target_os = "linux")]
 mod status;
+#[cfg(target_os = "linux")]
 mod update;
 mod vm;
 mod vm_console;
 
 /// `clap`-derived top-level CLI, replacing `scripts/firecrab-doctor.sh`.
 #[derive(Parser)]
-#[command(name = "firecrab", version, about = "firecrab host CLI")]
+#[command(name = "firecrab", version, about = "firecrab client for Linux hosts")]
 struct Cli {
-    /// Override the API base URL (else FIRECRAB_API, else http://127.0.0.1:5523).
+    /// Override the API base URL.
     #[arg(long, global = true, value_name = "URL")]
     api: Option<String>,
+    /// Use a named host from ~/firecrab/config.toml.
+    #[arg(long, global = true, value_name = "NAME")]
+    host: Option<String>,
     #[command(subcommand)]
     command: Command,
 }
@@ -28,6 +38,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Command {
     /// Diagnose host readiness for firecrab (KVM, nft, dnsmasq, UFW, ...).
+    #[cfg(target_os = "linux")]
     Doctor {
         /// Also print sha256 (first 12 hex chars) of template images.
         #[arg(long)]
@@ -37,18 +48,21 @@ enum Command {
         json: bool,
     },
     /// Show version and resolved host configuration paths.
+    #[cfg(target_os = "linux")]
     Info {
         /// Emit the [`info::InfoReport`] as JSON instead of the human format.
         #[arg(long)]
         json: bool,
     },
     /// Show systemd unit status and the API host status.
+    #[cfg(target_os = "linux")]
     Status {
         /// Emit the [`status::StatusReport`] as JSON instead of the human format.
         #[arg(long)]
         json: bool,
     },
     /// Check for a newer firecrab release, and optionally install it.
+    #[cfg(target_os = "linux")]
     Update {
         /// Only report whether a newer release exists (the default).
         #[arg(long)]
@@ -75,7 +89,13 @@ enum Command {
         #[command(subcommand)]
         command: image::Command,
     },
+    /// Save and select remote firecrab hosts.
+    Host {
+        #[command(subcommand)]
+        command: hosts::Command,
+    },
     /// Install, remove, or control the firecrab host services.
+    #[cfg(target_os = "linux")]
     Service {
         #[command(subcommand)]
         command: service::Command,
@@ -87,30 +107,37 @@ fn main() {
 }
 
 fn run(cli: Cli) -> i32 {
-    let Cli { api, command } = cli;
+    let Cli { api, host, command } = cli;
     match command {
+        #[cfg(target_os = "linux")]
         Command::Doctor { digest, json } => run_doctor(digest, json),
+        #[cfg(target_os = "linux")]
         Command::Info { json } => {
-            run_info(json, api);
-            0
+            finish_api_command(run_info(json, api.as_deref(), host.as_deref()))
         }
+        #[cfg(target_os = "linux")]
         Command::Status { json } => {
-            run_status(json, api);
-            0
+            finish_api_command(run_status(json, api.as_deref(), host.as_deref()))
         }
+        #[cfg(target_os = "linux")]
         Command::Update { check, apply, json } => run_update(check, apply, json),
-        Command::Vm { command } => {
-            let client = build_api_client(api.as_deref());
-            finish_api_command(vm::run(&client, command))
-        }
+        Command::Vm { command } => run_with_api_client(api.as_deref(), host.as_deref(), |client| {
+            vm::run(client, command)
+        }),
         Command::Network { command } => {
-            let client = build_api_client(api.as_deref());
-            finish_api_command(network::run(&client, command))
+            run_with_api_client(api.as_deref(), host.as_deref(), |client| {
+                network::run(client, command)
+            })
         }
         Command::Image { command } => {
-            let client = build_api_client(api.as_deref());
-            finish_api_command(image::run(&client, command))
+            run_with_api_client(api.as_deref(), host.as_deref(), |client| {
+                image::run(client, command)
+            })
         }
+        Command::Host { command } => {
+            finish_api_command(hosts::run(command, api.as_deref(), host.as_deref()))
+        }
+        #[cfg(target_os = "linux")]
         Command::Service { command } => match service::run(&shell::RealCommandRunner, command) {
             Ok(()) => 0,
             Err(error) => {
@@ -121,8 +148,24 @@ fn run(cli: Cli) -> i32 {
     }
 }
 
-fn build_api_client(api: Option<&str>) -> api_client::ApiClient {
-    api_client::ApiClient::new(api_client::resolve_api_base(api))
+/// Builds a client after applying flag, environment, and saved-host precedence.
+fn build_api_client(
+    api: Option<&str>,
+    host: Option<&str>,
+) -> Result<api_client::ApiClient, hosts::Error> {
+    api_client::resolve_api_base(api, host).map(api_client::ApiClient::new)
+}
+
+/// Resolves one remote client and maps either resolution or API failure to an exit code.
+fn run_with_api_client<E, F>(api: Option<&str>, host: Option<&str>, command: F) -> i32
+where
+    E: std::fmt::Display,
+    F: FnOnce(&api_client::ApiClient) -> Result<(), E>,
+{
+    match build_api_client(api, host) {
+        Ok(client) => finish_api_command(command(&client)),
+        Err(error) => finish_api_command(Err(error)),
+    }
 }
 
 fn finish_api_command<E: std::fmt::Display>(result: Result<(), E>) -> i32 {
@@ -140,6 +183,7 @@ fn finish_api_command<E: std::fmt::Display>(result: Result<(), E>) -> i32 {
 /// [`doctor::Report::exit_code`] computes. Split out of `main()` so this
 /// logic is unit-testable without needing a live `std::process::exit` —
 /// same pattern as `firecrab-api/src/main.rs`'s `run()`.
+#[cfg(target_os = "linux")]
 fn run_doctor(digest: bool, json: bool) -> i32 {
     let env = doctor::DoctorEnv::from_process_env();
     let runner = shell::RealCommandRunner;
@@ -154,21 +198,24 @@ fn run_doctor(digest: bool, json: bool) -> i32 {
 
 /// Runs the `info` subcommand end-to-end — extracted for the same
 /// testability reason as [`run_doctor`].
-fn run_info(json: bool, api: Option<String>) {
-    let api_base = api_client::resolve_api_base(api.as_deref());
+#[cfg(target_os = "linux")]
+fn run_info(json: bool, api: Option<&str>, host: Option<&str>) -> Result<(), hosts::Error> {
+    let api_base = api_client::resolve_api_base(api, host)?;
     let report = info::collect(&api_base);
     if json {
         info::print_json(&report);
     } else {
         info::print_human(&report);
     }
+    Ok(())
 }
 
 /// Runs the `status` subcommand end-to-end — extracted for the same
 /// testability reason as [`run_doctor`].
-fn run_status(json: bool, api: Option<String>) {
+#[cfg(target_os = "linux")]
+fn run_status(json: bool, api: Option<&str>, host: Option<&str>) -> Result<(), hosts::Error> {
     let runner = shell::RealCommandRunner;
-    let api_base = api_client::resolve_api_base(api.as_deref());
+    let api_base = api_client::resolve_api_base(api, host)?;
     let client = api_client::ApiClient::new(api_base);
     let report = status::collect(&runner, &client);
     if json {
@@ -176,6 +223,7 @@ fn run_status(json: bool, api: Option<String>) {
     } else {
         status::print_human(&report);
     }
+    Ok(())
 }
 
 /// Runs the `update` subcommand end-to-end and returns the process exit code —
@@ -184,6 +232,7 @@ fn run_status(json: bool, api: Option<String>) {
 /// With neither flag given this behaves as `--check`: a read-only default is
 /// the safe one for a command that can otherwise replace every binary on the
 /// host.
+#[cfg(target_os = "linux")]
 fn run_update(check: bool, apply: bool, json: bool) -> i32 {
     let outcome = update::run_check();
     if check || !apply {
@@ -237,41 +286,48 @@ mod tests {
     // outcomes, since those depend on what's actually installed on the
     // machine running the tests.
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_doctor_json_returns_valid_exit_code() {
         let code = run_doctor(false, true);
         assert!(code == 0 || code == 1, "unexpected exit code {code}");
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_doctor_human_returns_valid_exit_code() {
         let code = run_doctor(false, false);
         assert!(code == 0 || code == 1, "unexpected exit code {code}");
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_info_json_does_not_panic() {
-        run_info(true, Some("http://127.0.0.1:1".to_owned()));
+        run_info(true, Some("http://127.0.0.1:1"), None).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_info_human_does_not_panic() {
-        run_info(false, Some("http://127.0.0.1:1".to_owned()));
+        run_info(false, Some("http://127.0.0.1:1"), None).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_status_json_does_not_panic() {
         // Port 1 is a reserved, never-listening port, so the API portion
         // fails fast (connection refused) instead of waiting out the
         // client's 3s timeout.
-        run_status(true, Some("http://127.0.0.1:1".to_owned()));
+        run_status(true, Some("http://127.0.0.1:1"), None).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_status_human_does_not_panic() {
-        run_status(false, Some("http://127.0.0.1:1".to_owned()));
+        run_status(false, Some("http://127.0.0.1:1"), None).unwrap();
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_parses_doctor_digest_and_json_flags() {
         let cli = Cli::try_parse_from(["firecrab", "doctor", "--digest", "--json"]).unwrap();
@@ -284,6 +340,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_parses_info_api_flag() {
         let cli = Cli::try_parse_from(["firecrab", "info", "--api", "http://x:1"]).unwrap();
@@ -296,6 +353,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_parses_status_subcommand() {
         let cli = Cli::try_parse_from(["firecrab", "status"]).unwrap();
@@ -308,6 +366,7 @@ mod tests {
         assert!(Cli::try_parse_from(["firecrab", "bogus"]).is_err());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_parses_update_flags() {
         let cli = Cli::try_parse_from(["firecrab", "update", "--apply", "--json"]).unwrap();
@@ -321,6 +380,7 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_defaults_update_to_a_read_only_check() {
         let cli = Cli::try_parse_from(["firecrab", "update"]).unwrap();
@@ -334,11 +394,13 @@ mod tests {
         ));
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_rejects_check_and_apply_together() {
         assert!(Cli::try_parse_from(["firecrab", "update", "--check", "--apply"]).is_err());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_update_check_json_returns_a_valid_exit_code() {
         let _guard = update::ENV_LOCK.lock().unwrap();
@@ -352,6 +414,7 @@ mod tests {
         assert_eq!(code, 1, "an unreachable check must exit non-zero");
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn run_update_check_human_does_not_panic() {
         let _guard = update::ENV_LOCK.lock().unwrap();
@@ -461,6 +524,29 @@ mod tests {
     }
 
     #[test]
+    fn cli_parses_host_commands_and_global_selection() {
+        let add = Cli::try_parse_from([
+            "firecrab",
+            "host",
+            "add",
+            "prod",
+            "https://prod.example:5523",
+            "--use",
+        ])
+        .unwrap();
+        assert!(matches!(
+            add.command,
+            Command::Host {
+                command: hosts::Command::Add { r#use: true, .. }
+            }
+        ));
+
+        let list = Cli::try_parse_from(["firecrab", "vm", "list", "--host", "prod"]).unwrap();
+        assert_eq!(list.host.as_deref(), Some("prod"));
+        assert!(matches!(list.command, Command::Vm { .. }));
+    }
+
+    #[test]
     fn cli_rejects_missing_create_arguments_and_bad_uuid() {
         assert!(Cli::try_parse_from(["firecrab", "vm", "create"]).is_err());
         assert!(Cli::try_parse_from(["firecrab", "network", "create"]).is_err());
@@ -477,6 +563,7 @@ mod tests {
         assert_eq!(code, 1);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn cli_parses_service_commands() {
         let install = Cli::try_parse_from([

--- a/firecrab-cli/src/vm_console.rs
+++ b/firecrab-cli/src/vm_console.rs
@@ -2,8 +2,8 @@
 
 use std::io::IsTerminal;
 
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use futures_util::{SinkExt, StreamExt};
-use nix::sys::termios::{self, SetArg, Termios};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_tungstenite::tungstenite::{Error as WebSocketError, Message};
@@ -162,31 +162,25 @@ fn map_websocket_error(error: WebSocketError) -> Error {
     Error::Connection(error.to_string())
 }
 
-/// Restores the exact input terminal attributes when the console exits.
-struct RawTerminal {
-    original: Termios,
-}
+/// Restores the process terminal mode when the console exits.
+struct RawTerminal;
 
 impl RawTerminal {
+    /// Enables raw input only when stdin is attached to a terminal.
     fn enter() -> Result<Option<Self>, Error> {
         let input = std::io::stdin();
         if !input.is_terminal() {
             return Ok(None);
         }
 
-        let original =
-            termios::tcgetattr(&input).map_err(|error| Error::Terminal(error.to_string()))?;
-        let mut raw = original.clone();
-        termios::cfmakeraw(&mut raw);
-        termios::tcsetattr(&input, SetArg::TCSANOW, &raw)
-            .map_err(|error| Error::Terminal(error.to_string()))?;
-        Ok(Some(Self { original }))
+        enable_raw_mode().map_err(|error| Error::Terminal(error.to_string()))?;
+        Ok(Some(Self))
     }
 }
 
 impl Drop for RawTerminal {
     fn drop(&mut self) {
-        let _ = termios::tcsetattr(std::io::stdin(), SetArg::TCSANOW, &self.original);
+        let _ = disable_raw_mode();
     }
 }
 

--- a/firecrab-cli/src/vm_console.rs
+++ b/firecrab-cli/src/vm_console.rs
@@ -281,11 +281,19 @@ mod tests {
         let address = listener.local_addr().unwrap();
         let server = tokio::spawn(async move {
             let (mut tcp, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0_u8; 1024];
+            while !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
+                let read = tcp.read(&mut buffer).await.unwrap();
+                assert!(read > 0, "client closed before sending request headers");
+                request.extend_from_slice(&buffer[..read]);
+            }
             tcp.write_all(
                 b"HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: 25\r\nConnection: close\r\n\r\n{\"code\":\"vm_not_running\"}",
             )
             .await
             .unwrap();
+            tcp.shutdown().await.unwrap();
         });
 
         let error = stream(

--- a/install-cli.ps1
+++ b/install-cli.ps1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+Installs only the cross-platform firecrab client for the current Windows user.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = $(if ($env:FIRECRAB_VERSION) { $env:FIRECRAB_VERSION } else { "latest" }),
+    [string]$InstallDir = $(
+        if ($env:FIRECRAB_INSTALL_DIR) {
+            $env:FIRECRAB_INSTALL_DIR
+        } elseif ($env:LOCALAPPDATA) {
+            Join-Path $env:LOCALAPPDATA "Programs\firecrab\bin"
+        } else {
+            Join-Path $HOME "firecrab\bin"
+        }
+    ),
+    [switch]$Check,
+    [switch]$PrintAsset,
+    [switch]$PrintUrl
+)
+
+$ErrorActionPreference = "Stop"
+$releaseBase = if ($env:FIRECRAB_RELEASE_BASE) {
+    $env:FIRECRAB_RELEASE_BASE.TrimEnd("/")
+} else {
+    "https://github.com/SteelCrab/firecrab/releases"
+}
+
+$rawArchitecture = if ($env:FIRECRAB_CLI_ARCH) {
+    $env:FIRECRAB_CLI_ARCH
+} else {
+    [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+}
+$architecture = switch -Regex ($rawArchitecture) {
+    "^(X64|x86_64|amd64)$" { "x86_64"; break }
+    default { throw "unsupported Windows client architecture: $rawArchitecture" }
+}
+
+$asset = "firecrab-cli-$architecture-windows.zip"
+$normalizedVersion = if ([string]::IsNullOrWhiteSpace($Version) -or $Version -eq "latest") {
+    "latest"
+} elseif ($Version.StartsWith("v")) {
+    $Version
+} else {
+    "v$Version"
+}
+$downloadRoot = if ($normalizedVersion -eq "latest") {
+    "$releaseBase/latest/download"
+} else {
+    "$releaseBase/download/$normalizedVersion"
+}
+$assetUrl = "$downloadRoot/$asset"
+
+if ($PrintAsset) {
+    Write-Output $asset
+    return
+}
+if ($PrintUrl) {
+    Write-Output $assetUrl
+    return
+}
+if ($Check) {
+    Write-Output "would install $assetUrl to $(Join-Path $InstallDir 'firecrab.exe')"
+    return
+}
+
+function Install-ClientBinary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+        [Parameter(Mandatory = $true)]
+        [string]$DestinationDirectory
+    )
+
+    New-Item -ItemType Directory -Force -Path $DestinationDirectory | Out-Null
+    $DestinationDirectory = (Resolve-Path -LiteralPath $DestinationDirectory).ProviderPath
+    $destination = Join-Path $DestinationDirectory "firecrab.exe"
+    $temporaryOutput = Join-Path $DestinationDirectory (
+        ".firecrab-install-" + [guid]::NewGuid().ToString("N")
+    )
+    try {
+        $sourceStream = [System.IO.File]::Open(
+            $Source,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read
+        )
+        try {
+            $outputStream = [System.IO.File]::Open(
+                $temporaryOutput,
+                [System.IO.FileMode]::CreateNew,
+                [System.IO.FileAccess]::Write,
+                [System.IO.FileShare]::None
+            )
+            try {
+                $sourceStream.CopyTo($outputStream)
+            } finally {
+                $outputStream.Dispose()
+            }
+        } finally {
+            $sourceStream.Dispose()
+        }
+
+        $existing = Get-Item -LiteralPath $destination -Force -ErrorAction SilentlyContinue
+        if ($null -ne $existing -and $existing.PSIsContainer) {
+            throw "install destination $destination is a directory"
+        }
+        if ($null -ne $existing -and
+            (($existing.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)) {
+            Remove-Item -LiteralPath $destination -Force
+            $existing = $null
+        }
+        if ($null -ne $existing) {
+            [System.IO.File]::Replace($temporaryOutput, $destination, [System.Management.Automation.Language.NullString]::Value)
+        } else {
+            [System.IO.File]::Move($temporaryOutput, $destination)
+        }
+    } finally {
+        if (Test-Path -LiteralPath $temporaryOutput) {
+            Remove-Item -LiteralPath $temporaryOutput -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+$temporary = Join-Path ([System.IO.Path]::GetTempPath()) ("firecrab-cli-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $temporary | Out-Null
+try {
+    $archive = Join-Path $temporary $asset
+    $sums = Join-Path $temporary "SHA256SUMS"
+    Invoke-WebRequest -UseBasicParsing -Uri $assetUrl -OutFile $archive
+    Invoke-WebRequest -UseBasicParsing -Uri "$downloadRoot/SHA256SUMS" -OutFile $sums
+
+    $checksumLine = Get-Content $sums | Where-Object {
+        $fields = $_ -split "\s+"
+        if ($fields.Count -lt 2) { return $false }
+        $listed = $fields[-1].TrimStart("*").Replace("\", "/").Split("/")[-1]
+        $listed -eq $asset
+    } | Select-Object -First 1
+    if (-not $checksumLine) {
+        throw "checksum missing for $asset"
+    }
+    $expected = ($checksumLine -split "\s+")[0].ToLowerInvariant()
+    $actual = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+    if ($actual -ne $expected) {
+        throw "checksum mismatch for $asset"
+    }
+
+    $unpacked = Join-Path $temporary "unpacked"
+    Expand-Archive -Path $archive -DestinationPath $unpacked
+    $source = Join-Path $unpacked "firecrab.exe"
+    if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
+        throw "release archive does not contain firecrab.exe"
+    }
+    Install-ClientBinary -Source $source -DestinationDirectory $InstallDir
+    $InstallDir = (Resolve-Path -LiteralPath $InstallDir).ProviderPath
+} finally {
+    Remove-Item -LiteralPath $temporary -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$pathEntries = @($userPath -split ";" | Where-Object { $_ })
+if ($pathEntries -notcontains $InstallDir) {
+    $updatedPath = (@($pathEntries) + $InstallDir) -join ";"
+    [Environment]::SetEnvironmentVariable("Path", $updatedPath, "User")
+    $env:Path = "$InstallDir;$env:Path"
+    Write-Output "added $InstallDir to the user PATH; open a new terminal to use it"
+}
+Write-Output "installed firecrab to $(Join-Path $InstallDir 'firecrab.exe')"

--- a/install-cli.ps1
+++ b/install-cli.ps1
@@ -25,6 +25,17 @@ $releaseBase = if ($env:FIRECRAB_RELEASE_BASE) {
 } else {
     "https://github.com/SteelCrab/firecrab/releases"
 }
+$releaseUri = $null
+if (-not [System.Uri]::TryCreate($releaseBase, [System.UriKind]::Absolute, [ref]$releaseUri)) {
+    throw "FIRECRAB_RELEASE_BASE must be an absolute HTTPS URL"
+}
+if ($releaseUri.Scheme -eq "file") {
+    if ($env:FIRECRAB_TEST_ALLOW_FILE_URL -ne "1") {
+        throw "file:// release roots require FIRECRAB_TEST_ALLOW_FILE_URL=1"
+    }
+} elseif ($releaseUri.Scheme -ne "https") {
+    throw "FIRECRAB_RELEASE_BASE must use HTTPS"
+}
 
 $rawArchitecture = if ($env:FIRECRAB_CLI_ARCH) {
     $env:FIRECRAB_CLI_ARCH
@@ -127,8 +138,13 @@ New-Item -ItemType Directory -Path $temporary | Out-Null
 try {
     $archive = Join-Path $temporary $asset
     $sums = Join-Path $temporary "SHA256SUMS"
-    Invoke-WebRequest -UseBasicParsing -Uri $assetUrl -OutFile $archive
-    Invoke-WebRequest -UseBasicParsing -Uri "$downloadRoot/SHA256SUMS" -OutFile $sums
+    if ($releaseUri.Scheme -eq "file") {
+        Copy-Item -LiteralPath ([System.Uri]$assetUrl).LocalPath -Destination $archive
+        Copy-Item -LiteralPath ([System.Uri]"$downloadRoot/SHA256SUMS").LocalPath -Destination $sums
+    } else {
+        Invoke-WebRequest -UseBasicParsing -Uri $assetUrl -OutFile $archive
+        Invoke-WebRequest -UseBasicParsing -Uri "$downloadRoot/SHA256SUMS" -OutFile $sums
+    }
 
     $checksumLine = Get-Content $sums | Where-Object {
         $fields = $_ -split "\s+"

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -1,0 +1,136 @@
+#!/bin/sh
+# Install only the cross-platform firecrab client into a user-writable directory.
+set -eu
+
+RELEASE_BASE=${FIRECRAB_RELEASE_BASE:-https://github.com/SteelCrab/firecrab/releases}
+VERSION=${FIRECRAB_VERSION:-latest}
+INSTALL_DIR=${FIRECRAB_INSTALL_DIR:-}
+CHECK=0
+PRINT_ASSET=0
+PRINT_URL=0
+
+usage() {
+    cat <<'EOF'
+Usage: install-cli.sh [options]
+
+Install the firecrab client without root, Cargo, or the Linux host services.
+
+Options:
+  --version VER       Release tag such as v0.1.3 (default: latest)
+  --install-dir DIR   Destination directory (default: ~/.local/bin)
+  --check             Print the selected asset and destination without changes
+  --print-asset       Print the selected release asset name
+  --print-url         Print the selected release asset URL
+  -h, --help          Show this help
+
+Environment:
+  FIRECRAB_RELEASE_BASE  Alternate release root for mirrors or tests
+  FIRECRAB_VERSION       Default release tag
+  FIRECRAB_INSTALL_DIR   Default destination directory
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --version)
+            [ "$#" -ge 2 ] || { printf '%s\n' '--version needs a value' >&2; exit 2; }
+            VERSION=$2
+            shift 2
+            ;;
+        --install-dir)
+            [ "$#" -ge 2 ] || { printf '%s\n' '--install-dir needs a value' >&2; exit 2; }
+            INSTALL_DIR=$2
+            shift 2
+            ;;
+        --check) CHECK=1; shift ;;
+        --print-asset) PRINT_ASSET=1; shift ;;
+        --print-url) PRINT_URL=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'unknown option: %s\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$INSTALL_DIR" ]; then
+    [ -n "${HOME:-}" ] || { printf '%s\n' 'HOME is not set; pass --install-dir or FIRECRAB_INSTALL_DIR' >&2; exit 1; }
+    INSTALL_DIR="$HOME/.local/bin"
+fi
+RELEASE_BASE=${RELEASE_BASE%/}
+
+raw_os=${FIRECRAB_CLI_OS:-$(uname -s 2>/dev/null || printf unknown)}
+case "$raw_os" in
+    Linux|linux) platform=linux ;;
+    Darwin|darwin|macOS|macos) platform=macos ;;
+    *) printf 'unsupported client OS: %s\n' "$raw_os" >&2; exit 1 ;;
+esac
+
+raw_arch=${FIRECRAB_CLI_ARCH:-$(uname -m 2>/dev/null || printf unknown)}
+case "$raw_arch" in
+    x86_64|amd64|X64) architecture=x86_64 ;;
+    aarch64|arm64|Arm64) architecture=aarch64 ;;
+    *) printf 'unsupported client architecture: %s\n' "$raw_arch" >&2; exit 1 ;;
+esac
+
+asset="firecrab-cli-${architecture}-${platform}.tar.gz"
+case "$VERSION" in
+    ''|latest) download_root="$RELEASE_BASE/latest/download" ;;
+    v*) download_root="$RELEASE_BASE/download/$VERSION" ;;
+    *) download_root="$RELEASE_BASE/download/v$VERSION" ;;
+esac
+asset_url="$download_root/$asset"
+
+[ "$PRINT_ASSET" -eq 0 ] || { printf '%s\n' "$asset"; exit 0; }
+[ "$PRINT_URL" -eq 0 ] || { printf '%s\n' "$asset_url"; exit 0; }
+if [ "$CHECK" -eq 1 ]; then
+    printf 'would install %s to %s/firecrab\n' "$asset_url" "$INSTALL_DIR"
+    exit 0
+fi
+
+command -v curl >/dev/null 2>&1 || { printf '%s\n' 'curl is required' >&2; exit 1; }
+command -v tar >/dev/null 2>&1 || { printf '%s\n' 'tar is required' >&2; exit 1; }
+
+temporary=$(mktemp -d 2>/dev/null || mktemp -d -t firecrab-cli)
+temporary_binary=
+cleanup() {
+    rm -rf "$temporary"
+    [ -z "$temporary_binary" ] || rm -f "$temporary_binary"
+}
+trap cleanup EXIT HUP INT TERM
+curl -fsSL "$asset_url" -o "$temporary/$asset"
+curl -fsSL "$download_root/SHA256SUMS" -o "$temporary/SHA256SUMS"
+
+expected=$(awk -v name="$asset" '
+    $2 == name || $2 == "*" name || $2 ~ "/" name "$" { print $1; exit }
+' "$temporary/SHA256SUMS")
+[ -n "$expected" ] || { printf 'checksum missing for %s\n' "$asset" >&2; exit 1; }
+if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$temporary/$asset" | awk '{ print $1 }')
+elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$temporary/$asset" | awk '{ print $1 }')
+else
+    printf '%s\n' 'sha256sum or shasum is required' >&2
+    exit 1
+fi
+[ "$actual" = "$expected" ] || { printf 'checksum mismatch for %s\n' "$asset" >&2; exit 1; }
+
+mkdir -p "$temporary/unpacked" "$INSTALL_DIR"
+INSTALL_DIR=$(cd "$INSTALL_DIR" && pwd -P)
+tar -xzf "$temporary/$asset" -C "$temporary/unpacked"
+[ -f "$temporary/unpacked/firecrab" ] \
+    || { printf '%s\n' 'release archive does not contain firecrab' >&2; exit 1; }
+[ ! -d "$INSTALL_DIR/firecrab" ] \
+    || { printf '%s\n' 'install destination firecrab is a directory' >&2; exit 1; }
+temporary_binary=$(mktemp "$INSTALL_DIR/.firecrab-install.XXXXXX") \
+    || { printf '%s\n' 'could not create a private temporary install file' >&2; exit 1; }
+cp "$temporary/unpacked/firecrab" "$temporary_binary"
+chmod 0755 "$temporary_binary"
+mv -f "$temporary_binary" "$INSTALL_DIR/firecrab"
+temporary_binary=
+
+printf 'installed firecrab to %s/firecrab\n' "$INSTALL_DIR"
+case ":${PATH:-}:" in
+    *:"$INSTALL_DIR":*) ;;
+    *)
+        printf '%s\n' "$INSTALL_DIR is not on PATH. Add this line to your shell profile:"
+        printf '  export PATH="%s:%s"\n' "$INSTALL_DIR" "\$PATH"
+        ;;
+esac

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -25,6 +25,8 @@ Options:
 
 Environment:
   FIRECRAB_RELEASE_BASE  Alternate release root for mirrors or tests
+  FIRECRAB_TEST_ALLOW_FILE_URL=1
+                         Permit file:// release roots in tests only
   FIRECRAB_VERSION       Default release tag
   FIRECRAB_INSTALL_DIR   Default destination directory
 EOF
@@ -55,6 +57,17 @@ if [ -z "$INSTALL_DIR" ]; then
     INSTALL_DIR="$HOME/.local/bin"
 fi
 RELEASE_BASE=${RELEASE_BASE%/}
+case "$RELEASE_BASE" in
+    https://?*) ;;
+    file://?*)
+        [ "${FIRECRAB_TEST_ALLOW_FILE_URL:-}" = 1 ] \
+            || { printf '%s\n' 'file:// release roots require FIRECRAB_TEST_ALLOW_FILE_URL=1' >&2; exit 1; }
+        ;;
+    *)
+        printf '%s\n' 'FIRECRAB_RELEASE_BASE must use HTTPS' >&2
+        exit 1
+        ;;
+esac
 
 raw_os=${FIRECRAB_CLI_OS:-$(uname -s 2>/dev/null || printf unknown)}
 case "$raw_os" in

--- a/public-docs/firecrab-cli.md
+++ b/public-docs/firecrab-cli.md
@@ -1,8 +1,9 @@
 # firecrab CLI
 
-`firecrab` is a host command-line client for the same loopback REST API the dashboard uses.
-It diagnoses host readiness, prints resolved configuration, reports live status, and manages images,
-MicroNetworks, and VM lifecycles without a browser.
+`firecrab` is a Linux, macOS, and Windows command-line client for the same REST API the dashboard uses.
+It selects named Linux firecrab hosts and manages images, MicroNetworks, and VM lifecycles without a browser.
+Linux builds also diagnose and administer the local host.
+See [Installation](installation.md#cli-only-installation) for user-level installers.
 
 ## Contents
 
@@ -12,25 +13,27 @@ MicroNetworks, and VM lifecycles without a browser.
 | [doctor](#doctor) | The 13 host-readiness checks |
 | [info](#info) | Version and resolved paths |
 | [status](#status) | Live systemd and API state |
+| [Host profiles](#host-profiles) | Saved endpoints and selection order |
 | [Host API commands](#host-api-commands) | Image, MicroNetwork, and VM operations |
-| [update](#update) | Release check and in-place upgrade |
+| [update](#update) | Linux host release check and in-place upgrade |
 | [Develop](#develop) | Running the CLI from a checkout, no install |
 | [Related](#related) | Other documents |
 
 ## Architecture
 
-Each subcommand is independent: `doctor` reads the host directly, `info` reads only local configuration,
-and `status`, `image`, `network`, and `vm` call `firecrab-api`.
+Remote commands run on Linux, macOS, and Windows and call `firecrab-api` on a Linux host.
+The `doctor`, `info`, `status`, `update`, and `service` commands are present only in Linux builds.
 The resource commands never talk to Firecracker, nftables, or `firecrab-net-helper` directly — the CLI
 is a client, not a second control plane.
 
 ```mermaid
-flowchart TB
-    CLI["firecrab"]
-    Doctor["doctor"]
-    Info["info"]
-    Status["status"]
-    Resources["image / network / vm"]
+flowchart TD
+    CLI["firecrab<br/>Linux / macOS / Windows"]
+    Config[("~/firecrab/config.toml")]
+    Select["--api / FIRECRAB_API / --host / current host"]
+    Linux["Linux-only local commands"]
+    Doctor["doctor / info / status / service"]
+    Resources["host / image / network / vm"]
     Console["vm console"]
     Update["update"]
     Proc[("/dev/kvm, /proc/sys/net")]
@@ -40,31 +43,24 @@ flowchart TB
     API[("firecrab-api\n:5523")]
     GH[("api.github.com\nreleases/latest")]
     Helper[("firecrab-net-helper\nsocket")]
-    CLI --> Doctor
-    CLI --> Info
-    CLI --> Status
+    CLI --> Config
+    Config --> Select
+    CLI --> Select
+    CLI --> Linux
+    Linux --> Doctor
     CLI --> Resources
-    CLI --> Console
-    CLI --> Update
+    Select --> Console
+    Linux --> Update
     Doctor -->|read| Proc
     Doctor -->|shell out| Tools
-    Info -->|resolve| Paths
-    Status -->|is-active| Units
-    Status -->|GET /api/host| API
-    Resources -->|REST API| API
+    Doctor -->|resolve| Paths
+    Doctor -->|is-active| Units
+    Select --> Resources
+    Resources -->|HTTP(S) REST API| API
     Console -->|WebSocket serial stream| API
     Update -->|GET releases/latest| GH
     Update -->|ApplySelfUpdate| Helper
 ```
-
-| Subcommand | Talks to | Needs root |
-| --- | --- | --- |
-| `doctor` | `/proc`, `/dev/kvm`, and external tools (`nft`, `ufw`, `systemctl`, `getenforce`, `curl`) | No — privileged checks degrade to SKIP with a fix hint |
-| `info` | Only environment variables and install defaults | No |
-| `status` | `systemctl is-active` and `GET /api/host` | No |
-| `image`, `network`, and VM lifecycle commands | The corresponding `firecrab-api` REST resources | No |
-| `vm console` | The running VM's serial-console WebSocket | No |
-| `update` | `api.github.com`, the release asset host, and the net-helper socket | `--check` no; `--apply` yes (root or the `firecrab` account) |
 
 ## doctor
 
@@ -107,7 +103,7 @@ firecrab info --json
 
 - Fields: `version`, `prefix`, `datadir`, `confdir`, `unitdir`, `apiBase`.
 - Path defaults mirror `install.sh`: `PREFIX=/usr/local`, `DATADIR=/var/lib/firecrab`, `CONFDIR=/etc/firecrab`, `UNITDIR=/etc/systemd/system`, each overridable by the same-named environment variable.
-- `apiBase` resolves `--api`, then `FIRECRAB_API`, then `http://127.0.0.1:5523`.
+- `apiBase` uses the same endpoint selection order as [Host profiles](#host-profiles).
 
 ## status
 
@@ -121,7 +117,47 @@ firecrab status --api http://127.0.0.1:5523
 
 - `firecrab-api.service` / `firecrab-net-helper.service`: `systemctl is-active`, or `unknown` if `systemctl` itself cannot run.
 - `host`: `GET /api/host` — load average, memory, disk, and uptime — or `null` with `hostError` set if the API is unreachable or answers an error.
-- Base URL resolution is the same as `info`: `--api`, then `FIRECRAB_API`, then `http://127.0.0.1:5523`.
+- Base URL resolution uses the same endpoint selection order as [Host profiles](#host-profiles).
+
+## Host profiles
+
+Save each Linux host once, then use its short name from any supported client OS.
+
+```sh
+firecrab host add prod https://firecrab.example.com:5523 --use
+firecrab host add lab http://192.0.2.20:5523
+firecrab host list
+firecrab host show
+firecrab --host lab vm list
+firecrab host use prod
+firecrab host remove lab
+```
+
+The first added host becomes current automatically.
+The configuration is written atomically to `~/firecrab/config.toml`.
+On Windows, `~` is `%USERPROFILE%`; `FIRECRAB_CONFIG_DIR` overrides the directory for portable or test environments.
+
+```toml
+current_host = "prod"
+
+[hosts.prod]
+url = "https://firecrab.example.com:5523"
+```
+
+Host names use letters, digits, `.`, `_`, or `-`.
+URLs require `http://` or `https://`; embedded credentials, query strings, and fragments are rejected.
+The config stores endpoint URLs only, never passwords or private-key contents.
+Unknown TOML keys are rejected before a profile mutation, preventing a client upgrade or downgrade from silently removing configuration.
+
+Endpoint selection order:
+
+1. Global `--api URL`
+2. `FIRECRAB_API`
+3. Global `--host NAME`
+4. `current_host` from `~/firecrab/config.toml`
+5. `http://127.0.0.1:5523`
+
+`host show [NAME]` resolves the endpoint and probes `GET /api/host` so connection and TLS errors are visible before a mutation.
 
 ## Host API commands
 
@@ -188,8 +224,8 @@ firecrab vm create \
   --network NETWORK_ID
 ```
 
-The API base resolves in this order: global `--api URL`, `FIRECRAB_API`, then
-`http://127.0.0.1:5523`. The global flag may appear before or after a subcommand:
+The API base uses the [Host profiles](#host-profiles) selection order.
+Global flags may appear before or after a subcommand:
 
 ```sh
 firecrab --api http://127.0.0.1:5523 vm list
@@ -202,7 +238,7 @@ fields and request IDs remain visible.
 
 ## update
 
-Compares this build's version with the newest GitHub Release tag, and optionally installs it.
+This Linux-only host command compares the build with the newest GitHub Release tag and optionally installs it.
 
 ```sh
 firecrab update --check
@@ -248,6 +284,8 @@ cargo build -p firecrab-cli
 ./target/debug/firecrab status --api http://127.0.0.1:5523
 ./target/debug/firecrab image list --api http://127.0.0.1:5523
 ```
+
+On Windows, run `target\debug\firecrab.exe`; the `host`, `image`, `network`, and `vm` commands are identical.
 
 - `cargo run -p firecrab-cli -- doctor` works too; `cargo build` first is only for repeat runs without a rebuild each time.
 - Unit tests (`FakeCommandRunner`, no real host state touched): `cargo test -p firecrab-cli`.

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -108,16 +108,24 @@ After installation, save and verify a remote endpoint with the [CLI host profile
 ### Linux and macOS
 
 The POSIX installer detects Linux or macOS and x86_64 or ARM64, verifies `SHA256SUMS`, and installs to `~/.local/bin`.
+Download the installer and the separately published release checksum, verify the installer, and only then execute it.
 
 ```sh
-curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh | sh
+curl -fLO https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh
+curl -fLO https://github.com/SteelCrab/firecrab/releases/latest/download/SHA256SUMS
+grep ' install-cli.sh$' SHA256SUMS > install-cli.sh.sha256
+if command -v sha256sum >/dev/null; then
+  sha256sum -c install-cli.sh.sha256
+else
+  shasum -a 256 -c install-cli.sh.sha256
+fi
+sh install-cli.sh
 ```
 
 Pin a version or choose another user-writable directory when needed.
 
 ```sh
-curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh \
-  | sh -s -- --version v0.1.3 --install-dir "$HOME/bin"
+sh install-cli.sh --version v0.1.3 --install-dir "$HOME/bin"
 ```
 
 The installer prints an `export PATH=...` line when the destination is not already on `PATH`.
@@ -126,10 +134,14 @@ Use an installation directory controlled by the current user, not a shared writa
 
 ### Windows
 
-Run the user-level PowerShell installer.
+Download the user-level PowerShell installer and separately published release checksum, verify it, and only then execute it.
 
 ```powershell
-irm https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1 | iex
+Invoke-WebRequest https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1 -OutFile install-cli.ps1
+Invoke-WebRequest https://github.com/SteelCrab/firecrab/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+$expected = ((Get-Content SHA256SUMS | Where-Object { $_ -match ' install-cli\.ps1$' }) -split '\s+')[0]
+if ((Get-FileHash install-cli.ps1 -Algorithm SHA256).Hash -ne $expected) { throw 'installer checksum mismatch' }
+& ./install-cli.ps1
 ```
 
 It installs `firecrab.exe` under `%LOCALAPPDATA%\Programs\firecrab\bin` and adds that directory to the user `PATH`.
@@ -138,8 +150,7 @@ Open a new terminal after the first installation.
 Pin a client archive by passing `-Version` to the downloaded installer.
 
 ```powershell
-$installer = irm https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1
-& ([scriptblock]::Create($installer)) -Version v0.1.3
+& ./install-cli.ps1 -Version v0.1.3
 ```
 
 Use an installation directory controlled by the current user, not a shared writable directory.

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -6,6 +6,20 @@ glibc hosts (Debian, Fedora, Arch, openSUSE, Ubuntu) get the gnu bundle.
 musl hosts (Alpine) get the musl bundle.
 Pass `--libc gnu` or `--libc musl` to override.
 
+## Contents
+
+| Section | Content |
+| --- | --- |
+| [Requirements](#requirements) | Linux host prerequisites |
+| [Check the host](#check-the-host) | Read-only readiness check |
+| [Install](#install) | Full Linux host installation |
+| [CLI-only installation](#cli-only-installation) | Linux, macOS, and Windows remote client |
+| [Common options](#common-options) | Full host installer flags |
+| [Default paths](#default-paths) | Full host filesystem layout |
+| [Check the result](#check-the-result) | Service and API verification |
+| [Upgrade](#upgrade) | Full host upgrade |
+| [Related](#related) | Other documents |
+
 ## Requirements
 
 - Linux with systemd
@@ -87,31 +101,63 @@ Import one afterwards with [OCI import](oci.md) or the dashboard Images page.
 
 ## CLI-only installation
 
-`firecrab` (the CLI) is a single static binary.
-Install it on a machine that already runs `firecrab-api` elsewhere, or on the host itself alongside an existing full install.
+`firecrab` is a standalone remote client for Linux, macOS, and Windows.
+The CLI-only installers require no root access, Rust toolchain, Firecracker, or local host services.
+After installation, save and verify a remote endpoint with the [CLI host profiles](firecrab-cli.md#host-profiles).
 
-### From a GitHub Release
+### Linux and macOS
 
-Download the host bundle for the target architecture and libc, then extract only the `firecrab` binary.
+The POSIX installer detects Linux or macOS and x86_64 or ARM64, verifies `SHA256SUMS`, and installs to `~/.local/bin`.
 
 ```sh
-# x86_64 glibc host (Debian, Ubuntu, Fedora, Arch, openSUSE)
-curl -fsSL -o firecrab-host.tar.gz \
-  https://github.com/SteelCrab/firecrab/releases/latest/download/firecrab-host-x86_64-gnu.tar.gz
-tar -xzf firecrab-host.tar.gz firecrab
-sudo install -m 755 firecrab /usr/local/bin/firecrab
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh | sh
 ```
 
-Replace `x86_64-gnu` with the correct variant for your machine:
+Pin a version or choose another user-writable directory when needed.
 
-| Architecture | libc | Filename suffix |
-| --- | --- | --- |
-| x86\_64 | glibc (Debian, Ubuntu, Fedora, …) | `x86_64-gnu` |
-| x86\_64 | musl (Alpine) | `x86_64-musl` |
-| aarch64 | glibc | `aarch64-gnu` |
-| aarch64 | musl | `aarch64-musl` |
+```sh
+curl -fsSL https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh \
+  | sh -s -- --version v0.1.3 --install-dir "$HOME/bin"
+```
 
-Pin a version by replacing `latest` with a tag, for example `v0.1.0`.
+The installer prints an `export PATH=...` line when the destination is not already on `PATH`.
+Pass `--version TAG` to pin the client archive; changing only the installer script URL does not change its default `latest` archive selection.
+Use an installation directory controlled by the current user, not a shared writable directory.
+
+### Windows
+
+Run the user-level PowerShell installer.
+
+```powershell
+irm https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1 | iex
+```
+
+It installs `firecrab.exe` under `%LOCALAPPDATA%\Programs\firecrab\bin` and adds that directory to the user `PATH`.
+Open a new terminal after the first installation.
+
+Pin a client archive by passing `-Version` to the downloaded installer.
+
+```powershell
+$installer = irm https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1
+& ([scriptblock]::Create($installer)) -Version v0.1.3
+```
+
+Use an installation directory controlled by the current user, not a shared writable directory.
+
+### Release assets
+
+The installers select one of these standalone archives.
+
+| Client | Asset |
+| --- | --- |
+| Linux x86_64 | `firecrab-cli-x86_64-linux.tar.gz` |
+| Linux ARM64 | `firecrab-cli-aarch64-linux.tar.gz` |
+| macOS Intel | `firecrab-cli-x86_64-macos.tar.gz` |
+| macOS Apple silicon | `firecrab-cli-aarch64-macos.tar.gz` |
+| Windows x86_64 | `firecrab-cli-x86_64-windows.zip` |
+
+Archive URLs may be pinned by replacing `latest` with a tag, for example `v0.1.0`.
+When using either installer script, pass `--version` or `-Version` as shown above.
 
 ### From source
 
@@ -119,10 +165,10 @@ Pin a version by replacing `latest` with a tag, for example `v0.1.0`.
 git clone https://github.com/SteelCrab/firecrab.git
 cd firecrab
 cargo build --release --locked -p firecrab-cli
-sudo install -m 755 target/release/firecrab /usr/local/bin/firecrab
 ```
 
 Requires the repository Rust toolchain (`rust-toolchain.toml`).
+Copy `target/release/firecrab` or `target\release\firecrab.exe` into a directory on the user `PATH`.
 
 ### On a host with a full install
 

--- a/scripts/release_compliance.py
+++ b/scripts/release_compliance.py
@@ -38,7 +38,10 @@ ALLOWED_LICENSE_IDS = {
     "Zlib",
 }
 ALLOWED_LICENSE_EXCEPTIONS = {"LLVM-exception"}
-LEGACY_LICENSE_EXPRESSIONS = {"MIT/Apache-2.0": "MIT OR Apache-2.0"}
+LEGACY_LICENSE_EXPRESSIONS = {
+    "Apache-2.0/MIT": "Apache-2.0 OR MIT",
+    "MIT/Apache-2.0": "MIT OR Apache-2.0",
+}
 _LICENSE_TOKEN_RE = re.compile(
     r"\s*(\(|\)|AND\b|OR\b|WITH\b|[A-Za-z0-9][A-Za-z0-9.+-]*)",
     re.IGNORECASE,

--- a/scripts/test-install-cli-release.sh
+++ b/scripts/test-install-cli-release.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Cross-platform CLI installer contract and a local end-to-end install.
+set -euo pipefail
+
+ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+failed=0
+pass() { printf 'ok  %s\n' "$*"; }
+fail() { printf 'not ok  %s\n' "$*" >&2; failed=1; }
+
+expect_eq() {
+    local got=$1 want=$2 label=$3
+    if [ "$got" = "$want" ]; then pass "$label"; else fail "$label (got '$got', want '$want')"; fi
+}
+
+expect_eq \
+    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-x86_64-linux.tar.gz \
+    "Linux x86_64 asset"
+expect_eq \
+    "$(FIRECRAB_CLI_OS=Darwin FIRECRAB_CLI_ARCH=arm64 "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-aarch64-macos.tar.gz \
+    "Apple silicon asset"
+expect_eq \
+    "$(FIRECRAB_CLI_OS=linux FIRECRAB_CLI_ARCH=aarch64 "$ROOT/install-cli.sh" --version 1.2.3 --print-url)" \
+    "https://github.com/SteelCrab/firecrab/releases/download/v1.2.3/firecrab-cli-aarch64-linux.tar.gz" \
+    "bare version becomes a v-prefixed release URL"
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+release="$scratch/releases/latest/download"
+mkdir -p "$release/payload" "$scratch/bin"
+printf '#!/bin/sh\nprintf "firecrab test\\n"\n' >"$release/payload/firecrab"
+chmod +x "$release/payload/firecrab"
+tar -czf "$release/firecrab-cli-x86_64-linux.tar.gz" -C "$release/payload" firecrab
+(
+    cd "$release"
+    sha256sum firecrab-cli-x86_64-linux.tar.gz >SHA256SUMS
+)
+
+FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+FIRECRAB_CLI_OS=Linux \
+FIRECRAB_CLI_ARCH=x86_64 \
+PATH="/usr/bin:/bin" \
+    "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null
+if [ -x "$scratch/bin/firecrab" ] && [ "$("$scratch/bin/firecrab")" = "firecrab test" ]; then
+    pass "local release installs an executable client"
+else
+    fail "local release installs an executable client"
+fi
+
+victim="$scratch/victim"
+printf 'leave this file alone\n' >"$victim"
+unlink "$scratch/bin/firecrab"
+ln -s "$victim" "$scratch/bin/firecrab"
+FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+FIRECRAB_CLI_OS=Linux \
+FIRECRAB_CLI_ARCH=x86_64 \
+    "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null
+if [ ! -L "$scratch/bin/firecrab" ] \
+    && [ "$(cat "$victim")" = "leave this file alone" ] \
+    && [ "$("$scratch/bin/firecrab")" = "firecrab test" ]; then
+    pass "existing destination symlink is replaced without following it"
+else
+    fail "existing destination symlink is replaced without following it"
+fi
+
+if env -u HOME \
+    FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    "$ROOT/install-cli.sh" --install-dir "$scratch/bin" --check >/dev/null; then
+    pass "explicit install directory does not require HOME"
+else
+    fail "explicit install directory does not require HOME"
+fi
+
+relative_output=$(
+    cd "$scratch"
+    FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+    FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+        "$ROOT/install-cli.sh" --install-dir relative-bin
+)
+absolute_bin="$(cd "$scratch" && pwd -P)/relative-bin"
+if [[ "$relative_output" == *"export PATH=\"$absolute_bin:"* ]] \
+    && [ "$(cd / && PATH="$absolute_bin:/usr/bin:/bin" firecrab)" = "firecrab test" ]; then
+    pass "relative install directory produces a usable absolute PATH"
+else
+    fail "relative install directory produces a usable absolute PATH"
+fi
+
+printf 'tampered\n' >>"$release/firecrab-cli-x86_64-linux.tar.gz"
+if FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+    FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null 2>&1; then
+    fail "tampered archive is rejected"
+else
+    pass "tampered archive is rejected"
+fi
+
+if [ "$failed" -ne 0 ]; then
+    printf 'FAILED\n' >&2
+    exit 1
+fi
+printf 'all tests passed\n'

--- a/scripts/test-install-cli-release.sh
+++ b/scripts/test-install-cli-release.sh
@@ -38,6 +38,7 @@ tar -czf "$release/firecrab-cli-x86_64-linux.tar.gz" -C "$release/payload" firec
 )
 
 FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+FIRECRAB_TEST_ALLOW_FILE_URL=1 \
 FIRECRAB_CLI_OS=Linux \
 FIRECRAB_CLI_ARCH=x86_64 \
 PATH="/usr/bin:/bin" \
@@ -53,6 +54,7 @@ printf 'leave this file alone\n' >"$victim"
 unlink "$scratch/bin/firecrab"
 ln -s "$victim" "$scratch/bin/firecrab"
 FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+FIRECRAB_TEST_ALLOW_FILE_URL=1 \
 FIRECRAB_CLI_OS=Linux \
 FIRECRAB_CLI_ARCH=x86_64 \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null
@@ -75,6 +77,7 @@ fi
 relative_output=$(
     cd "$scratch"
     FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+    FIRECRAB_TEST_ALLOW_FILE_URL=1 \
     FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
         "$ROOT/install-cli.sh" --install-dir relative-bin
 )
@@ -88,11 +91,29 @@ fi
 
 printf 'tampered\n' >>"$release/firecrab-cli-x86_64-linux.tar.gz"
 if FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+    FIRECRAB_TEST_ALLOW_FILE_URL=1 \
     FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null 2>&1; then
     fail "tampered archive is rejected"
 else
     pass "tampered archive is rejected"
+fi
+
+for unsafe_base in http://example.test/releases ftp://example.test/releases; do
+    if FIRECRAB_RELEASE_BASE="$unsafe_base" \
+        FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+        "$ROOT/install-cli.sh" --print-url >/dev/null 2>&1; then
+        fail "unsafe release URL is rejected: $unsafe_base"
+    else
+        pass "unsafe release URL is rejected: $unsafe_base"
+    fi
+done
+if FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
+    FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    "$ROOT/install-cli.sh" --print-url >/dev/null 2>&1; then
+    fail "file release URL requires explicit test opt-in"
+else
+    pass "file release URL requires explicit test opt-in"
 fi
 
 if [ "$failed" -ne 0 ]; then

--- a/scripts/test-install-cli.ps1
+++ b/scripts/test-install-cli.ps1
@@ -12,57 +12,12 @@ function Restore-ProcessEnvironment {
     }
 }
 
-function Start-ReleaseFixtureServer {
-    param(
-        [string]$Archive,
-        [string]$Sums,
-        [int]$Port
-    )
-
-    Start-Job -ScriptBlock {
-        param($ArchivePath, $SumsPath, $ListenPort)
-
-        $listener = New-Object System.Net.HttpListener
-        $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
-        $listener.Start()
-        Write-Output "ready"
-        try {
-            while ($true) {
-                $pending = $listener.GetContextAsync()
-                while (-not $pending.IsCompleted) {
-                    Start-Sleep -Milliseconds 50
-                }
-                $context = $pending.GetAwaiter().GetResult()
-                $path = $context.Request.Url.AbsolutePath
-                if ($path -eq "/releases/latest/download/firecrab-cli-x86_64-windows.zip") {
-                    $body = [System.IO.File]::ReadAllBytes($ArchivePath)
-                    $context.Response.StatusCode = 200
-                } elseif ($path -eq "/releases/latest/download/SHA256SUMS") {
-                    $body = [System.IO.File]::ReadAllBytes($SumsPath)
-                    $context.Response.StatusCode = 200
-                } else {
-                    $body = [System.Text.Encoding]::UTF8.GetBytes("not found")
-                    $context.Response.StatusCode = 404
-                }
-                try {
-                    $context.Response.ContentLength64 = $body.Length
-                    $context.Response.OutputStream.Write($body, 0, $body.Length)
-                } finally {
-                    $context.Response.Close()
-                }
-            }
-        } finally {
-            $listener.Close()
-        }
-    } -ArgumentList $Archive, $Sums, $Port
-}
-
 $oldArch = $env:FIRECRAB_CLI_ARCH
 $oldReleaseBase = $env:FIRECRAB_RELEASE_BASE
+$oldAllowFileUrl = $env:FIRECRAB_TEST_ALLOW_FILE_URL
 $oldProcessPath = $env:Path
 $oldUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
 $scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("firecrab-cli-test-" + [guid]::NewGuid())
-$server = $null
 
 try {
     $env:FIRECRAB_CLI_ARCH = "x86_64"
@@ -94,24 +49,8 @@ try {
     $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
     [System.IO.File]::WriteAllText($sums, "$hash  $asset`n")
 
-    $probe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
-    $probe.Start()
-    $port = ([System.Net.IPEndPoint]$probe.LocalEndpoint).Port
-    $probe.Stop()
-    $server = Start-ReleaseFixtureServer -Archive $archive -Sums $sums -Port $port
-    $ready = $false
-    foreach ($attempt in 1..50) {
-        Start-Sleep -Milliseconds 50
-        if ((Receive-Job -Job $server -Keep) -contains "ready") {
-            $ready = $true
-            break
-        }
-    }
-    if (-not $ready) {
-        throw "release fixture server did not start"
-    }
-
-    $env:FIRECRAB_RELEASE_BASE = "http://127.0.0.1:$port/releases"
+    $env:FIRECRAB_RELEASE_BASE = ([System.Uri](Join-Path $scratch "releases")).AbsoluteUri.TrimEnd("/")
+    $env:FIRECRAB_TEST_ALLOW_FILE_URL = "1"
     & $installer -InstallDir $installDir
     $installed = Join-Path $installDir "firecrab.exe"
     if (-not (Test-Path -LiteralPath $installed -PathType Leaf)) {
@@ -169,15 +108,30 @@ try {
     if (-not $rejected -or [System.IO.File]::ReadAllText($installed) -ne "firecrab replacement") {
         throw "tampered release was not rejected with the installed binary preserved"
     }
-} finally {
-    if ($null -ne $server) {
-        Stop-Job -Job $server -ErrorAction SilentlyContinue
-        Remove-Job -Job $server -Force -ErrorAction SilentlyContinue
+
+    foreach ($unsafeBase in @("http://example.test/releases", "ftp://example.test/releases")) {
+        $env:FIRECRAB_RELEASE_BASE = $unsafeBase
+        try {
+            & $installer -PrintUrl
+            throw "unsafe release URL was accepted: $unsafeBase"
+        } catch {
+            if ($_.Exception.Message -match "unsafe release URL was accepted") { throw }
+        }
     }
+    $env:FIRECRAB_RELEASE_BASE = ([System.Uri](Join-Path $scratch "releases")).AbsoluteUri.TrimEnd("/")
+    Remove-Item -LiteralPath Env:FIRECRAB_TEST_ALLOW_FILE_URL
+    try {
+        & $installer -PrintUrl
+        throw "file release URL was accepted without explicit test opt-in"
+    } catch {
+        if ($_.Exception.Message -match "was accepted without") { throw }
+    }
+} finally {
     [Environment]::SetEnvironmentVariable("Path", $oldUserPath, "User")
     $env:Path = $oldProcessPath
     Restore-ProcessEnvironment -Name "FIRECRAB_CLI_ARCH" -Value $oldArch
     Restore-ProcessEnvironment -Name "FIRECRAB_RELEASE_BASE" -Value $oldReleaseBase
+    Restore-ProcessEnvironment -Name "FIRECRAB_TEST_ALLOW_FILE_URL" -Value $oldAllowFileUrl
     Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
 }
 

--- a/scripts/test-install-cli.ps1
+++ b/scripts/test-install-cli.ps1
@@ -1,0 +1,184 @@
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$installer = Join-Path $root "install-cli.ps1"
+
+function Restore-ProcessEnvironment {
+    param([string]$Name, [AllowNull()][string]$Value)
+
+    if ($null -eq $Value) {
+        Remove-Item -LiteralPath "Env:$Name" -ErrorAction SilentlyContinue
+    } else {
+        Set-Item -LiteralPath "Env:$Name" -Value $Value
+    }
+}
+
+function Start-ReleaseFixtureServer {
+    param(
+        [string]$Archive,
+        [string]$Sums,
+        [int]$Port
+    )
+
+    Start-Job -ScriptBlock {
+        param($ArchivePath, $SumsPath, $ListenPort)
+
+        $listener = New-Object System.Net.HttpListener
+        $listener.Prefixes.Add("http://127.0.0.1:$ListenPort/")
+        $listener.Start()
+        Write-Output "ready"
+        try {
+            while ($true) {
+                $pending = $listener.GetContextAsync()
+                while (-not $pending.IsCompleted) {
+                    Start-Sleep -Milliseconds 50
+                }
+                $context = $pending.GetAwaiter().GetResult()
+                $path = $context.Request.Url.AbsolutePath
+                if ($path -eq "/releases/latest/download/firecrab-cli-x86_64-windows.zip") {
+                    $body = [System.IO.File]::ReadAllBytes($ArchivePath)
+                    $context.Response.StatusCode = 200
+                } elseif ($path -eq "/releases/latest/download/SHA256SUMS") {
+                    $body = [System.IO.File]::ReadAllBytes($SumsPath)
+                    $context.Response.StatusCode = 200
+                } else {
+                    $body = [System.Text.Encoding]::UTF8.GetBytes("not found")
+                    $context.Response.StatusCode = 404
+                }
+                try {
+                    $context.Response.ContentLength64 = $body.Length
+                    $context.Response.OutputStream.Write($body, 0, $body.Length)
+                } finally {
+                    $context.Response.Close()
+                }
+            }
+        } finally {
+            $listener.Close()
+        }
+    } -ArgumentList $Archive, $Sums, $Port
+}
+
+$oldArch = $env:FIRECRAB_CLI_ARCH
+$oldReleaseBase = $env:FIRECRAB_RELEASE_BASE
+$oldProcessPath = $env:Path
+$oldUserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$scratch = Join-Path ([System.IO.Path]::GetTempPath()) ("firecrab-cli-test-" + [guid]::NewGuid())
+$server = $null
+
+try {
+    $env:FIRECRAB_CLI_ARCH = "x86_64"
+    $asset = & $installer -PrintAsset
+    if ($asset -ne "firecrab-cli-x86_64-windows.zip") {
+        throw "unexpected Windows asset: $asset"
+    }
+
+    $url = & $installer -Version "1.2.3" -PrintUrl
+    $expected = "https://github.com/SteelCrab/firecrab/releases/download/v1.2.3/firecrab-cli-x86_64-windows.zip"
+    if ($url -ne $expected) {
+        throw "unexpected Windows URL: $url"
+    }
+
+    $check = & $installer -Check -InstallDir (Join-Path $scratch "bin")
+    if ($check -notmatch "would install") {
+        throw "check mode did not describe the install"
+    }
+
+    $release = Join-Path $scratch "releases\latest\download"
+    $payload = Join-Path $scratch "payload"
+    $installDir = Join-Path $scratch "bin"
+    New-Item -ItemType Directory -Force -Path $release, $payload | Out-Null
+    $fixtureBinary = Join-Path $payload "firecrab.exe"
+    [System.IO.File]::WriteAllText($fixtureBinary, "firecrab fixture")
+    $archive = Join-Path $release $asset
+    Compress-Archive -Path $fixtureBinary -DestinationPath $archive -Force
+    $sums = Join-Path $release "SHA256SUMS"
+    $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+    [System.IO.File]::WriteAllText($sums, "$hash  $asset`n")
+
+    $probe = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+    $probe.Start()
+    $port = ([System.Net.IPEndPoint]$probe.LocalEndpoint).Port
+    $probe.Stop()
+    $server = Start-ReleaseFixtureServer -Archive $archive -Sums $sums -Port $port
+    $ready = $false
+    foreach ($attempt in 1..50) {
+        Start-Sleep -Milliseconds 50
+        if ((Receive-Job -Job $server -Keep) -contains "ready") {
+            $ready = $true
+            break
+        }
+    }
+    if (-not $ready) {
+        throw "release fixture server did not start"
+    }
+
+    $env:FIRECRAB_RELEASE_BASE = "http://127.0.0.1:$port/releases"
+    & $installer -InstallDir $installDir
+    $installed = Join-Path $installDir "firecrab.exe"
+    if (-not (Test-Path -LiteralPath $installed -PathType Leaf)) {
+        throw "installer did not create firecrab.exe"
+    }
+    if ([System.IO.File]::ReadAllText($installed) -ne "firecrab fixture") {
+        throw "installer changed the fixture binary"
+    }
+    [System.IO.File]::WriteAllText($fixtureBinary, "firecrab replacement")
+    Compress-Archive -Path $fixtureBinary -DestinationPath $archive -Force
+    $hash = (Get-FileHash -Algorithm SHA256 $archive).Hash.ToLowerInvariant()
+    [System.IO.File]::WriteAllText($sums, "$hash  $asset`n")
+    & $installer -InstallDir $installDir
+    if ([System.IO.File]::ReadAllText($installed) -ne "firecrab replacement") {
+        throw "installer did not atomically replace an existing binary"
+    }
+    $victim = Join-Path $scratch "victim.txt"
+    [System.IO.File]::WriteAllText($victim, "keep victim")
+    Remove-Item -LiteralPath $installed -Force
+    New-Item -ItemType SymbolicLink -Path $installed -Target $victim | Out-Null
+    & $installer -InstallDir $installDir
+    if ([System.IO.File]::ReadAllText($victim) -ne "keep victim" -or
+        ((Get-Item -LiteralPath $installed).Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "installer followed the destination symlink"
+    }
+
+    Push-Location $scratch
+    try {
+        & $installer -InstallDir "relative-bin"
+    } finally {
+        Pop-Location
+    }
+    $relativeBin = Join-Path $scratch "relative-bin"
+    if (-not (Test-Path -LiteralPath (Join-Path $relativeBin "firecrab.exe"))) {
+        throw "relative installation did not resolve against the PowerShell location"
+    }
+    # Linux PowerShell cannot persist the Windows user PATH registry value.
+    # Keep that assertion on Windows; Docker checks the process value instead.
+    $pathScope = if ($IsWindows) { "User" } else { "Process" }
+    $userPathEntries = @([Environment]::GetEnvironmentVariable("Path", $pathScope) -split ";" | Where-Object { $_ })
+    if ($userPathEntries -notcontains $relativeBin) {
+        throw "relative installation did not persist an absolute PATH"
+    }
+    if ($userPathEntries -notcontains $installDir) {
+        throw "installer did not add its directory to the user PATH"
+    }
+    [System.IO.File]::AppendAllText($archive, "tampered")
+    $rejected = $false
+    try {
+        & $installer -InstallDir $installDir
+    } catch {
+        if ($_.Exception.Message -notmatch "checksum mismatch") { throw }
+        $rejected = $true
+    }
+    if (-not $rejected -or [System.IO.File]::ReadAllText($installed) -ne "firecrab replacement") {
+        throw "tampered release was not rejected with the installed binary preserved"
+    }
+} finally {
+    if ($null -ne $server) {
+        Stop-Job -Job $server -ErrorAction SilentlyContinue
+        Remove-Job -Job $server -Force -ErrorAction SilentlyContinue
+    }
+    [Environment]::SetEnvironmentVariable("Path", $oldUserPath, "User")
+    $env:Path = $oldProcessPath
+    Restore-ProcessEnvironment -Name "FIRECRAB_CLI_ARCH" -Value $oldArch
+    Restore-ProcessEnvironment -Name "FIRECRAB_RELEASE_BASE" -Value $oldReleaseBase
+    Remove-Item -LiteralPath $scratch -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "all tests passed"

--- a/scripts/test_release_compliance.py
+++ b/scripts/test_release_compliance.py
@@ -139,6 +139,7 @@ class ReleaseComplianceTests(unittest.TestCase):
         self.assertFalse(rc.license_allowed("MIT AND GPL-2.0-only"))
         self.assertTrue(rc.license_allowed("MIT AND BSD-3-Clause"))
         self.assertTrue(rc.license_allowed("MIT/Apache-2.0"))
+        self.assertTrue(rc.license_allowed("Apache-2.0/MIT"))
         self.assertTrue(
             rc.license_allowed("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT")
         )


### PR DESCRIPTION
## New Features

- Add named remote host profiles under `~/firecrab/config.toml` with deterministic endpoint selection.
- Support remote VM, network, image, and console commands on Linux, macOS, and Windows.
- Publish standalone CLI archives and checksum-verifying user installers for each supported platform.

## Bug Fixes

- Serialize concurrent profile mutations and reject unknown TOML fields before writes.
- Replace installer destinations without following existing symbolic links.
- Normalize relative install directories before adding them to `PATH`.
- Preserve direct `--api` access when no home directory is available.

## Docs

- Document CLI-only installation, host profiles, endpoint precedence, and native verification steps.

## Validation

- Pass 264 Linux tests and 69 native macOS ARM64 tests.
- Pass Docker PowerShell installer QA and POSIX installer security regression tests.
- Connect the native macOS CLI through SSH to a live Linux host and query host, VM, network, and image APIs.
- Reach 84.0% patch coverage and 82.7% CLI rustdoc coverage.

Closes #248


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cross-platform CLI installers for Linux, macOS, and Windows with checksum verification.
  - Added named host profiles with commands to add, list, select, show, and remove endpoints.
  - Added host selection through command-line options, environment variables, or saved preferences.
  - Improved terminal console mode handling.
  - Added platform-specific CLI binaries and release packages.

- **Documentation**
  - Updated installation and CLI documentation for cross-platform use and host profiles.

- **Tests**
  - Added automated installer, release, cross-platform, and host-management verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->