### PR TITLE
fix(oci): bound apt-get mirror timeout in guest sysinit

### DIFF
--- a/firecrab-api/src/oci/provision.rs
+++ b/firecrab-api/src/oci/provision.rs
@@ -937,8 +937,19 @@ pub(crate) const BASE_PACKAGE_INSTALL: &str = r#"
 if [ ! -f /etc/firecrab/base-packages.ok ]; then
   ok=0
   if [ -x /usr/bin/apt-get ]; then
-    if DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -qq \
-      && DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y -qq \
+    # Runs synchronously in sysinit — an unreachable/slow mirror must fail
+    # fast, or it blocks the console (and every respawn behind it) forever.
+    # ConnectTimeout bounds the TCP handshake specifically; Timeout alone
+    # left a black-holed mirror IP taking ~30s per address to fail. But a
+    # sources.list with several Release files (main+updates+backports+
+    # security), each retried across several mirror IPs, still stacks these
+    # per-attempt timeouts into 90s+ — so a hard wall-clock cap wraps the
+    # whole call as a backstop independent of apt's own timeout accounting.
+    APT_OPTS="-o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 \
+      -o Acquire::http::ConnectTimeout=5 -o Acquire::https::ConnectTimeout=5 \
+      -o Acquire::Retries=1"
+    if /usr/bin/timeout 25 env DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get update -qq $APT_OPTS \
+      && /usr/bin/timeout 25 env DEBIAN_FRONTEND=noninteractive /usr/bin/apt-get install -y -qq $APT_OPTS \
         iputils-ping iproute2 ca-certificates curl procps openssh-server udev; then
       ok=1
     fi


### PR DESCRIPTION
## Summary

`BASE_PACKAGE_INSTALL`'s `apt-get update`/`install` ran synchronously inside
busybox init's `sysinit` action with no timeout. `sysinit` blocks every later
inittab entry — including the `ttyS0`/console respawn — until it exits, so an
unreachable mirror froze the whole guest console, not just package
installation. Reproduced live: importing `ubuntu-26.10` in a
network-restricted environment left the console silent for 5+ minutes after
`FIRECRAB_NETWORK_READY`.

`Acquire::http::Timeout`/`ConnectTimeout` alone were not enough — a
`sources.list` with several Release files (main/updates/backports/security),
each retried across several mirror IPs, still stacked per-attempt timeouts
into 90s+.

## Changes

- Add `Acquire::http/https::Timeout` and `ConnectTimeout` to bound each
  request phase
- Wrap the whole `apt-get update`/`install` call in `/usr/bin/timeout 25` as
  a hard wall-clock backstop, independent of whether apt's own timeout
  options are honored for every phase

## Checks

- `cargo fmt -p firecrab-api -- --check`
- `cargo clippy -p firecrab-api --all-targets -- -D warnings`
- `cargo test -p firecrab-api oci::provision_tests` — 24 passed
- e2e (ubuntu-26.10, network-restricted host): 5+ minutes of silence before
  this fix, login prompt reached in 21-53s after

Closes #260
