### PR TITLE
fix(oci): OCI import wedges on a hardened image's permission bits

### DIFF
--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -3274,7 +3274,7 @@ async fn import_oci_image(
         tracker, templates, reference, alias, image_root, &scratch, credential,
     )
     .await;
-    if let Err(error) = tokio::fs::remove_dir_all(&scratch).await
+    if let Err(error) = remove_import_scratch(&scratch).await
         && error.kind() != io::ErrorKind::NotFound
     {
         tracing::warn!(
@@ -3288,7 +3288,7 @@ async fn import_oci_image(
 }
 
 async fn reset_import_scratch(scratch: &Path) -> Result<(), ResolveError> {
-    match tokio::fs::remove_dir_all(scratch).await {
+    match remove_import_scratch(scratch).await {
         Ok(()) => {}
         Err(error) if error.kind() == io::ErrorKind::NotFound => {}
         Err(error) => {
@@ -3298,6 +3298,49 @@ async fn reset_import_scratch(scratch: &Path) -> Result<(), ResolveError> {
     tokio::fs::create_dir_all(scratch)
         .await
         .map_err(|error| cache_io("create import scratch", scratch.to_owned(), error))
+}
+
+/// Removes a scratch tree, tolerating directories a merged layer stamped
+/// owner-non-writable (Fedora's `/usr/bin`, `/usr/lib*`, `/root`, `/afs`, ...
+/// ship 555/550 by design — see `apply_directory_metadata`). `remove_dir_all`
+/// cannot unlink entries under those without a chmod pass first, which left
+/// every retry wedged on the previous attempt's leftovers.
+async fn remove_import_scratch(scratch: &Path) -> io::Result<()> {
+    let path = scratch.to_owned();
+    tokio::task::spawn_blocking(move || {
+        make_tree_removable(&path)?;
+        std::fs::remove_dir_all(&path)
+    })
+    .await
+    .unwrap_or_else(|error| Err(io::Error::other(format!("removal task failed: {error}"))))
+}
+
+/// Recursively grants the owner write+execute on every directory under
+/// `path` (including `path` itself) so a subsequent removal can unlink
+/// everything beneath it. Missing paths are not an error — the caller's
+/// removal call handles that the same way it always has.
+fn make_tree_removable(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.is_dir() {
+        return Ok(());
+    }
+    let mode = metadata.permissions().mode();
+    if mode & 0o700 != 0o700 {
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode | 0o700))?;
+    }
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            make_tree_removable(&entry.path())?;
+        }
+    }
+    Ok(())
 }
 
 async fn import_oci_image_in_scratch(

--- a/firecrab-api/src/oci.rs
+++ b/firecrab-api/src/oci.rs
@@ -4838,4 +4838,86 @@ mod tests {
             );
         }
     }
+
+    /// A hardened image can merge in directories a lower layer stamped
+    /// owner-non-writable (Fedora's `/usr/bin`-style 555 trees). Reusing a
+    /// scratch directory for the next import must chmod its way through
+    /// those before it can unlink them, not wedge on the first entry.
+    #[tokio::test]
+    async fn reset_import_scratch_recreates_trees_with_owner_non_writable_directories() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().expect("create scratch fixture root");
+        let scratch = root.path().join("scratch");
+        let locked = scratch.join("usr/bin");
+        std::fs::create_dir_all(&locked).expect("create locked subtree");
+        std::fs::write(locked.join("payload"), b"merged layer file").expect("write locked file");
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555))
+            .expect("lock down subtree like a hardened image ships it");
+
+        reset_import_scratch(&scratch)
+            .await
+            .expect("reset scratch despite owner-non-writable directories");
+
+        assert!(scratch.is_dir(), "scratch must exist after reset");
+        assert_eq!(
+            std::fs::read_dir(&scratch).unwrap().count(),
+            0,
+            "reset must leave an empty scratch tree"
+        );
+    }
+
+    /// The very first import for an alias has nothing to clean up yet.
+    #[tokio::test]
+    async fn reset_import_scratch_creates_a_fresh_tree_when_none_exists() {
+        let root = tempfile::tempdir().expect("create scratch fixture root");
+        let scratch = root.path().join("never-created").join("scratch");
+
+        reset_import_scratch(&scratch)
+            .await
+            .expect("create scratch when nothing previously existed");
+
+        assert!(scratch.is_dir());
+    }
+
+    /// A `symlink_metadata` failure that is not "missing" — for example, a
+    /// parent directory whose traversal bit was stripped — must propagate
+    /// instead of being swallowed the way a genuinely missing path is.
+    #[test]
+    fn make_tree_removable_propagates_errors_other_than_not_found() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().expect("create fixture root");
+        let blocked = root.path().join("blocked");
+        std::fs::create_dir(&blocked).expect("create blocked directory");
+        let target = blocked.join("child");
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o000))
+            .expect("strip traversal permission from blocked directory");
+
+        let result = make_tree_removable(&target);
+
+        std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755))
+            .expect("restore traversal permission so the fixture can be cleaned up");
+        let error = result.expect_err("stat through a non-traversable directory must fail");
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    /// The scratch path itself is always a directory in production, but the
+    /// recursive chmod must not mistreat a stray non-directory left in its
+    /// place by, e.g., a prior partial write.
+    #[test]
+    fn make_tree_removable_ignores_non_directory_paths() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let root = tempfile::tempdir().expect("create fixture root");
+        let file_path = root.path().join("not-a-directory");
+        std::fs::write(&file_path, b"stray file").expect("write fixture file");
+        std::fs::set_permissions(&file_path, std::fs::Permissions::from_mode(0o644))
+            .expect("set fixture file mode");
+
+        make_tree_removable(&file_path).expect("non-directory paths are left alone");
+
+        let mode = std::fs::metadata(&file_path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o644, "must not chmod a non-directory");
+    }
 }

--- a/firecrab-api/src/oci/merge.rs
+++ b/firecrab-api/src/oci/merge.rs
@@ -669,11 +669,20 @@ fn extract_non_directory_entries(
         }
         if entry_type.is_file() {
             let destination = root.join(&path);
-            fs::set_permissions(
-                &destination,
-                fs::Permissions::from_mode(mode & HOST_SAFE_MODE_MASK),
-            )
-            .map_err(|error| merge_io("set merged file permissions", destination, error))?;
+            // Distro images ship some files (Fedora's /etc/gshadow) with no
+            // owner-read bit at all. `run_mkfs` reads every file's bytes
+            // through `fakeroot` — which fakes `stat()`/`chown()` results but
+            // never bypasses the kernel's real DAC read check — as the same
+            // unprivileged host user that extracted them, so a literal 0
+            // there makes the file unreadable even to its own owner and
+            // fails the ext4 build. That same build already normalizes every
+            // inode's on-disk owner to root:root (issue #250) before mkfs
+            // runs, and real root ignores its own DAC bits regardless of
+            // what they say, so forcing owner-read here changes nothing a
+            // root-owned file's guest security depends on.
+            let host_mode = (mode & HOST_SAFE_MODE_MASK) | 0o400;
+            fs::set_permissions(&destination, fs::Permissions::from_mode(host_mode))
+                .map_err(|error| merge_io("set merged file permissions", destination, error))?;
         }
     }
     Ok(())

--- a/firecrab-api/src/oci/merge_tests.rs
+++ b/firecrab-api/src/oci/merge_tests.rs
@@ -1242,3 +1242,38 @@ async fn character_and_block_devices_are_not_extracted_into_the_merged_tree() {
         }
     }
 }
+
+/// Fedora ships `/etc/gshadow` with mode 0: no owner-read bit at all.
+/// `run_mkfs` reads merged files back as the unprivileged host user under
+/// `fakeroot`, which cannot bypass the kernel's real DAC read check, so a
+/// literal 0 would make the file unreadable and fail the ext4 build.
+#[tokio::test]
+async fn files_with_no_owner_read_bit_gain_it_after_merge() {
+    let directory = tempdir().expect("create fixture directory");
+    let mut builder = Builder::new(Vec::new());
+    append_entry(&mut builder, "etc/", EntryType::Directory, None, &[], 0o755);
+    append_entry(
+        &mut builder,
+        "etc/gshadow",
+        EntryType::Regular,
+        None,
+        b"root:*::root\n",
+        0o000,
+    );
+    let layers = validate(vec![layer(&directory, "unreadable-file", &finish(builder))]).await;
+    let destination = directory.path().join("unreadable-file-rootfs");
+
+    merge_validated_layers(&layers, &destination)
+        .await
+        .expect("merge a layer containing a file with no owner-read bit");
+
+    let mode = std::fs::metadata(destination.join("etc/gshadow"))
+        .unwrap()
+        .permissions()
+        .mode();
+    assert_eq!(
+        mode & 0o7777,
+        0o400,
+        "merged file must gain owner-read despite the layer shipping mode 0"
+    );
+}


### PR DESCRIPTION
## Summary

Importing `fedora:46` failed: `OCI cache remove import scratch failed at
.../import/fedora-46: Permission denied (os error 13)`.

Two root causes, the second surfacing once the first was fixed:

1. `apply_directory_metadata` correctly stamps every directory's
   tar-recorded mode for guest fidelity. Fedora ships `/usr/bin`,
   `/usr/lib*`, `/root`, `/afs` at 555/550 (no owner-write) by design.
   `reset_import_scratch`'s `remove_dir_all` cannot unlink entries under a
   non-writable directory, so the first failed cleanup left a scratch tree
   every later retry immediately re-failed against — the alias was
   permanently wedged.
2. `run_mkfs` reads every file through `fakeroot`, which fakes
   `stat()`/`chown()` results but never bypasses the kernel's real DAC read
   check. Fedora ships `/etc/gshadow` at mode `0000` — unreadable even to
   its own host owner (the unprivileged extracting user) — so `mkfs.ext4 -d`
   could not copy its bytes and the ext4 build failed.

## Changes

- `oci.rs`: chmod-before-remove pre-pass (`make_tree_removable`) ahead of
  both scratch `remove_dir_all` call sites (`reset_import_scratch`, and the
  post-import cleanup that was silently leaving the wedge behind for the
  *next* attempt)
- `merge.rs`: guarantee owner-read (`mode | 0o400`) on every extracted
  regular file — safe because `run_mkfs` already normalizes every inode's
  on-disk owner to root:root before packing (#250), and real root ignores
  its own DAC bits regardless of what they say

## Checks

- `cargo fmt -p firecrab-api -- --check`
- `cargo clippy -p firecrab-api --all-targets -- -D warnings`
- `cargo test -p firecrab-api oci::` — 207 passed (one unrelated
  `registry_fixture` flake reproduced once under parallel load, then passed
  4/4 on rerun)
- e2e: re-ran the `fedora:46` import — succeeded in 12s, template registered
  and visible in `/api/images`

Closes #261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cleanup of locked import scratch directories, including read-only directory trees.
  * Preserved non-directory scratch paths and tolerated already-missing paths during cleanup.
  * Ensured merged files retain owner-read permission, preventing unreadable files during extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->