### PR TITLE
feat(release): complete CLI target matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,15 +117,19 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-24.04
-            asset: firecrab-cli-x86_64-linux.tar.gz
+            asset: firecrab-cli-x86_64-linux-musl.tar.gz
             musl: true
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+            asset: firecrab-cli-x86_64-linux-gnu.tar.gz
+            musl: false
           - target: aarch64-unknown-linux-musl
             runner: ubuntu-24.04-arm
-            asset: firecrab-cli-aarch64-linux.tar.gz
+            asset: firecrab-cli-aarch64-linux-musl.tar.gz
             musl: true
-          - target: x86_64-apple-darwin
-            runner: macos-15-intel
-            asset: firecrab-cli-x86_64-macos.tar.gz
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            asset: firecrab-cli-aarch64-linux-gnu.tar.gz
             musl: false
           - target: aarch64-apple-darwin
             runner: macos-15
@@ -135,6 +139,12 @@ jobs:
             runner: windows-latest
             asset: firecrab-cli-x86_64-windows.zip
             musl: false
+          - target: aarch64-pc-windows-msvc
+            runner: windows-11-arm
+            asset: firecrab-cli-aarch64-windows.zip
+            musl: false
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v7
 
@@ -287,9 +297,9 @@ jobs:
             x86_64-unknown-linux-gnu
             aarch64-unknown-linux-musl
             aarch64-unknown-linux-gnu
-            x86_64-apple-darwin
             aarch64-apple-darwin
             x86_64-pc-windows-msvc
+            aarch64-pc-windows-msvc
           )
           metadata_args=()
           for target in "${targets[@]}"; do

--- a/README.md
+++ b/README.md
@@ -55,6 +55,43 @@ The installer cannot enable KVM. If `/dev/kvm` is missing, turn on hardware (or
 nested) virtualization first. Every option, install path, and troubleshooting step is
 in the [installation guide](public-docs/installation.md).
 
+### Install the remote CLI binary
+
+The standalone `firecrab` client manages a remote Linux host from Linux, Apple
+silicon macOS, or x86_64/ARM64 Windows. It does not install Firecracker or local host
+services.
+
+On Linux or macOS, download and verify the release installer before executing it:
+
+```sh
+curl -fLO https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.sh
+curl -fLO https://github.com/SteelCrab/firecrab/releases/latest/download/SHA256SUMS
+grep ' install-cli.sh$' SHA256SUMS > install-cli.sh.sha256
+if command -v sha256sum >/dev/null; then
+  sha256sum -c install-cli.sh.sha256
+else
+  shasum -a 256 -c install-cli.sh.sha256
+fi
+sh install-cli.sh
+```
+
+Linux automatically selects the matching GNU or musl archive. The default destination
+is `~/.local/bin/firecrab`.
+
+On Windows PowerShell:
+
+```powershell
+Invoke-WebRequest https://github.com/SteelCrab/firecrab/releases/latest/download/install-cli.ps1 -OutFile install-cli.ps1
+Invoke-WebRequest https://github.com/SteelCrab/firecrab/releases/latest/download/SHA256SUMS -OutFile SHA256SUMS
+$expected = ((Get-Content SHA256SUMS | Where-Object { $_ -match ' install-cli\.ps1$' }) -split '\s+')[0]
+if ((Get-FileHash install-cli.ps1 -Algorithm SHA256).Hash -ne $expected) { throw 'installer checksum mismatch' }
+& ./install-cli.ps1
+```
+
+The Windows installer selects x86_64 or ARM64 and adds its user-level installation
+directory to `PATH`. See [CLI host profiles](public-docs/firecrab-cli.md#host-profiles)
+for connecting the installed client to a firecrab host.
+
 ## Quick start
 
 Open `http://127.0.0.1:5523/` after installation, then:

--- a/docs/tests/cli-cross-platform.md
+++ b/docs/tests/cli-cross-platform.md
@@ -19,11 +19,13 @@ python3 scripts/check-doc-links.py
 
 Native release CI runs `cargo test` and `cargo build` for these targets:
 
+- `x86_64-unknown-linux-gnu`
 - `x86_64-unknown-linux-musl`
+- `aarch64-unknown-linux-gnu`
 - `aarch64-unknown-linux-musl`
-- `x86_64-apple-darwin`
 - `aarch64-apple-darwin`
 - `x86_64-pc-windows-msvc`
+- `aarch64-pc-windows-msvc`
 
 ## Keyword checklist
 

--- a/install-cli.ps1
+++ b/install-cli.ps1
@@ -44,6 +44,7 @@ $rawArchitecture = if ($env:FIRECRAB_CLI_ARCH) {
 }
 $architecture = switch -Regex ($rawArchitecture) {
     "^(X64|x86_64|amd64)$" { "x86_64"; break }
+    "^(Arm64|aarch64)$" { "aarch64"; break }
     default { throw "unsupported Windows client architecture: $rawArchitecture" }
 }
 

--- a/install-cli.sh
+++ b/install-cli.sh
@@ -29,6 +29,7 @@ Environment:
                          Permit file:// release roots in tests only
   FIRECRAB_VERSION       Default release tag
   FIRECRAB_INSTALL_DIR   Default destination directory
+  FIRECRAB_CLI_LIBC      Linux libc override: gnu, glibc, or musl
 EOF
 }
 
@@ -83,7 +84,30 @@ case "$raw_arch" in
     *) printf 'unsupported client architecture: %s\n' "$raw_arch" >&2; exit 1 ;;
 esac
 
-asset="firecrab-cli-${architecture}-${platform}.tar.gz"
+case "$platform" in
+    linux)
+        raw_libc=${FIRECRAB_CLI_LIBC:-}
+        if [ -z "$raw_libc" ]; then
+            if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ] \
+                || { command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl; }; then
+                raw_libc=musl
+            else
+                raw_libc=gnu
+            fi
+        fi
+        case "$raw_libc" in
+            gnu|glibc) libc=gnu ;;
+            musl) libc=musl ;;
+            *) printf 'unsupported Linux libc: %s\n' "$raw_libc" >&2; exit 1 ;;
+        esac
+        asset="firecrab-cli-${architecture}-linux-${libc}.tar.gz"
+        ;;
+    macos)
+        [ "$architecture" = aarch64 ] \
+            || { printf '%s\n' 'unsupported macOS client architecture: x86_64' >&2; exit 1; }
+        asset="firecrab-cli-aarch64-macos.tar.gz"
+        ;;
+esac
 case "$VERSION" in
     ''|latest) download_root="$RELEASE_BASE/latest/download" ;;
     v*) download_root="$RELEASE_BASE/download/$VERSION" ;;

--- a/public-docs/installation.md
+++ b/public-docs/installation.md
@@ -161,11 +161,13 @@ The installers select one of these standalone archives.
 
 | Client | Asset |
 | --- | --- |
-| Linux x86_64 | `firecrab-cli-x86_64-linux.tar.gz` |
-| Linux ARM64 | `firecrab-cli-aarch64-linux.tar.gz` |
-| macOS Intel | `firecrab-cli-x86_64-macos.tar.gz` |
+| Linux x86_64 glibc | `firecrab-cli-x86_64-linux-gnu.tar.gz` |
+| Linux x86_64 musl | `firecrab-cli-x86_64-linux-musl.tar.gz` |
+| Linux ARM64 glibc | `firecrab-cli-aarch64-linux-gnu.tar.gz` |
+| Linux ARM64 musl | `firecrab-cli-aarch64-linux-musl.tar.gz` |
 | macOS Apple silicon | `firecrab-cli-aarch64-macos.tar.gz` |
 | Windows x86_64 | `firecrab-cli-x86_64-windows.zip` |
+| Windows ARM64 | `firecrab-cli-aarch64-windows.zip` |
 
 Archive URLs may be pinned by replacing `latest` with a tag, for example `v0.1.0`.
 When using either installer script, pass `--version` or `-Version` as shown above.

--- a/scripts/test-install-cli-release.sh
+++ b/scripts/test-install-cli-release.sh
@@ -13,17 +13,41 @@ expect_eq() {
 }
 
 expect_eq \
-    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 "$ROOT/install-cli.sh" --print-asset)" \
-    firecrab-cli-x86_64-linux.tar.gz \
-    "Linux x86_64 asset"
+    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 FIRECRAB_CLI_LIBC=gnu "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-x86_64-linux-gnu.tar.gz \
+    "Linux x86_64 GNU asset"
+expect_eq \
+    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=arm64 FIRECRAB_CLI_LIBC=musl "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-aarch64-linux-musl.tar.gz \
+    "Linux ARM64 musl asset"
+expect_eq \
+    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 FIRECRAB_CLI_LIBC=musl "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-x86_64-linux-musl.tar.gz \
+    "Linux x86_64 musl asset"
+expect_eq \
+    "$(FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=arm64 FIRECRAB_CLI_LIBC=glibc "$ROOT/install-cli.sh" --print-asset)" \
+    firecrab-cli-aarch64-linux-gnu.tar.gz \
+    "Linux ARM64 glibc alias selects GNU asset"
 expect_eq \
     "$(FIRECRAB_CLI_OS=Darwin FIRECRAB_CLI_ARCH=arm64 "$ROOT/install-cli.sh" --print-asset)" \
     firecrab-cli-aarch64-macos.tar.gz \
     "Apple silicon asset"
 expect_eq \
-    "$(FIRECRAB_CLI_OS=linux FIRECRAB_CLI_ARCH=aarch64 "$ROOT/install-cli.sh" --version 1.2.3 --print-url)" \
-    "https://github.com/SteelCrab/firecrab/releases/download/v1.2.3/firecrab-cli-aarch64-linux.tar.gz" \
+    "$(FIRECRAB_CLI_OS=linux FIRECRAB_CLI_ARCH=aarch64 FIRECRAB_CLI_LIBC=gnu "$ROOT/install-cli.sh" --version 1.2.3 --print-url)" \
+    "https://github.com/SteelCrab/firecrab/releases/download/v1.2.3/firecrab-cli-aarch64-linux-gnu.tar.gz" \
     "bare version becomes a v-prefixed release URL"
+if FIRECRAB_CLI_OS=Darwin FIRECRAB_CLI_ARCH=x86_64 \
+    "$ROOT/install-cli.sh" --print-asset >/dev/null 2>&1; then
+    fail "Intel macOS is rejected"
+else
+    pass "Intel macOS is rejected"
+fi
+if FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 FIRECRAB_CLI_LIBC=other \
+    "$ROOT/install-cli.sh" --print-asset >/dev/null 2>&1; then
+    fail "unknown Linux libc is rejected"
+else
+    pass "unknown Linux libc is rejected"
+fi
 
 scratch=$(mktemp -d)
 trap 'rm -rf "$scratch"' EXIT
@@ -31,16 +55,17 @@ release="$scratch/releases/latest/download"
 mkdir -p "$release/payload" "$scratch/bin"
 printf '#!/bin/sh\nprintf "firecrab test\\n"\n' >"$release/payload/firecrab"
 chmod +x "$release/payload/firecrab"
-tar -czf "$release/firecrab-cli-x86_64-linux.tar.gz" -C "$release/payload" firecrab
+tar -czf "$release/firecrab-cli-x86_64-linux-gnu.tar.gz" -C "$release/payload" firecrab
 (
     cd "$release"
-    sha256sum firecrab-cli-x86_64-linux.tar.gz >SHA256SUMS
+    sha256sum firecrab-cli-x86_64-linux-gnu.tar.gz >SHA256SUMS
 )
 
 FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
 FIRECRAB_TEST_ALLOW_FILE_URL=1 \
 FIRECRAB_CLI_OS=Linux \
 FIRECRAB_CLI_ARCH=x86_64 \
+FIRECRAB_CLI_LIBC=gnu \
 PATH="/usr/bin:/bin" \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null
 if [ -x "$scratch/bin/firecrab" ] && [ "$("$scratch/bin/firecrab")" = "firecrab test" ]; then
@@ -57,6 +82,7 @@ FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
 FIRECRAB_TEST_ALLOW_FILE_URL=1 \
 FIRECRAB_CLI_OS=Linux \
 FIRECRAB_CLI_ARCH=x86_64 \
+FIRECRAB_CLI_LIBC=gnu \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null
 if [ ! -L "$scratch/bin/firecrab" ] \
     && [ "$(cat "$victim")" = "leave this file alone" ] \
@@ -68,6 +94,7 @@ fi
 
 if env -u HOME \
     FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    FIRECRAB_CLI_LIBC=gnu \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" --check >/dev/null; then
     pass "explicit install directory does not require HOME"
 else
@@ -79,6 +106,7 @@ relative_output=$(
     FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
     FIRECRAB_TEST_ALLOW_FILE_URL=1 \
     FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    FIRECRAB_CLI_LIBC=gnu \
         "$ROOT/install-cli.sh" --install-dir relative-bin
 )
 absolute_bin="$(cd "$scratch" && pwd -P)/relative-bin"
@@ -89,10 +117,11 @@ else
     fail "relative install directory produces a usable absolute PATH"
 fi
 
-printf 'tampered\n' >>"$release/firecrab-cli-x86_64-linux.tar.gz"
+printf 'tampered\n' >>"$release/firecrab-cli-x86_64-linux-gnu.tar.gz"
 if FIRECRAB_RELEASE_BASE="file://$scratch/releases" \
     FIRECRAB_TEST_ALLOW_FILE_URL=1 \
     FIRECRAB_CLI_OS=Linux FIRECRAB_CLI_ARCH=x86_64 \
+    FIRECRAB_CLI_LIBC=gnu \
     "$ROOT/install-cli.sh" --install-dir "$scratch/bin" >/dev/null 2>&1; then
     fail "tampered archive is rejected"
 else

--- a/scripts/test-install-cli.ps1
+++ b/scripts/test-install-cli.ps1
@@ -26,6 +26,13 @@ try {
         throw "unexpected Windows asset: $asset"
     }
 
+    $env:FIRECRAB_CLI_ARCH = "ARM64"
+    $armAsset = & $installer -PrintAsset
+    if ($armAsset -ne "firecrab-cli-aarch64-windows.zip") {
+        throw "unexpected Windows ARM64 asset: $armAsset"
+    }
+    $env:FIRECRAB_CLI_ARCH = "x86_64"
+
     $url = & $installer -Version "1.2.3" -PrintUrl
     $expected = "https://github.com/SteelCrab/firecrab/releases/download/v1.2.3/firecrab-cli-x86_64-windows.zip"
     if ($url -ne $expected) {


### PR DESCRIPTION
## New Features

- Publish GNU and musl CLI archives for Linux x86_64 and ARM64.
- Publish native Windows CLI archives for x86_64 and ARM64.
- Select Linux libc and Windows architecture in the user-level installers.

## Changes

- Keep macOS CLI releases scoped to Apple Silicon ARM64.
- Fail every native CLI release build on compiler warnings.

## Docs

- Add checksum-verified binary installation flows to the README and installation guide.
- Document the complete seven-target release matrix and QA contract.

## Tests

- Cover GNU and musl selection, Windows ARM64 selection, unsupported Intel macOS, and invalid libc overrides.

Closes #256
